### PR TITLE
feat(docs): Terms & Privacy docs, LICENSE, key-reports fix, CD key uniqueness

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2025 KeyAway (https://keyaway.app)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This license applies to the software and source code only. The KeyAway name,
+logo, and brand identity are not licensed hereunder. Use of the KeyAway
+branding without permission is not permitted.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,13 @@ In Studio, create **Program** documents and add CD keys (key, status, version, v
 
 ---
 
+## Legal
+
+- [Terms of Service](docs/TERMS_OF_SERVICE.md)
+- [Privacy Policy](docs/PRIVACY_POLICY.md)
+
+---
+
 ## License
 
-MIT © [eyyMinda](https://github.com/eyyMinda)
+MIT. See [LICENSE](LICENSE) for details. KeyAway (keyaway.app) retains all rights to the KeyAway name and branding.

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -1,0 +1,62 @@
+# Privacy Policy
+
+**Last updated: October 12, 2025**
+
+KeyAway (keyaway.app) is the service described in this policy. Learn how we handle your personal data, comments, and contributions while keeping the site transparent.
+
+---
+
+## 1. Information We Collect
+
+KeyAway does not require account registration. We may collect limited information when you:
+
+- Post comments (such as your GitHub profile if using Giscus)
+- Make a donation through a third-party service
+- Submit CD key suggestions or contact us (name, email, and message content - stored securely via Sanity CMS)
+- Report key status (anonymous, no personal data collected)
+
+---
+
+## 2. Purpose of Content
+
+All CD keys listed on KeyAway are **public giveaway keys** provided directly by software distributors. They are made available to everyone for a limited time or version. We simply aggregate and display them in one place to make them easier to access.
+
+> **No stolen, pirated, or unauthorized keys are hosted or distributed.**
+
+---
+
+## 3. Cookies and Analytics
+
+We may use basic analytics or cookies to understand site usage. No personal data is sold or shared with advertisers.
+
+---
+
+## 4. Third-Party Services
+
+Comments and donations are handled by trusted third-party services (e.g., GitHub Discussions, PayPal, or similar). Please refer to their respective privacy policies for details.
+
+---
+
+## 5. Key Suggestions & Contact Forms
+
+When you submit a CD key suggestion or contact us through our forms:
+
+- **Data Collected:** Your name, email, and message/key details
+- **Purpose:** To verify and publish legitimate keys, or to respond to your inquiry
+- **Storage:** Submissions are stored securely in Sanity CMS and are only accessible by site administrators
+- **Retention:** We retain submissions until they are processed. Contact messages may be kept for support purposes
+- **No Sharing:** Your personal information is never shared with third parties or used for marketing
+
+> **Note:** Only the CD keys themselves (not your personal info) are published publicly after verification. Your email is used solely for communication if needed.
+
+---
+
+## 6. Data Security
+
+We take reasonable measures to protect your data, including secure HTTPS connections and trusted CMS infrastructure. However, no online service is 100% secure.
+
+---
+
+## 7. Contact
+
+If you have questions about this Privacy Policy, please contact us via the website.

--- a/docs/TERMS_OF_SERVICE.md
+++ b/docs/TERMS_OF_SERVICE.md
@@ -1,0 +1,62 @@
+# Terms of Service
+
+**Last updated: October 12, 2025**
+
+KeyAway is the service operated at [keyaway.app](https://www.keyaway.app). These terms govern your use of our platform for sharing publicly available giveaway CD keys.
+
+---
+
+## 1. Acceptance of Terms
+
+By accessing and using KeyAway, you agree to comply with these Terms of Service. If you do not agree, please discontinue use of the website.
+
+---
+
+## 2. Purpose of the Site
+
+KeyAway provides access to publicly available giveaway CD keys for selected software programs. These keys are released by the software distributors themselves as limited-time or version-specific promotional offers.
+
+> **We do not host, distribute, or promote pirated or stolen keys.**
+>
+> KeyAway's role is to make legitimate giveaway keys easier to discover in one place.
+
+---
+
+## 3. User Contributions & Key Suggestions
+
+Users can contribute to KeyAway by:
+
+- **Suggesting CD Keys:** Submit new legitimate giveaway keys for any software through our suggestion form
+- **Reporting Key Status:** Mark keys as working, expired, or limit reached to help maintain accuracy
+- **Posting Comments:** Engage with the community through our commenting system
+
+**By contributing, you agree:**
+
+- To only submit legitimate giveaway keys from official sources
+- Not to post unlawful, offensive, or harmful content
+- That KeyAway reserves the right to moderate, verify, or remove any submission
+- That submitted keys may be published publicly after verification
+
+---
+
+## 4. Validity of Keys
+
+Giveaway keys may only work with specific versions of the software and for a limited time. We cannot guarantee their availability or functionality once the distributor ends the promotion.
+
+---
+
+## 5. Donations
+
+Donations are voluntary and non-refundable. They are used solely to support the operation and hosting of the website.
+
+---
+
+## 6. Limitation of Liability
+
+KeyAway is provided "as is." We are not responsible for invalid, expired, or misused CD keys, nor for damages arising from the use of this website.
+
+---
+
+## 7. Contact & Questions
+
+If you have any questions about these Terms of Service or need to report an issue, please contact us via the website.

--- a/src/app/api/v1/admin/key-reports/route.ts
+++ b/src/app/api/v1/admin/key-reports/route.ts
@@ -20,26 +20,32 @@ export async function PATCH(req: NextRequest) {
 
     const b = body as Record<string, unknown>;
     const programSlug = typeof b.programSlug === "string" ? b.programSlug.trim() : "";
-    const keyIndex = b.keyIndex;
+    const keyIndex =
+      typeof b.keyIndex === "number" ? b.keyIndex : parseInt(String(b.keyIndex ?? ""), 10);
     const newStatus = typeof b.newStatus === "string" ? b.newStatus.trim() : "";
 
-    if (!programSlug || keyIndex === undefined || !newStatus) {
+    if (!programSlug || keyIndex < 0 || Number.isNaN(keyIndex) || !newStatus) {
       return Errors.validation("Missing required fields: programSlug, keyIndex, newStatus");
     }
     if (!VALID_STATUSES.includes(newStatus as (typeof VALID_STATUSES)[number])) {
       return Errors.validation(`Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}`);
     }
 
-    const programDoc = await client.fetch<{ _id: string } | null>(
-      `*[_type == "program" && slug.current == $slug][0]{ _id }`,
+    const programDoc = await client.fetch<{ _id: string; cdKeys?: Array<{ key?: string; status?: string; _key?: string }> } | null>(
+      `*[_type == "program" && slug.current == $slug][0]{ _id, cdKeys }`,
       { slug: programSlug }
     );
     if (!programDoc) return Errors.notFound(`Program not found for slug: ${programSlug}`);
 
-    const result = await client
-      .patch(programDoc._id)
-      .set({ [`cdKeys[${keyIndex}].status`]: newStatus })
-      .commit();
+    const cdKeys = programDoc.cdKeys ?? [];
+    if (keyIndex < 0 || keyIndex >= cdKeys.length) {
+      return Errors.validation(`Invalid keyIndex: ${keyIndex} (program has ${cdKeys.length} keys)`);
+    }
+
+    const updatedKeys = cdKeys.map((k, i) =>
+      i === keyIndex ? { ...k, status: newStatus } : k
+    );
+    const result = await client.patch(programDoc._id).set({ cdKeys: updatedKeys }).commit();
 
     return NextResponse.json({ data: result, meta: {} });
   } catch (err) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -84,6 +84,7 @@ export default async function RootLayout({
       <head>
         {/* Verification Metadata */}
         <meta name="google-site-verification" content="jCM2s4y7bLvOzH32pe8QtRIdwbgEOmntka957Z-tXKI" />
+        <meta name="facebook-domain-verification" content="r1iisd1vo2n1fuctve43oc853x7k3p" />
         <meta name="websitelaunches-verification" content="dd1325f78db38d8052054c8b99e596eb" />
 
         {/* Technology Stack Metadata */}

--- a/src/app/privacy/PrivacyContent.tsx
+++ b/src/app/privacy/PrivacyContent.tsx
@@ -12,7 +12,8 @@ export default function PrivacyContent() {
             <h1 className="text-4xl font-bold text-white mb-4">Privacy Policy</h1>
             <p className="text-lg text-neutral-300 mb-2">Last updated: October 12, 2025</p>
             <p className="text-neutral-400">
-              Learn how we handle your personal data, comments, and contributions while keeping the site transparent.
+              KeyAway (keyaway.app) is the service described in this policy. Learn how we handle your personal data,
+              comments, and contributions while keeping the site transparent.
             </p>
           </div>
         </div>

--- a/src/app/terms/TermsContent.tsx
+++ b/src/app/terms/TermsContent.tsx
@@ -12,7 +12,11 @@ export default function TermsContent() {
             <h1 className="text-4xl font-bold text-white mb-4">Terms of Service</h1>
             <p className="text-lg text-neutral-300 mb-2">Last updated: October 12, 2025</p>
             <p className="text-neutral-400">
-              Read the terms of service for using our platform for sharing publicly available giveaway CD keys.
+              KeyAway is the service operated at{" "}
+              <a href="https://www.keyaway.app" className="text-primary-400 hover:text-primary-300 underline">
+                keyaway.app
+              </a>
+              . These terms govern your use of our platform for sharing publicly available giveaway CD keys.
             </p>
           </div>
         </div>

--- a/src/sanity/schemaTypes/program.ts
+++ b/src/sanity/schemaTypes/program.ts
@@ -39,7 +39,19 @@ export const program = defineType({
       name: "cdKeys",
       title: "CD Keys",
       type: "array",
-      of: [{ type: "cdKey" }]
+      of: [{ type: "cdKey" }],
+      validation: Rule =>
+        Rule.custom((keys: { key?: string }[] | undefined) => {
+          if (!keys || keys.length === 0) return true;
+          const normalized = (keys ?? [])
+            .map(k => (typeof k?.key === "string" ? k.key.trim().toUpperCase().replace(/\s+/g, "") : ""))
+            .filter(Boolean);
+          const unique = new Set(normalized);
+          if (unique.size < normalized.length) {
+            return "Duplicate CD keys are not allowed within the same program.";
+          }
+          return true;
+        })
     }
   ],
   preview: {


### PR DESCRIPTION
## Summary

Adds Terms and Privacy documentation, MIT LICENSE with KeyAway branding, fixes admin key-reports status persistence, enforces unique CD keys per program, and adds Facebook domain verification.

## Changelog

<!-- tags: feat, docs, fix -->

### Highlights

- Terms of Service and Privacy Policy docs with README legal links
- Admin key-reports PATCH correctly persists single cdKey status updates
- Duplicate CD keys blocked within the same program in Sanity validation

### Legal & trust

- MIT LICENSE with KeyAway branding reserved
- facebook-domain-verification meta tag in layout

---

## Environment Variables

None

## Testing

- Admin key report status change persists after refresh
- Studio rejects duplicate normalized CD keys on one program
- Terms/Privacy linked from README

## Technical Details

No Sanity migrations; program schema adds client-side validation only.
