### PR TITLE
fix(cron): add run logging and admin status card

### DIFF
--- a/docs/EXPIRED_KEYS_SYSTEM.md
+++ b/docs/EXPIRED_KEYS_SYSTEM.md
@@ -89,15 +89,17 @@ Updates all expired keys across all programs.
   "crons": [
     {
       "path": "/api/v1/cron/update-expired-keys",
-      "schedule": "0 0 * * *"
+      "schedule": "0 20 * * *"
     }
   ]
 }
 ```
 
-Runs once a day (midnight UTC) to update all expired keys.
+Runs once a day (20:00 UTC) to update all expired keys.
 
 **Env:** `CRON_SECRET` (optional). Vercel adds `x-vercel-cron` when invoking crons. Use `CRON_SECRET` + `Authorization: Bearer <secret>` for manual triggers.
+
+**Tracking:** Each run is logged to Sanity (`cronRun`). View last runs in Admin Dashboard → System → Cron Jobs.
 
 ### Proxy Rate Limiting
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import ProtectedAdminLayout from "@/src/components/admin/ProtectedAdminLayout";
+import CronStatusCard from "@/src/components/admin/CronStatusCard";
 
 export default function AdminHomePage() {
   return (
@@ -144,6 +145,14 @@ export default function AdminHomePage() {
               <p className="text-sm text-gray-500">Coming soon - Detailed reporting</p>
             </div>
           </div>
+        </div>
+      </div>
+
+      {/* Cron Status */}
+      <div className="mt-12">
+        <h3 className="text-xl font-semibold text-gray-900 mb-6">System</h3>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <CronStatusCard />
         </div>
       </div>
 

--- a/src/app/api/v1/admin/cron-status/route.ts
+++ b/src/app/api/v1/admin/cron-status/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { client } from "@/src/sanity/lib/client";
+import { cronRunsQuery } from "@/src/lib/sanity/queries";
+import { requireAdminSession } from "@/src/lib/admin/adminAuth";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+const LIMIT = 50;
+
+/** GET /api/v1/admin/cron-status - Last cron runs (last 7 days, admin only) */
+export async function GET(req: NextRequest) {
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const admin = await requireAdminSession();
+  if (admin instanceof Response) return admin;
+
+  try {
+    const since = new Date(Date.now() - SEVEN_DAYS_MS).toISOString();
+    const runs = await client.fetch<Array<{ _id: string; job: string; source: string; status: string; details?: string; ranAt: string }>>(
+      cronRunsQuery,
+      { since, limit: LIMIT }
+    );
+
+    return NextResponse.json({
+      data: { runs: runs ?? [] },
+      meta: {}
+    });
+  } catch (err) {
+    console.error("[GET /api/v1/admin/cron-status]", err);
+    return Errors.internal();
+  }
+}

--- a/src/app/api/v1/cron/bundle-events/route.ts
+++ b/src/app/api/v1/cron/bundle-events/route.ts
@@ -1,23 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
+import { client } from "@/src/sanity/lib/client";
 import { runBundleEvents } from "@/src/lib/analytics/bundleEvents";
+import { verifyCronAuth, logCronRun } from "@/src/lib/api/cronUtils";
 import { Errors } from "@/src/lib/api/errors";
-
-function verifyCronAuth(req: Request): boolean {
-  const auth = req.headers.get("authorization");
-  const cronSecret = process.env.CRON_SECRET;
-  if (cronSecret && auth === `Bearer ${cronSecret}`) return true;
-  if (req.headers.get("x-vercel-cron") === "1") return true;
-  return false;
-}
 
 /** GET /api/v1/cron/bundle-events - Cron: bundle tracking events */
 export async function GET(req: NextRequest) {
-  if (!verifyCronAuth(req)) return Errors.unauthorized("Cron auth required");
+  const { ok, source } = verifyCronAuth(req);
+  if (!ok) return Errors.unauthorized("Cron auth required");
 
   try {
     const result = await runBundleEvents(false);
 
     if (!result.ok) {
+      await logCronRun(client, {
+        job: "bundle-events",
+        source,
+        status: "error",
+        details: result.error ?? `created=${result.created} appended=${result.appended}`
+      });
       return NextResponse.json(
         {
           error: {
@@ -29,6 +30,12 @@ export async function GET(req: NextRequest) {
         { status: 500 }
       );
     }
+
+    const details =
+      result.created > 0 || result.appended > 0
+        ? `${result.created} new, ${result.appended} appended`
+        : "No events to bundle";
+    await logCronRun(client, { job: "bundle-events", source, status: "ok", details });
 
     return NextResponse.json({
       data: {
@@ -43,6 +50,12 @@ export async function GET(req: NextRequest) {
     });
   } catch (err) {
     console.error("[GET /api/v1/cron/bundle-events]", err);
+    await logCronRun(client, {
+      job: "bundle-events",
+      source,
+      status: "error",
+      details: err instanceof Error ? err.message : "Unknown error"
+    }).catch(() => {});
     return Errors.internal();
   }
 }

--- a/src/app/api/v1/cron/update-expired-keys/route.ts
+++ b/src/app/api/v1/cron/update-expired-keys/route.ts
@@ -1,41 +1,51 @@
 import { NextRequest, NextResponse } from "next/server";
+import { client } from "@/src/sanity/lib/client";
 import { updateAllExpiredKeys } from "@/src/lib/sanity/sanityActions";
+import { verifyCronAuth, logCronRun } from "@/src/lib/api/cronUtils";
 import { Errors } from "@/src/lib/api/errors";
-
-function isCronRequest(req: Request): boolean {
-  const auth = req.headers.get("authorization");
-  const cronSecret = process.env.CRON_SECRET;
-  if (cronSecret && auth === `Bearer ${cronSecret}`) return true;
-  if (req.headers.get("x-vercel-cron") === "1") return true;
-  return false;
-}
 
 /** GET /api/v1/cron/update-expired-keys - Cron: update expired keys (requires cron auth) */
 export async function GET(req: NextRequest) {
-  if (!isCronRequest(req)) return Errors.unauthorized("Cron auth required");
+  const { ok, source } = verifyCronAuth(req);
+  if (!ok) return Errors.unauthorized("Cron auth required");
 
   try {
     await updateAllExpiredKeys();
+    await logCronRun(client, { job: "update-expired-keys", source, status: "ok" });
     return NextResponse.json({
       data: { message: "Expired keys updated successfully" },
       meta: {}
     });
   } catch (err) {
     console.error("[GET /api/v1/cron/update-expired-keys]", err);
+    await logCronRun(client, {
+      job: "update-expired-keys",
+      source,
+      status: "error",
+      details: err instanceof Error ? err.message : "Unknown error"
+    }).catch(() => {});
     return Errors.internal();
   }
 }
 
 /** POST /api/v1/cron/update-expired-keys - Manual trigger (no auth; used by admin Key Status) */
 export async function POST(req: NextRequest) {
+  const source = "manual" as const;
   try {
     await updateAllExpiredKeys();
+    await logCronRun(client, { job: "update-expired-keys", source, status: "ok" });
     return NextResponse.json({
       data: { success: true, message: "Expired keys updated successfully" },
       meta: {}
     });
   } catch (err) {
     console.error("[POST /api/v1/cron/update-expired-keys]", err);
+    await logCronRun(client, {
+      job: "update-expired-keys",
+      source,
+      status: "error",
+      details: err instanceof Error ? err.message : "Unknown error"
+    }).catch(() => {});
     return Errors.internal();
   }
 }

--- a/src/components/admin/CronStatusCard.tsx
+++ b/src/components/admin/CronStatusCard.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { formatRelativeTimeCompact } from "@/src/lib/dateUtils";
+
+interface CronRun {
+  _id: string;
+  job: string;
+  source: string;
+  status: string;
+  details?: string;
+  ranAt: string;
+}
+
+function SourceBadge({ source }: { source: string }) {
+  const styles: Record<string, string> = {
+    vercel_cron: "bg-blue-100 text-blue-800",
+    bearer: "bg-amber-100 text-amber-800",
+    manual: "bg-gray-100 text-gray-700"
+  };
+  const labels: Record<string, string> = {
+    vercel_cron: "Vercel",
+    bearer: "Bearer",
+    manual: "Manual"
+  };
+  return (
+    <span className={`text-xs px-2 py-0.5 rounded ${styles[source] ?? "bg-gray-100"}`}>
+      {labels[source] ?? source}
+    </span>
+  );
+}
+
+function JobLabel({ job }: { job: string }) {
+  const labels: Record<string, string> = {
+    "bundle-events": "Bundle Events",
+    "update-expired-keys": "Update Expired Keys"
+  };
+  return <>{labels[job] ?? job}</>;
+}
+
+export default function CronStatusCard() {
+  const [runs, setRuns] = useState<CronRun[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/v1/admin/cron-status")
+      .then(res => res.json())
+      .then(data => {
+        if (data?.data?.runs) setRuns(data.data.runs);
+        else setError("Failed to load");
+      })
+      .catch(() => setError("Failed to load"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">🕐 Cron Jobs</h3>
+        <p className="text-gray-500 text-sm">Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">🕐 Cron Jobs</h3>
+        <p className="text-red-600 text-sm">{error}</p>
+      </div>
+    );
+  }
+
+  const byJob = {
+    "bundle-events": runs.find(r => r.job === "bundle-events" && r.source === "vercel_cron"),
+    "update-expired-keys": runs.find(r => r.job === "update-expired-keys" && r.source === "vercel_cron")
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6">
+      <h3 className="text-lg font-semibold text-gray-900 mb-2">🕐 Cron Jobs</h3>
+      <p className="text-gray-500 text-sm mb-4">Last Vercel cron runs (manual runs shown in history)</p>
+
+      <div className="space-y-4 mb-4">
+        <div className="flex items-center justify-between py-2 border-b border-gray-100">
+          <div>
+            <span className="font-medium text-gray-900">Bundle Events</span>
+            <p className="text-xs text-gray-500">Daily at 21:00 UTC</p>
+          </div>
+          {byJob["bundle-events"] ? (
+            <div className="text-right">
+              <span className={`text-sm font-medium ${byJob["bundle-events"].status === "ok" ? "text-green-600" : "text-red-600"}`}>
+                {byJob["bundle-events"].status === "ok" ? "✓" : "✗"}
+              </span>
+              <p className="text-xs text-gray-500">{formatRelativeTimeCompact(byJob["bundle-events"].ranAt)}</p>
+            </div>
+          ) : (
+            <span className="text-amber-600 text-sm">No Vercel run yet</span>
+          )}
+        </div>
+        <div className="flex items-center justify-between py-2 border-b border-gray-100">
+          <div>
+            <span className="font-medium text-gray-900">Update Expired Keys</span>
+            <p className="text-xs text-gray-500">Daily at 20:00 UTC</p>
+          </div>
+          {byJob["update-expired-keys"] ? (
+            <div className="text-right">
+              <span className={`text-sm font-medium ${byJob["update-expired-keys"].status === "ok" ? "text-green-600" : "text-red-600"}`}>
+                {byJob["update-expired-keys"].status === "ok" ? "✓" : "✗"}
+              </span>
+              <p className="text-xs text-gray-500">{formatRelativeTimeCompact(byJob["update-expired-keys"].ranAt)}</p>
+            </div>
+          ) : (
+            <span className="text-amber-600 text-sm">No Vercel run yet</span>
+          )}
+        </div>
+      </div>
+
+      {runs.length > 0 && (
+        <details className="mt-4">
+          <summary className="text-sm text-gray-600 cursor-pointer hover:text-gray-900">Recent runs ({runs.length})</summary>
+          <ul className="mt-2 space-y-1 text-xs max-h-48 overflow-y-auto">
+            {runs.slice(0, 20).map(run => (
+              <li key={run._id} className="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
+                <span>
+                  <JobLabel job={run.job} /> <SourceBadge source={run.source} />
+                  {run.details && <span className="text-gray-500 ml-1">({run.details})</span>}
+                </span>
+                <span className={`font-medium ${run.status === "ok" ? "text-green-600" : "text-red-600"}`}>
+                  {formatRelativeTimeCompact(run.ranAt)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/lib/api/cronUtils.ts
+++ b/src/lib/api/cronUtils.ts
@@ -1,0 +1,31 @@
+import { SanityClient } from "@sanity/client";
+
+export type CronSource = "vercel_cron" | "bearer" | "manual";
+export type CronJob = "bundle-events" | "update-expired-keys";
+
+/** Verifies cron auth (x-vercel-cron or Bearer token). Returns ok + source for logging. */
+export function verifyCronAuth(req: Request): { ok: boolean; source: CronSource } {
+  if (req.headers.get("x-vercel-cron") === "1") return { ok: true, source: "vercel_cron" };
+  const auth = req.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret && auth === `Bearer ${cronSecret}`) return { ok: true, source: "bearer" };
+  return { ok: false, source: "manual" };
+}
+
+export async function logCronRun(
+  client: SanityClient,
+  opts: { job: CronJob; source: CronSource; status: "ok" | "error"; details?: string }
+): Promise<void> {
+  try {
+    await client.create({
+      _type: "cronRun",
+      job: opts.job,
+      source: opts.source,
+      status: opts.status,
+      ...(opts.details && { details: opts.details }),
+      ranAt: new Date().toISOString()
+    });
+  } catch (err) {
+    console.error("[logCronRun]", err);
+  }
+}

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -88,6 +88,15 @@ export const keyReportsQuery = `*[_type=="keyReport" && _createdAt >= $since]{
       _id, eventType, programSlug, path, referrer, country, city, keyHash, keyIdentifier, keyNormalized, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt, _createdAt
     } | order(_createdAt desc)`;
 
+/* ------------ Cron Runs ------------ */
+export const cronRunsQuery = `*[_type == "cronRun" && ranAt >= $since]{
+  _id, job, source, status, details, ranAt
+} | order(ranAt desc) [0...$limit]`;
+
+export const lastCronRunByJobQuery = `*[_type == "cronRun" && job == $job] | order(ranAt desc) [0]{
+  ranAt, source, status, details
+}`;
+
 /* ------------ Duplicate Key Report Check ------------ */
 export const duplicateKeyReportQuery = `*[_type=="keyReport" && ipHash == $ipHash && programSlug == $programSlug && keyHash == $keyHash]{
       _id, eventType, programSlug, keyHash, keyIdentifier, createdAt

--- a/src/sanity/schemaTypes/cronRun.ts
+++ b/src/sanity/schemaTypes/cronRun.ts
@@ -1,0 +1,70 @@
+import { defineType } from "sanity";
+
+export const cronRun = defineType({
+  name: "cronRun",
+  title: "Cron Run",
+  type: "document",
+  readOnly: true,
+  fields: [
+    {
+      name: "job",
+      title: "Job",
+      type: "string",
+      options: {
+        list: [
+          { title: "Bundle Events", value: "bundle-events" },
+          { title: "Update Expired Keys", value: "update-expired-keys" }
+        ]
+      },
+      validation: Rule => Rule.required()
+    },
+    {
+      name: "source",
+      title: "Source",
+      type: "string",
+      description: "How the cron was triggered",
+      options: {
+        list: [
+          { title: "Vercel Cron", value: "vercel_cron" },
+          { title: "Bearer Token", value: "bearer" },
+          { title: "Manual (POST)", value: "manual" }
+        ]
+      },
+      validation: Rule => Rule.required()
+    },
+    {
+      name: "status",
+      title: "Status",
+      type: "string",
+      options: {
+        list: [
+          { title: "Success", value: "ok" },
+          { title: "Error", value: "error" }
+        ]
+      },
+      validation: Rule => Rule.required()
+    },
+    {
+      name: "details",
+      title: "Details",
+      type: "string",
+      description: "Optional result summary (e.g. bundled 5 events)"
+    },
+    {
+      name: "ranAt",
+      title: "Ran At",
+      type: "datetime",
+      validation: Rule => Rule.required()
+    }
+  ],
+  preview: {
+    select: { job: "job", source: "source", status: "status", ranAt: "ranAt" },
+    prepare({ job, source, status, ranAt }) {
+      const d = ranAt ? new Date(ranAt).toLocaleString() : "";
+      return {
+        title: `${job} (${status})`,
+        subtitle: `${source} · ${d}`
+      };
+    }
+  }
+});

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -3,6 +3,7 @@ import { type SchemaTypeDefinition } from "sanity";
 import { trackingEvent } from "./trackingEvent";
 import { trackingEventBundle } from "./trackingEventBundle";
 import { keyReport } from "./keyReport";
+import { cronRun } from "./cronRun";
 import contactMessage from "./contactMessage";
 import keySuggestion from "./keySuggestion";
 
@@ -21,6 +22,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     trackingEvent,
     trackingEventBundle,
     keyReport,
+    cronRun,
     contactMessage,
     keySuggestion,
     link,

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "crons": [
-    { "path": "/api/v1/cron/update-expired-keys", "schedule": "0 0 * * *" },
-    { "path": "/api/v1/cron/bundle-events", "schedule": "0 3 * * *" }
+    { "path": "/api/v1/cron/update-expired-keys", "schedule": "0 20 * * *" },
+    { "path": "/api/v1/cron/bundle-events", "schedule": "0 21 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary

Adds cron run logging and an admin Cron Status card, centralizes cron auth, and adjusts schedules to 20:00 and 21:00 UTC.

## Changelog

<!-- tags: feat, api, fix -->

### Highlights

- cronRun Sanity documents record each job run with status and source
- CronStatusCard on admin dashboard shows last Vercel runs per job
- Shared verifyCronAuth and logCronRun utilities

### Cron infrastructure

- GET /api/v1/admin/cron-status returns last 7 days of runs
- Expired keys at 20:00 UTC; bundle events at 21:00 UTC
- EXPIRED_KEYS_SYSTEM.md updated with schedule notes

---

## Environment Variables

None added. Uses existing SANITY_API_TOKEN and optional CRON_SECRET.

## Testing

- Manual cron trigger creates cronRun document in Sanity
- Admin System section lists recent runs

## Technical Details

Requires SANITY_API_TOKEN write access for cronRun logging.
