### PR TITLE
feat(admin): dashboard refresh, username in session, CronStatusCard tweaks

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -12,7 +12,16 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     // }),
     GitHub({
       clientId: process.env.AUTH_GITHUB_ID!,
-      clientSecret: process.env.AUTH_GITHUB_SECRET!
+      clientSecret: process.env.AUTH_GITHUB_SECRET!,
+      profile(profile) {
+        return {
+          id: profile.id.toString(),
+          name: profile.name ?? profile.login,
+          email: profile.email ?? null,
+          image: profile.avatar_url,
+          username: profile.login
+        };
+      }
     })
   ],
   session: {
@@ -24,17 +33,20 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       if (!user?.email) return false;
       return verifyAdminMembership(user.email);
     },
-    async jwt({ token, user }) {
+    async jwt({ token, user, profile }) {
       if (user?.email) {
         token.email = user.email;
         token.isAdmin = true;
       }
+      const username = (user as { username?: string })?.username ?? (profile && "login" in profile ? (profile.login as string) : undefined);
+      if (username) token.username = username;
       return token;
     },
     async session({ session, token }) {
       if (session.user) {
         session.user.email = token.email ?? session.user.email;
         (session.user as { isAdmin?: boolean }).isAdmin = token.isAdmin === true;
+        (session.user as { username?: string }).username = token.username as string | undefined;
       }
       return session;
     },

--- a/docs/EXPIRED_KEYS_SYSTEM.md
+++ b/docs/EXPIRED_KEYS_SYSTEM.md
@@ -89,13 +89,13 @@ Updates all expired keys across all programs.
   "crons": [
     {
       "path": "/api/v1/cron/update-expired-keys",
-      "schedule": "0 20 * * *"
+      "schedule": "0 22 * * *"
     }
   ]
 }
 ```
 
-Runs once a day (20:00 UTC) to update all expired keys.
+Runs once a day (22:00 UTC) to update all expired keys.
 
 **Env:** `CRON_SECRET` (optional). Vercel adds `x-vercel-cron` when invoking crons. Use `CRON_SECRET` + `Authorization: Bearer <secret>` for manual triggers.
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,194 +1,68 @@
-import Link from "next/link";
 import ProtectedAdminLayout from "@/src/components/admin/ProtectedAdminLayout";
+import DashboardCard from "@/src/components/admin/DashboardCard";
 import CronStatusCard from "@/src/components/admin/CronStatusCard";
+import QuickOverviewStats from "@/src/components/admin/QuickOverviewStats";
+import WelcomeHeader from "@/src/components/admin/WelcomeHeader";
 
 export default function AdminHomePage() {
   return (
-    <ProtectedAdminLayout title="Admin Dashboard" subtitle="Manage your KeyAway platform">
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {/* Analytics Card */}
-        <Link href="/admin/analytics" className="group">
-          <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 hover:shadow-lg transition-all duration-200 group-hover:border-blue-300">
-            <div className="flex items-center space-x-4">
-              <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center group-hover:bg-blue-200 transition-colors">
-                <span className="text-2xl">📊</span>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
-                  Analytics
-                </h3>
-                <p className="text-sm text-gray-500">View user behavior and engagement metrics</p>
-              </div>
-            </div>
-          </div>
-        </Link>
+    <ProtectedAdminLayout headerContent={<WelcomeHeader />}>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
+        <DashboardCard
+          href="/admin/analytics"
+          title="Analytics"
+          subtitle="View user behavior and engagement metrics"
+          icon="📊"
+          color="blue"
+        />
+        <DashboardCard
+          href="/admin/programs"
+          title="Programs"
+          subtitle="Manage CD key programs and content"
+          icon="🎮"
+          color="green"
+        />
+        <DashboardCard
+          href="/admin/events"
+          title="Events"
+          subtitle="Track and analyze user interactions"
+          icon="📈"
+          color="purple"
+        />
+        <DashboardCard
+          href="/admin/key-reports"
+          title="Key Reports"
+          subtitle="Manage all CD key reports (working, expired, limit reached)"
+          icon="🔄"
+          color="orange"
+        />
+        <DashboardCard
+          href="/admin/key-suggestions"
+          title="Key Suggestions"
+          subtitle="Review user-submitted CD keys"
+          icon="🔑"
+          color="yellow"
+        />
+        <DashboardCard
+          href="/admin/messages"
+          title="Messages"
+          subtitle="View and respond to contact messages"
+          icon="📬"
+          color="pink"
+        />
+      </div>
 
-        {/* Programs Card */}
-        <Link href="/admin/programs" className="group">
-          <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 hover:shadow-lg transition-all duration-200 group-hover:border-green-300">
-            <div className="flex items-center space-x-4">
-              <div className="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center group-hover:bg-green-200 transition-colors">
-                <span className="text-2xl">🎮</span>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 group-hover:text-green-600 transition-colors">
-                  Programs
-                </h3>
-                <p className="text-sm text-gray-500">Manage CD key programs and content</p>
-              </div>
-            </div>
-          </div>
-        </Link>
-
-        {/* Events Card */}
-        <Link href="/admin/events" className="group">
-          <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 hover:shadow-lg transition-all duration-200 group-hover:border-purple-300">
-            <div className="flex items-center space-x-4">
-              <div className="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center group-hover:bg-purple-200 transition-colors">
-                <span className="text-2xl">📈</span>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 group-hover:text-purple-600 transition-colors">
-                  Events
-                </h3>
-                <p className="text-sm text-gray-500">Track and analyze user interactions</p>
-              </div>
-            </div>
-          </div>
-        </Link>
-
-        {/* Key Reports Card */}
-        <Link href="/admin/key-reports" className="group">
-          <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 hover:shadow-lg transition-all duration-200 group-hover:border-orange-300">
-            <div className="flex items-center space-x-4">
-              <div className="w-12 h-12 bg-orange-100 rounded-lg flex items-center justify-center group-hover:bg-orange-200 transition-colors">
-                <span className="text-2xl">🔄</span>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 group-hover:text-orange-600 transition-colors">
-                  Key Reports
-                </h3>
-                <p className="text-sm text-gray-500">Manage all CD key reports (working, expired, limit reached)</p>
-              </div>
-            </div>
-          </div>
-        </Link>
-
-        {/* Key Suggestions Card */}
-        <Link href="/admin/key-suggestions" className="group">
-          <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 hover:shadow-lg transition-all duration-200 group-hover:border-yellow-300">
-            <div className="flex items-center space-x-4">
-              <div className="w-12 h-12 bg-yellow-100 rounded-lg flex items-center justify-center group-hover:bg-yellow-200 transition-colors">
-                <span className="text-2xl">🔑</span>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 group-hover:text-yellow-600 transition-colors">
-                  Key Suggestions
-                </h3>
-                <p className="text-sm text-gray-500">Review user-submitted CD keys</p>
-              </div>
-            </div>
-          </div>
-        </Link>
-
-        {/* Messages Card */}
-        <Link href="/admin/messages" className="group">
-          <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 hover:shadow-lg transition-all duration-200 group-hover:border-pink-300">
-            <div className="flex items-center space-x-4">
-              <div className="w-12 h-12 bg-pink-100 rounded-lg flex items-center justify-center group-hover:bg-pink-200 transition-colors">
-                <span className="text-2xl">📬</span>
-              </div>
-              <div>
-                <h3 className="text-lg font-semibold text-gray-900 group-hover:text-pink-600 transition-colors">
-                  Messages
-                </h3>
-                <p className="text-sm text-gray-500">View and respond to contact messages</p>
-              </div>
-            </div>
-          </div>
-        </Link>
-
-        {/* Settings Card */}
-        <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 opacity-50">
-          <div className="flex items-center space-x-4">
-            <div className="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center">
-              <span className="text-2xl">⚙️</span>
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold text-gray-900">Settings</h3>
-              <p className="text-sm text-gray-500">Coming soon - Platform configuration</p>
-            </div>
-          </div>
-        </div>
-
-        {/* Users Card */}
-        <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 opacity-50">
-          <div className="flex items-center space-x-4">
-            <div className="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center">
-              <span className="text-2xl">👥</span>
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold text-gray-900">Users</h3>
-              <p className="text-sm text-gray-500">Coming soon - User management</p>
-            </div>
-          </div>
-        </div>
-
-        {/* Reports Card */}
-        <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 opacity-50">
-          <div className="flex items-center space-x-4">
-            <div className="w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center">
-              <span className="text-2xl">📋</span>
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold text-gray-900">Reports</h3>
-              <p className="text-sm text-gray-500">Coming soon - Detailed reporting</p>
-            </div>
-          </div>
-        </div>
+      {/* Quick Overview */}
+      <div className="mt-8 md:mt-12">
+        <h3 className="text-xl font-semibold text-gray-900 mb-4 md:mb-6">Quick Overview</h3>
+        <QuickOverviewStats />
       </div>
 
       {/* Cron Status */}
-      <div className="mt-12">
-        <h3 className="text-xl font-semibold text-gray-900 mb-6">System</h3>
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="mt-8 md:mt-12">
+        <h3 className="text-xl font-semibold text-gray-900 mb-4 md:mb-6">System</h3>
+        <div className="grid grid-cols-1 gap-4 md:gap-6">
           <CronStatusCard />
-        </div>
-      </div>
-
-      {/* Quick Stats */}
-      <div className="mt-12">
-        <h3 className="text-xl font-semibold text-gray-900 mb-6">Quick Overview</h3>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="bg-gradient-to-r from-blue-500 to-blue-600 rounded-xl p-6 text-white">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-blue-300 text-sm">Total Events Today</p>
-                <p className="text-gray-300 text-3xl font-bold">Loading...</p>
-              </div>
-              <span className="text-4xl opacity-50">📊</span>
-            </div>
-          </div>
-
-          <div className="bg-gradient-to-r from-green-500 to-green-600 rounded-xl p-6 text-white">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-green-300 text-sm">Active Programs</p>
-                <p className="text-gray-300 text-3xl font-bold">Loading...</p>
-              </div>
-              <span className="text-4xl opacity-50">🎮</span>
-            </div>
-          </div>
-
-          <div className="bg-gradient-to-r from-purple-500 to-purple-600 rounded-xl p-6 text-white">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-purple-300 text-sm">Social Clicks</p>
-                <p className="text-gray-300 text-3xl font-bold">Loading...</p>
-              </div>
-              <span className="text-4xl opacity-50">📱</span>
-            </div>
-          </div>
         </div>
       </div>
     </ProtectedAdminLayout>

--- a/src/app/api/v1/admin/dashboard/counts/route.ts
+++ b/src/app/api/v1/admin/dashboard/counts/route.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdminSession } from "@/src/lib/admin/adminAuth";
 import { client } from "@/src/sanity/lib/client";
+import { siteStatsQuery } from "@/src/lib/sanity/queries";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 
 const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
-/** GET /api/v1/admin/dashboard/counts - New messages and suggestions counts (last 60 days) */
+/** GET /api/v1/admin/dashboard/counts - Counts + site stats for admin overview */
 export async function GET(req: NextRequest) {
   const { ok: rateOk } = rateLimitMiddleware(req);
   if (!rateOk) return Errors.tooManyRequests();
@@ -16,18 +18,32 @@ export async function GET(req: NextRequest) {
 
   try {
     const since = new Date(Date.now() - SIXTY_DAYS_MS).toISOString();
+    const weekAgo = new Date(Date.now() - WEEK_MS).toISOString();
 
-    const [newMessages, newSuggestions] = await Promise.all([
-      client.fetch<number>(`count(*[_type == "contactMessage" && status == "new" && createdAt >= $since])`, {
-        since
-      }),
-      client.fetch<number>(`count(*[_type == "keySuggestion" && status == "new" && createdAt >= $since])`, {
-        since
-      })
+    const [[newMessages, newSuggestions], siteStats] = await Promise.all([
+      Promise.all([
+        client.fetch<number>(`count(*[_type == "contactMessage" && status == "new" && createdAt >= $since])`, {
+          since
+        }),
+        client.fetch<number>(`count(*[_type == "keySuggestion" && status == "new" && createdAt >= $since])`, {
+          since
+        })
+      ]),
+      client.fetch<{ totalPrograms: number; totalKeys: number; totalReports: number; recentReports: number }>(
+        siteStatsQuery,
+        { weekAgo }
+      )
     ]);
 
     return NextResponse.json({
-      data: { newMessages: newMessages ?? 0, newSuggestions: newSuggestions ?? 0 },
+      data: {
+        newMessages: newMessages ?? 0,
+        newSuggestions: newSuggestions ?? 0,
+        totalPrograms: siteStats?.totalPrograms ?? 0,
+        totalKeys: siteStats?.totalKeys ?? 0,
+        totalReports: siteStats?.totalReports ?? 0,
+        recentReports: siteStats?.recentReports ?? 0
+      },
       meta: {}
     });
   } catch (err) {

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -3,11 +3,14 @@ import AdminHeader from "./layout/AdminHeader";
 
 interface AdminLayoutProps {
   children: ReactNode;
-  title: string;
+  title?: string;
   subtitle?: string;
+  /** When provided, replaces the default title+subtitle header */
+  headerContent?: ReactNode;
 }
 
-export default function AdminLayout({ children, title, subtitle }: AdminLayoutProps) {
+export default function AdminLayout({ children, title, subtitle, headerContent }: AdminLayoutProps) {
+  const showHeader = headerContent ?? title;
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Header */}
@@ -16,10 +19,16 @@ export default function AdminLayout({ children, title, subtitle }: AdminLayoutPr
       {/* Main Content */}
       <main className="max-w-[90rem] mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         {/* Page Header */}
-        <div className="mb-6 sm:mb-8">
-          <h2 className="text-2xl sm:text-3xl font-bold text-gray-900">{title}</h2>
-          {subtitle && <p className="mt-2 text-base sm:text-lg text-gray-600">{subtitle}</p>}
-        </div>
+        {showHeader && (
+          <div className="mb-6 sm:mb-8">
+            {headerContent ?? (
+              <>
+                <h2 className="text-2xl sm:text-3xl font-bold text-gray-900">{title}</h2>
+                {subtitle && <p className="mt-2 text-base sm:text-lg text-gray-600">{subtitle}</p>}
+              </>
+            )}
+          </div>
+        )}
 
         {/* Content */}
         {children}

--- a/src/components/admin/CronStatusCard.tsx
+++ b/src/components/admin/CronStatusCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { FiInfo } from "react-icons/fi";
 import { formatRelativeTimeCompact } from "@/src/lib/dateUtils";
 
 interface CronRun {
@@ -72,69 +73,88 @@ export default function CronStatusCard() {
     );
   }
 
-  const byJob = {
+  const vercelByJob = {
     "bundle-events": runs.find(r => r.job === "bundle-events" && r.source === "vercel_cron"),
     "update-expired-keys": runs.find(r => r.job === "update-expired-keys" && r.source === "vercel_cron")
   };
+  const lastByJob = {
+    "bundle-events": runs.find(r => r.job === "bundle-events"),
+    "update-expired-keys": runs.find(r => r.job === "update-expired-keys")
+  };
+
+  function JobStatusRow({ job, schedule, label }: { job: "bundle-events" | "update-expired-keys"; schedule: string; label: string }) {
+    const vercelRun = vercelByJob[job];
+    const lastRun = lastByJob[job];
+    return (
+      <div className="flex items-center justify-between py-2 border-b border-gray-100">
+        <div>
+          <span className="font-medium text-gray-900">{label}</span>
+          <p className="text-xs text-gray-500">{schedule}</p>
+        </div>
+        {vercelRun ? (
+          <div className="text-right">
+            <span className={`text-sm font-medium ${vercelRun.status === "ok" ? "text-green-600" : "text-red-600"}`}>
+              {vercelRun.status === "ok" ? "✓" : "✗"}
+            </span>
+            <p className="text-xs text-gray-500">{formatRelativeTimeCompact(vercelRun.ranAt)}</p>
+          </div>
+        ) : lastRun ? (
+          <div className="text-right">
+            <p className="text-xs text-gray-600">
+              Last: <SourceBadge source={lastRun.source} /> {formatRelativeTimeCompact(lastRun.ranAt)}
+            </p>
+            <p className="text-xs text-amber-600 flex items-center justify-end gap-1.5">
+              <FiInfo
+                className="w-4 h-4 shrink-0"
+                title="Automatic Vercel cron runs on schedule. This job was triggered manually (Bearer) or via POST."
+              />
+              No automatic run yet
+            </p>
+          </div>
+        ) : (
+          <span className="text-amber-600 text-sm">No runs yet</span>
+        )}
+      </div>
+    );
+  }
 
   return (
-    <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6">
+    <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 w-full">
       <h3 className="text-lg font-semibold text-gray-900 mb-2">🕐 Cron Jobs</h3>
-      <p className="text-gray-500 text-sm mb-4">Last Vercel cron runs (manual runs shown in history)</p>
+      <p className="text-gray-500 text-sm mb-4">
+        Automatic runs via Vercel cron. Manual/Bearer runs appear in recent history.
+      </p>
 
-      <div className="space-y-4 mb-4">
-        <div className="flex items-center justify-between py-2 border-b border-gray-100">
-          <div>
-            <span className="font-medium text-gray-900">Bundle Events</span>
-            <p className="text-xs text-gray-500">Daily at 21:00 UTC</p>
-          </div>
-          {byJob["bundle-events"] ? (
-            <div className="text-right">
-              <span className={`text-sm font-medium ${byJob["bundle-events"].status === "ok" ? "text-green-600" : "text-red-600"}`}>
-                {byJob["bundle-events"].status === "ok" ? "✓" : "✗"}
-              </span>
-              <p className="text-xs text-gray-500">{formatRelativeTimeCompact(byJob["bundle-events"].ranAt)}</p>
-            </div>
-          ) : (
-            <span className="text-amber-600 text-sm">No Vercel run yet</span>
-          )}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <div className="space-y-0 min-w-0 lg:pr-8">
+          <JobStatusRow job="bundle-events" schedule="Daily at 21:00 UTC" label="Bundle Events" />
+          <JobStatusRow job="update-expired-keys" schedule="Daily at 20:00 UTC" label="Update Expired Keys" />
         </div>
-        <div className="flex items-center justify-between py-2 border-b border-gray-100">
-          <div>
-            <span className="font-medium text-gray-900">Update Expired Keys</span>
-            <p className="text-xs text-gray-500">Daily at 20:00 UTC</p>
-          </div>
-          {byJob["update-expired-keys"] ? (
-            <div className="text-right">
-              <span className={`text-sm font-medium ${byJob["update-expired-keys"].status === "ok" ? "text-green-600" : "text-red-600"}`}>
-                {byJob["update-expired-keys"].status === "ok" ? "✓" : "✗"}
-              </span>
-              <p className="text-xs text-gray-500">{formatRelativeTimeCompact(byJob["update-expired-keys"].ranAt)}</p>
-            </div>
+
+        <div className="min-w-0 lg:border-l lg:pl-8 border-gray-200">
+          <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">Recent runs</h4>
+          {runs.length > 0 ? (
+            <ul className="space-y-1.5 text-sm max-h-40 overflow-y-auto">
+              {runs.slice(0, 20).map(run => (
+                <li key={run._id} className="flex items-center justify-between gap-2 py-1.5 border-b border-gray-50 last:border-0">
+                  <span className="text-gray-900 font-medium shrink-0">
+                    <JobLabel job={run.job} />
+                  </span>
+                  <span className="flex items-center gap-2 flex-wrap justify-end">
+                    <SourceBadge source={run.source} />
+                    {run.details && <span className="text-gray-500 text-xs">({run.details})</span>}
+                    <span className={`font-medium shrink-0 ${run.status === "ok" ? "text-green-600" : "text-red-600"}`}>
+                      {formatRelativeTimeCompact(run.ranAt)}
+                    </span>
+                  </span>
+                </li>
+              ))}
+            </ul>
           ) : (
-            <span className="text-amber-600 text-sm">No Vercel run yet</span>
+            <p className="text-gray-500 text-sm">No runs recorded yet</p>
           )}
         </div>
       </div>
-
-      {runs.length > 0 && (
-        <details className="mt-4">
-          <summary className="text-sm text-gray-600 cursor-pointer hover:text-gray-900">Recent runs ({runs.length})</summary>
-          <ul className="mt-2 space-y-1 text-xs max-h-48 overflow-y-auto">
-            {runs.slice(0, 20).map(run => (
-              <li key={run._id} className="flex items-center justify-between py-1 border-b border-gray-50 last:border-0">
-                <span>
-                  <JobLabel job={run.job} /> <SourceBadge source={run.source} />
-                  {run.details && <span className="text-gray-500 ml-1">({run.details})</span>}
-                </span>
-                <span className={`font-medium ${run.status === "ok" ? "text-green-600" : "text-red-600"}`}>
-                  {formatRelativeTimeCompact(run.ranAt)}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </details>
-      )}
     </div>
   );
 }

--- a/src/components/admin/CronStatusCard.tsx
+++ b/src/components/admin/CronStatusCard.tsx
@@ -128,7 +128,7 @@ export default function CronStatusCard() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <div className="space-y-0 min-w-0 lg:pr-8">
           <JobStatusRow job="bundle-events" schedule="Daily at 21:00 UTC" label="Bundle Events" />
-          <JobStatusRow job="update-expired-keys" schedule="Daily at 20:00 UTC" label="Update Expired Keys" />
+          <JobStatusRow job="update-expired-keys" schedule="Daily at 22:00 UTC" label="Update Expired Keys" />
         </div>
 
         <div className="min-w-0 lg:border-l lg:pl-8 border-gray-200">

--- a/src/components/admin/DashboardCard.tsx
+++ b/src/components/admin/DashboardCard.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+
+export interface DashboardCardProps {
+  href: string;
+  title: string;
+  subtitle: string;
+  icon: string;
+  /** Tailwind color for icon bg and hover border, e.g. "blue", "green" */
+  color?: "blue" | "green" | "purple" | "orange" | "yellow" | "pink";
+}
+
+const colorClasses: Record<string, { bg: string; hover: string }> = {
+  blue: { bg: "bg-blue-100 group-hover:bg-blue-200", hover: "group-hover:border-blue-300" },
+  green: { bg: "bg-green-100 group-hover:bg-green-200", hover: "group-hover:border-green-300" },
+  purple: { bg: "bg-purple-100 group-hover:bg-purple-200", hover: "group-hover:border-purple-300" },
+  orange: { bg: "bg-orange-100 group-hover:bg-orange-200", hover: "group-hover:border-orange-300" },
+  yellow: { bg: "bg-yellow-100 group-hover:bg-yellow-200", hover: "group-hover:border-yellow-300" },
+  pink: { bg: "bg-pink-100 group-hover:bg-pink-200", hover: "group-hover:border-pink-300" }
+};
+
+export default function DashboardCard({ href, title, subtitle, icon, color = "blue" }: DashboardCardProps) {
+  const { bg, hover } = colorClasses[color] ?? colorClasses.blue;
+  return (
+    <Link href={href} className="group">
+      <div
+        className={`bg-white rounded-xl shadow-soft border border-gray-200 p-6 hover:shadow-lg transition-all duration-200 ${hover}`}>
+        <div className="flex items-center space-x-4">
+          <div className={`w-12 h-12 ${bg} rounded-lg flex items-center justify-center transition-colors`}>
+            <span className="text-2xl">{icon}</span>
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900 group-hover:text-gray-700 transition-colors">{title}</h3>
+            <p className="text-sm text-gray-500">{subtitle}</p>
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/admin/ProtectedAdminLayout.tsx
+++ b/src/components/admin/ProtectedAdminLayout.tsx
@@ -6,7 +6,12 @@ import { useSession } from "next-auth/react";
 import AdminLayout from "./AdminLayout";
 import type { ProtectedAdminLayoutProps } from "@/src/types";
 
-export default function ProtectedAdminLayout({ title, subtitle, children }: ProtectedAdminLayoutProps) {
+export default function ProtectedAdminLayout({
+  title,
+  subtitle,
+  headerContent,
+  children
+}: ProtectedAdminLayoutProps) {
   const { data: session, status } = useSession();
   const [isChecking, setIsChecking] = useState(true);
   const router = useRouter();
@@ -47,7 +52,7 @@ export default function ProtectedAdminLayout({ title, subtitle, children }: Prot
   }
 
   return (
-    <AdminLayout title={title} subtitle={subtitle}>
+    <AdminLayout title={title} subtitle={subtitle} headerContent={headerContent}>
       {children}
     </AdminLayout>
   );

--- a/src/components/admin/QuickOverviewStats.tsx
+++ b/src/components/admin/QuickOverviewStats.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+
+interface DashboardStats {
+  newMessages: number;
+  newSuggestions: number;
+  totalPrograms: number;
+  totalKeys: number;
+  totalReports: number;
+  recentReports: number;
+}
+
+const defaultStats: DashboardStats = {
+  newMessages: 0,
+  newSuggestions: 0,
+  totalPrograms: 0,
+  totalKeys: 0,
+  totalReports: 0,
+  recentReports: 0
+};
+
+function StatCard({
+  title,
+  value,
+  subtitle,
+  href,
+  iconBg,
+  icon
+}: {
+  title: string;
+  value: string | number;
+  subtitle: string;
+  href?: string;
+  iconBg: string;
+  icon: string;
+}) {
+  const content = (
+    <div
+      className={`bg-white rounded-xl shadow-soft border border-gray-200 p-6 transition-shadow ${
+        href ? "group-hover:shadow-lg" : ""
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-gray-500 text-sm">{title}</p>
+          <p className="text-gray-900 text-3xl font-bold">{value}</p>
+          {subtitle && <p className="text-gray-500 text-xs mt-0.5">{subtitle}</p>}
+        </div>
+        <div className={`w-12 h-12 rounded-lg flex items-center justify-center ${iconBg}`}>
+          <span className="text-2xl">{icon}</span>
+        </div>
+      </div>
+    </div>
+  );
+  if (href) {
+    return <Link href={href} className="block group">{content}</Link>;
+  }
+  return content;
+}
+
+export default function QuickOverviewStats() {
+  const [stats, setStats] = useState<DashboardStats>(defaultStats);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/v1/admin/dashboard/counts")
+      .then(res => res.json())
+      .then(data => {
+        const d = data?.data ?? data;
+        setStats({
+          newMessages: d?.newMessages ?? 0,
+          newSuggestions: d?.newSuggestions ?? 0,
+          totalPrograms: d?.totalPrograms ?? 0,
+          totalKeys: d?.totalKeys ?? 0,
+          totalReports: d?.totalReports ?? 0,
+          recentReports: d?.recentReports ?? 0
+        });
+      })
+      .catch(() => setStats(defaultStats))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+        {[1, 2, 3, 4].map(i => (
+          <div key={i} className="bg-gray-100 rounded-xl p-6 animate-pulse h-28" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6">
+      <StatCard
+        title="Programs"
+        value={stats.totalPrograms}
+        subtitle={`${stats.totalKeys} CD keys total`}
+        href="/admin/programs"
+        iconBg="bg-green-100"
+        icon="🎮"
+      />
+      <StatCard
+        title="Key Reports"
+        value={stats.totalReports}
+        subtitle={`${stats.recentReports} in last 7 days`}
+        href="/admin/key-reports"
+        iconBg="bg-orange-100"
+        icon="🔄"
+      />
+      <StatCard
+        title="New Messages"
+        value={stats.newMessages}
+        subtitle="Awaiting response (60d)"
+        href="/admin/messages"
+        iconBg="bg-pink-100"
+        icon="📬"
+      />
+      <StatCard
+        title="Key Suggestions"
+        value={stats.newSuggestions}
+        subtitle="To review (60d)"
+        href="/admin/key-suggestions"
+        iconBg="bg-amber-100"
+        icon="🔑"
+      />
+    </div>
+  );
+}

--- a/src/components/admin/WelcomeHeader.tsx
+++ b/src/components/admin/WelcomeHeader.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+
+export default function WelcomeHeader() {
+  const { data: session } = useSession();
+  const name = session?.user?.username ?? session?.user?.name ?? session?.user?.email?.split("@")[0] ?? null;
+  const firstName = name?.split(/\s+/)[0];
+
+  return (
+    <div className="mb-6 sm:mb-8">
+      <h2 className="text-2xl sm:text-3xl font-bold text-gray-900">
+        {firstName ? `Welcome, ${firstName}` : "Welcome back"}
+      </h2>
+      <p className="mt-2 text-base sm:text-lg text-gray-600">Here&apos;s what needs your attention</p>
+    </div>
+  );
+}

--- a/src/types/admin/index.ts
+++ b/src/types/admin/index.ts
@@ -20,8 +20,10 @@ export interface AdminLayoutProps {
 }
 
 export interface ProtectedAdminLayoutProps {
-  title: string;
-  subtitle: string;
+  title?: string;
+  subtitle?: string;
+  /** Custom header (e.g. WelcomeHeader). Replaces title+subtitle when provided */
+  headerContent?: React.ReactNode;
   children: React.ReactNode;
 }
 

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -3,6 +3,8 @@ import "next-auth";
 declare module "next-auth" {
   interface User {
     isAdmin?: boolean;
+    /** OAuth username (e.g. GitHub login) */
+    username?: string | null;
   }
 
   interface Session {
@@ -17,5 +19,6 @@ declare module "next-auth/jwt" {
   interface JWT {
     isAdmin?: boolean;
     email?: string | null;
+    username?: string | null;
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "crons": [
-    { "path": "/api/v1/cron/update-expired-keys", "schedule": "0 20 * * *" },
+    { "path": "/api/v1/cron/update-expired-keys", "schedule": "0 22 * * *" },
     { "path": "/api/v1/cron/bundle-events", "schedule": "0 21 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary

Refreshes the admin dashboard with reusable components and real-time stats, adds GitHub username to the session welcome header, improves Cron Status card, and moves expired-keys cron to 22:00 UTC.

## Changelog

<!-- tags: feat, ui, api -->

### Highlights

- DashboardCard, QuickOverviewStats, and WelcomeHeader replace placeholders
- Dashboard counts API returns programs, keys, reports, and recent reports
- GitHub username shown in admin welcome header

### Admin dashboard

- CronStatusCard clearer manual vs Vercel run messaging
- update-expired-keys cron schedule moved to 22:00 UTC

---

## Environment Variables

None

## Testing

- /admin dashboard shows live counts and welcome name
- CronStatusCard reflects last run source

## Technical Details

cronRun schema from prior commits; no new migrations in this PR.
