### PR TITLE
feat(auth): 7-day admin sessions and admin events/report UI tweaks

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -26,7 +26,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   ],
   session: {
     strategy: "jwt",
-    maxAge: process.env.NODE_ENV === "development" ? 7 * 24 * 60 * 60 : 2 * 60 * 60 // 7 days dev, 2 hours prod
+    maxAge: 7 * 24 * 60 * 60 // 7 days
   },
   callbacks: {
     async signIn({ user }) {

--- a/src/components/admin/ReportDetailsModal.tsx
+++ b/src/components/admin/ReportDetailsModal.tsx
@@ -405,9 +405,6 @@ export default function ReportDetailsModal({ isOpen, onClose, report }: ReportDe
                       )}
                     </div>
                     <div className="flex flex-col gap-1.5 sm:items-end sm:text-right text-xs text-gray-600 shrink-0">
-                      <span className="max-w-72" title={`${reportItem.city}, ${reportItem.country}`}>
-                        {reportItem.city}, {reportItem.country}
-                      </span>
                       <div className="flex flex-wrap items-center justify-end gap-1.5 w-full sm:max-w-[20rem]">
                         <span className={visitorTierBadgeClasses(tier, false)}>{tier}</span>
                         {isSpam ? <span className={visitorTierBadgeClasses("new", true)}>spammer</span> : null}
@@ -415,6 +412,9 @@ export default function ReportDetailsModal({ isOpen, onClose, report }: ReportDe
                           {hashShort}
                         </span>
                       </div>
+                      <span className="max-w-72" title={`${reportItem.city}, ${reportItem.country}`}>
+                        {reportItem.city}, {reportItem.country}
+                      </span>
                       {hash ? (
                         <button
                           type="button"

--- a/src/components/admin/events/EventsTable.tsx
+++ b/src/components/admin/events/EventsTable.tsx
@@ -2,11 +2,7 @@ import React from "react";
 import { AnalyticsEventData } from "@/src/types";
 import SortableTableHead, { SortableColumn, SortDirection } from "@/src/components/ui/SortableTableHead";
 import Pagination from "@/src/components/ui/Pagination";
-import {
-  extractReferrerInfo,
-  effectiveReferrerHref,
-  formatEventName
-} from "@/src/lib/analytics/analyticsUtils";
+import { extractReferrerInfo, effectiveReferrerHref, formatEventName } from "@/src/lib/analytics/analyticsUtils";
 import { analyticsEventPillClasses, visitorTierBadgeClasses } from "@/src/theme/colorSchema";
 import { isPageViewNotFoundRow } from "@/src/lib/analytics/pageViewDisplay";
 
@@ -61,25 +57,27 @@ export default function EventsTable({
               const hashShort = hash ? `${hash.slice(0, 10)}…` : null;
               return (
                 <tr key={event._id} className="hover:bg-gray-50">
-                  <td className="max-w-52 p-4 align-top text-sm text-gray-900">
+                  <td className="max-w-40 p-4 align-top text-sm text-gray-900">
                     {hash ? (
-                      <div className="flex flex-wrap items-center gap-1.5">
-                        {event.visitorIsSpammer ? (
-                          <span className={visitorTierBadgeClasses("new", true)}>spammer</span>
-                        ) : null}
-                        <span className={visitorTierBadgeClasses(event.visitTier, false)}>
-                          {event.visitTier || "new"}
-                        </span>
-                        <span className="font-mono text-[10px] text-gray-500 truncate min-w-0" title={hash}>
+                      <div className="flex flex-col gap-0">
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <span className={visitorTierBadgeClasses(event.visitTier, false)}>
+                            {event.visitTier || "new"}
+                          </span>
+                          {event.visitorIsSpammer ? (
+                            <span className={visitorTierBadgeClasses("new", true)}>spammer</span>
+                          ) : null}
+                        </div>
+                        <div className="font-mono text-[10px] text-gray-500 truncate min-w-0" title={hash}>
                           {hashShort}
-                        </span>
+                        </div>
                       </div>
                     ) : (
                       <span className="text-gray-400 text-xs">—</span>
                     )}
                   </td>
                   <td className="max-w-44 p-4 align-top whitespace-nowrap">
-                    <div className="flex flex-col gap-0 items-start">
+                    <div className="flex flex-col gap-0 items-center">
                       {event.notFound === true && (
                         <span className="text-xs font-semibold text-rose-900 mx-auto">Not Found</span>
                       )}


### PR DESCRIPTION
## Summary

Extends admin NextAuth sessions to 7 days in production and improves admin Events and key report detail layouts for visitor hash and location readability.

## Changelog

<!-- tags: feat, ui, enhance -->

### Highlights

- Admin JWT sessions last 7 days in production (matching dev)
- Events table stacks tier, spammer badge, and hash on separate lines
- Report details modal shows city/country below visitor badges

---

## Environment Variables

None

## Testing

- Admin session persists across days in production-like config
- Events visitor column readable at narrow widths
- Report details spammer toggle still works after layout change

## Technical Details

No schema changes.
