### PR TITLE
feat(analytics): add updatedAt to bundles; treat bearer as auto run in CronStatusCard

### DIFF
--- a/src/components/admin/CronStatusCard.tsx
+++ b/src/components/admin/CronStatusCard.tsx
@@ -16,12 +16,12 @@ interface CronRun {
 function SourceBadge({ source }: { source: string }) {
   const styles: Record<string, string> = {
     vercel_cron: "bg-blue-100 text-blue-800",
-    bearer: "bg-amber-100 text-amber-800",
+    bearer: "bg-blue-100 text-blue-800",
     manual: "bg-gray-100 text-gray-700"
   };
   const labels: Record<string, string> = {
     vercel_cron: "Vercel",
-    bearer: "Bearer",
+    bearer: "Vercel",
     manual: "Manual"
   };
   return (
@@ -74,8 +74,8 @@ export default function CronStatusCard() {
   }
 
   const vercelByJob = {
-    "bundle-events": runs.find(r => r.job === "bundle-events" && r.source === "vercel_cron"),
-    "update-expired-keys": runs.find(r => r.job === "update-expired-keys" && r.source === "vercel_cron")
+    "bundle-events": runs.find(r => r.job === "bundle-events" && (r.source === "vercel_cron" || r.source === "bearer")),
+    "update-expired-keys": runs.find(r => r.job === "update-expired-keys" && (r.source === "vercel_cron" || r.source === "bearer"))
   };
   const lastByJob = {
     "bundle-events": runs.find(r => r.job === "bundle-events"),
@@ -106,7 +106,7 @@ export default function CronStatusCard() {
             <p className="text-xs text-amber-600 flex items-center justify-end gap-1.5">
               <FiInfo
                 className="w-4 h-4 shrink-0"
-                title="Automatic Vercel cron runs on schedule. This job was triggered manually (Bearer) or via POST."
+                title="Automatic Vercel cron runs on schedule. This job was triggered manually via POST."
               />
               No automatic run yet
             </p>
@@ -122,7 +122,7 @@ export default function CronStatusCard() {
     <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 w-full">
       <h3 className="text-lg font-semibold text-gray-900 mb-2">🕐 Cron Jobs</h3>
       <p className="text-gray-500 text-sm mb-4">
-        Automatic runs via Vercel cron. Manual/Bearer runs appear in recent history.
+        Automatic runs via Vercel cron. Manual runs appear in recent history.
       </p>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">

--- a/src/lib/analytics/bundleEvents.ts
+++ b/src/lib/analytics/bundleEvents.ts
@@ -72,8 +72,11 @@ export async function runBundleEvents(skipRetention = false): Promise<BundleEven
       const newEventCount = incomplete.eventCount + toAdd.length;
       const idsToDelete = toAdd.map(e => e._id);
       const tx = client.transaction();
+      const now = new Date().toISOString();
       tx.patch(incomplete._id, p =>
-        p.append("events", newEvents).set({ timeRangeEnd: newTimeRangeEnd, eventCount: newEventCount })
+        p
+          .append("events", newEvents)
+          .set({ timeRangeEnd: newTimeRangeEnd, eventCount: newEventCount, updatedAt: now })
       );
       idsToDelete.forEach(id => tx.delete(id));
       await tx.commit();
@@ -100,9 +103,11 @@ export async function runBundleEvents(skipRetention = false): Promise<BundleEven
       after = timeRangeEnd;
       const idsToDelete = batch.map(e => e._id);
       const tx = client.transaction();
+      const now = new Date().toISOString();
       tx.create({
         _type: "trackingEventBundle",
-        bundledAt: new Date().toISOString(),
+        bundledAt: now,
+        updatedAt: now,
         timeRangeStart,
         timeRangeEnd,
         eventCount: events.length,

--- a/src/sanity/schemaTypes/trackingEventBundle.ts
+++ b/src/sanity/schemaTypes/trackingEventBundle.ts
@@ -26,6 +26,13 @@ export const trackingEventBundle = defineType({
   type: "document",
   fields: [
     {
+      name: "updatedAt",
+      title: "Updated At",
+      type: "datetime",
+      description: "Last time cron added events to this bundle",
+      readOnly: true
+    },
+    {
       name: "bundledAt",
       title: "Bundled At",
       type: "datetime",


### PR DESCRIPTION
## Summary

Adds updatedAt to event bundles and refreshes CronStatusCard so bearer-triggered runs display like Vercel cron runs.

## Changelog

<!-- tags: feat, api, enhance -->

### Highlights

- trackingEventBundle gains updatedAt on create and append
- CronStatusCard treats bearer-triggered runs as automatic
- Simplified cron badge copy without separate Bearer label

---

## Environment Variables

None

## Testing

- Trigger bundle-events manually with bearer auth; CronStatusCard shows automatic run
- Existing bundles gain updatedAt on next append

## Technical Details

Sanity trackingEventBundle schema field addition only.
