### PR TITLE
feat: bucketed interaction tracking and analytics hardening

### DIFF
--- a/docs/interactions-tracking.md
+++ b/docs/interactions-tracking.md
@@ -1,0 +1,54 @@
+# Interactions tracking naming rules
+
+This project uses a dedicated bucketed interaction pipeline (`interactionEventBucket`), separate from analytics events.
+
+## Required fields
+
+- `interactionId` — exact element/action identity
+- `sectionId` — coarse placement identity (top-level section)
+- `pagePath` — normalized route path
+- `programSlug` — optional, only when interaction is program-specific
+
+## `sectionId` rules
+
+Author sections with the nested map `SECTIONS` in `src/lib/analytics/interactionCatalog.ts` (e.g. `SECTIONS.home.hero`). Allowed **stored string values** are exactly:
+
+| Group | Constant | Stored value |
+| --- | --- | --- |
+| `global` | `header` | `header` |
+| `home` | `hero` | `hero` |
+| `home` | `featuredProgram` | `featured_program` |
+| `home` | `popularPrograms` | `popular_programs` |
+| `home` | `features` | `features` |
+| `home` | `cta` | `cta` |
+| `browse` | `allProgramsGrid` | `all_programs_grid` — full grid on `/programs` |
+| `program` | `programInformation` | `program_information` — `ProgramInformation.tsx` on `/program/[slug]` |
+
+`sectionId` should be stable and broad. Do not encode button-level details here.
+
+Merged flat access: `SECTION_IDS` (same values as `SECTIONS.*.*`) for defaults and tooling.
+
+## `interactionId` rules
+
+Use only values from `INTERACTION_IDS` in `src/lib/analytics/interactionCatalog.ts`.
+
+Conventions:
+
+- lower_snake_case
+- verb/action last when practical (`..._open`, `..._click`, `..._view_keys`)
+- stable over time (do not include transient UI copy or locale text)
+
+Examples:
+
+- `hero_visitor_hint_open`
+- `program_grid_view_keys_button`
+- `featured_program_view_keys`
+- `header_contact`
+
+## Adding new interactions
+
+1. Add section constant(s) under the right `SECTIONS.*` group (or add a new group if needed), then rely on the flattened `SECTION_IDS` for allowlisting.
+2. Add interaction constant(s) to `INTERACTION_IDS`.
+3. Use constants in component tracking calls (`trackInteraction`).
+4. Keep `sectionId` top-level and move element-specific meaning into `interactionId`.
+5. Avoid creating dynamic IDs from user/content strings unless absolutely needed.

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -29,7 +29,6 @@ export default function EventsPage() {
     { key: "event", label: "Event Type", sortable: true },
     { key: "program", label: "Program", sortable: true },
     { key: "social", label: "Social", sortable: true },
-    { key: "interaction", label: "Interaction", sortable: true },
     { key: "path", label: "Path", sortable: true },
     { key: "location", label: "Location", sortable: true },
     { key: "referrer", label: "Referrer", sortable: true },
@@ -106,10 +105,6 @@ export default function EventsPage() {
           break;
         case "social": {
           cmp = (a.social || "").localeCompare(b.social || "");
-          break;
-        }
-        case "interaction": {
-          cmp = (a.interaction || "").localeCompare(b.interaction || "");
           break;
         }
         case "path":

--- a/src/app/admin/interactions/page.tsx
+++ b/src/app/admin/interactions/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import ProtectedAdminLayout from "@/src/components/admin/ProtectedAdminLayout";
 import AnalyticsCard from "@/src/components/admin/AnalyticsCard";
 import DataTable from "@/src/components/admin/DataTable";
 import TimeFilter from "@/src/components/admin/TimeFilter";
 import { getDateRange } from "@/src/lib/analytics/analyticsUtils";
 import { InteractionEventBucketData } from "@/src/types";
+import SortableTableHead, { SortDirection, SortableColumn } from "@/src/components/ui/SortableTableHead";
+import Pagination from "@/src/components/ui/Pagination";
+import { adminChrome } from "@/src/theme/colorSchema";
 
 interface InteractionsApiResponse {
   data: {
@@ -39,6 +42,24 @@ export default function InteractionsPage() {
   const [bySection, setBySection] = useState<Array<{ key: string; value: number }>>([]);
   const [byPath, setByPath] = useState<Array<{ key: string; value: number }>>([]);
   const [byProgram, setByProgram] = useState<Array<{ key: string; value: number }>>([]);
+  const [selectedSection, setSelectedSection] = useState("all");
+  const [selectedPath, setSelectedPath] = useState("all");
+  const [selectedInteraction, setSelectedInteraction] = useState("all");
+  const [sortColumn, setSortColumn] = useState<string>("lastSeenAt");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const rowsPerPage = 25;
+
+  const tableColumns: SortableColumn[] = [
+    { key: "interactionId", label: "Interaction", sortable: true },
+    { key: "sectionId", label: "Section", sortable: true },
+    { key: "pagePath", label: "Path", sortable: true },
+    { key: "programSlug", label: "Program", sortable: true },
+    { key: "count", label: "Count", sortable: true },
+    { key: "bucketDateHour", label: "Hour Bucket", sortable: true },
+    { key: "lastSeenAt", label: "Last Seen", sortable: true }
+  ];
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -74,6 +95,47 @@ export default function InteractionsPage() {
     fetchData();
   }, [fetchData]);
 
+  const sectionOptions = useMemo(
+    () => Array.from(new Set(rows.map(r => r.sectionId).filter(Boolean))).sort(),
+    [rows]
+  );
+  const pathOptions = useMemo(
+    () => Array.from(new Set(rows.map(r => r.pagePath).filter(Boolean))).sort(),
+    [rows]
+  );
+  const interactionOptions = useMemo(
+    () => Array.from(new Set(rows.map(r => r.interactionId).filter(Boolean))).sort(),
+    [rows]
+  );
+
+  const filteredRows = useMemo(() => {
+    return rows.filter(r => {
+      if (selectedSection !== "all" && r.sectionId !== selectedSection) return false;
+      if (selectedPath !== "all" && r.pagePath !== selectedPath) return false;
+      if (selectedInteraction !== "all" && r.interactionId !== selectedInteraction) return false;
+      return true;
+    });
+  }, [rows, selectedInteraction, selectedPath, selectedSection]);
+
+  const sortedRows = useMemo(() => {
+    const list = [...filteredRows];
+    list.sort((a, b) => {
+      const av = (a as unknown as Record<string, unknown>)[sortColumn];
+      const bv = (b as unknown as Record<string, unknown>)[sortColumn];
+      let cmp = 0;
+      if (sortColumn === "count") cmp = (Number(av) || 0) - (Number(bv) || 0);
+      else if (sortColumn === "lastSeenAt") cmp = new Date(String(av || "")).getTime() - new Date(String(bv || "")).getTime();
+      else cmp = String(av || "").localeCompare(String(bv || ""));
+      return sortDirection === "asc" ? cmp : -cmp;
+    });
+    return list;
+  }, [filteredRows, sortColumn, sortDirection]);
+
+  const totalPages = Math.max(1, Math.ceil(sortedRows.length / rowsPerPage));
+  const clampedPage = Math.min(currentPage, totalPages);
+  const pageStart = (clampedPage - 1) * rowsPerPage;
+  const pagedRows = sortedRows.slice(pageStart, pageStart + rowsPerPage);
+
   return (
     <ProtectedAdminLayout title="Interactions" subtitle="Lightweight bucketed interaction tracking">
       <div className="mb-6">
@@ -95,12 +157,131 @@ export default function InteractionsPage() {
       {loading ? (
         <div className="bg-white rounded-xl border border-gray-200 p-8 text-center text-gray-500">Loading interactions...</div>
       ) : (
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-          <DataTable title="Top Interactions" data={byInteraction} maxItems={12} showPercentage />
-          <DataTable title="Top Sections" data={bySection} maxItems={12} showPercentage />
-          <DataTable title="Top Paths" data={byPath} maxItems={12} showPercentage />
-          <DataTable title="Top Programs" data={byProgram} maxItems={12} showPercentage />
-        </div>
+        <>
+          <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            <DataTable title="Top Interactions" data={byInteraction} maxItems={12} showPercentage />
+            <DataTable title="Top Sections" data={bySection} maxItems={12} showPercentage />
+            <DataTable title="Top Paths" data={byPath} maxItems={12} showPercentage />
+            <DataTable title="Top Programs" data={byProgram} maxItems={12} showPercentage />
+          </div>
+
+          <div className="mt-6 bg-white rounded-xl shadow-soft border border-gray-200 p-6">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Filter Buckets</h3>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <label className="block text-xs font-semibold text-gray-600 mb-1">Section</label>
+                <select
+                  value={selectedSection}
+                  onChange={e => {
+                    setSelectedSection(e.target.value);
+                    setCurrentPage(1);
+                  }}
+                  className="w-full rounded-lg border border-gray-300 p-2 text-sm">
+                  <option value="all">All</option>
+                  {sectionOptions.map(o => (
+                    <option key={o} value={o}>
+                      {o}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-600 mb-1">Path</label>
+                <select
+                  value={selectedPath}
+                  onChange={e => {
+                    setSelectedPath(e.target.value);
+                    setCurrentPage(1);
+                  }}
+                  className="w-full rounded-lg border border-gray-300 p-2 text-sm">
+                  <option value="all">All</option>
+                  {pathOptions.map(o => (
+                    <option key={o} value={o}>
+                      {o}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-600 mb-1">Interaction</label>
+                <select
+                  value={selectedInteraction}
+                  onChange={e => {
+                    setSelectedInteraction(e.target.value);
+                    setCurrentPage(1);
+                  }}
+                  className="w-full rounded-lg border border-gray-300 p-2 text-sm">
+                  <option value="all">All</option>
+                  {interactionOptions.map(o => (
+                    <option key={o} value={o}>
+                      {o}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="mt-3 flex gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setSelectedSection("all");
+                  setSelectedPath("all");
+                  setSelectedInteraction("all");
+                  setCurrentPage(1);
+                }}
+                className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${adminChrome.filterPillIdle}`}>
+                Reset Filters
+              </button>
+            </div>
+          </div>
+
+          <div className="mt-6 bg-white rounded-xl shadow-soft border border-gray-200">
+            <div className="p-6 border-b border-gray-200">
+              <h3 className="text-lg font-semibold text-gray-900">Interaction Buckets</h3>
+              <p className="text-sm text-gray-500 mt-1">Showing {pagedRows.length} of {sortedRows.length} filtered rows</p>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <SortableTableHead
+                  columns={tableColumns}
+                  sortColumn={sortColumn}
+                  sortDirection={sortDirection}
+                  onSort={col => {
+                    setCurrentPage(1);
+                    if (col === sortColumn) setSortDirection(prev => (prev === "asc" ? "desc" : "asc"));
+                    else {
+                      setSortColumn(col);
+                      setSortDirection("asc");
+                    }
+                  }}
+                />
+                <tbody className="bg-white divide-y divide-gray-200">
+                  {pagedRows.map(row => (
+                    <tr key={row._id} className="hover:bg-gray-50">
+                      <td className="p-4 text-sm font-mono text-gray-900">{row.interactionId}</td>
+                      <td className="p-4 text-sm text-gray-900">{row.sectionId}</td>
+                      <td className="p-4 text-sm font-mono text-gray-700">{row.pagePath}</td>
+                      <td className="p-4 text-sm text-gray-700">{row.programSlug || "-"}</td>
+                      <td className="p-4 text-sm font-semibold text-gray-900">{row.count.toLocaleString()}</td>
+                      <td className="p-4 text-xs font-mono text-gray-500">{row.bucketDateHour}</td>
+                      <td className="p-4 text-sm text-gray-500">{new Date(row.lastSeenAt).toLocaleString()}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="p-4 border-t border-gray-200">
+              <Pagination
+                currentPage={clampedPage}
+                totalPages={totalPages}
+                totalItems={sortedRows.length}
+                itemsPerPage={rowsPerPage}
+                onPageChange={setCurrentPage}
+                variant="simple"
+              />
+            </div>
+          </div>
+        </>
       )}
 
       <div className="mt-6 bg-white rounded-xl border border-gray-200 p-4 text-sm text-gray-600">

--- a/src/app/admin/interactions/page.tsx
+++ b/src/app/admin/interactions/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import ProtectedAdminLayout from "@/src/components/admin/ProtectedAdminLayout";
+import AnalyticsCard from "@/src/components/admin/AnalyticsCard";
+import DataTable from "@/src/components/admin/DataTable";
+import TimeFilter from "@/src/components/admin/TimeFilter";
+import { getDateRange } from "@/src/lib/analytics/analyticsUtils";
+import { InteractionEventBucketData } from "@/src/types";
+
+interface InteractionsApiResponse {
+  data: {
+    rows: InteractionEventBucketData[];
+    totals: {
+      totalCount: number;
+      buckets: number;
+      uniqueInteractionIds: number;
+      uniqueSections: number;
+    };
+    byInteraction: Array<{ key: string; value: number }>;
+    bySection: Array<{ key: string; value: number }>;
+    byPath: Array<{ key: string; value: number }>;
+    byProgram: Array<{ key: string; value: number }>;
+  };
+}
+
+export default function InteractionsPage() {
+  const [loading, setLoading] = useState(true);
+  const [selectedPeriod, setSelectedPeriod] = useState("30d");
+  const [customDateRange, setCustomDateRange] = useState({ start: "", end: "" });
+  const [rows, setRows] = useState<InteractionEventBucketData[]>([]);
+  const [totals, setTotals] = useState({
+    totalCount: 0,
+    buckets: 0,
+    uniqueInteractionIds: 0,
+    uniqueSections: 0
+  });
+  const [byInteraction, setByInteraction] = useState<Array<{ key: string; value: number }>>([]);
+  const [bySection, setBySection] = useState<Array<{ key: string; value: number }>>([]);
+  const [byPath, setByPath] = useState<Array<{ key: string; value: number }>>([]);
+  const [byProgram, setByProgram] = useState<Array<{ key: string; value: number }>>([]);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      if (selectedPeriod === "custom" && (!customDateRange.start || !customDateRange.end)) {
+        setRows([]);
+        setTotals({ totalCount: 0, buckets: 0, uniqueInteractionIds: 0, uniqueSections: 0 });
+        setByInteraction([]);
+        setBySection([]);
+        setByPath([]);
+        setByProgram([]);
+        return;
+      }
+      const { since, until } = getDateRange(selectedPeriod, customDateRange);
+      const res = await fetch(`/api/v1/admin/interactions?since=${encodeURIComponent(since)}&until=${encodeURIComponent(until)}`);
+      const json = (await res.json()) as InteractionsApiResponse;
+      if (!res.ok) throw new Error("Failed to fetch interactions");
+      setRows(json.data.rows || []);
+      setTotals(json.data.totals);
+      setByInteraction((json.data.byInteraction || []).map(i => ({ ...i, label: i.key })));
+      setBySection((json.data.bySection || []).map(i => ({ ...i, label: i.key })));
+      setByPath((json.data.byPath || []).map(i => ({ ...i, label: i.key })));
+      setByProgram((json.data.byProgram || []).map(i => ({ ...i, label: i.key })));
+    } catch (e) {
+      console.error("[admin interactions] fetch", e);
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [customDateRange, selectedPeriod]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return (
+    <ProtectedAdminLayout title="Interactions" subtitle="Lightweight bucketed interaction tracking">
+      <div className="mb-6">
+        <TimeFilter
+          selectedPeriod={selectedPeriod}
+          onPeriodChange={setSelectedPeriod}
+          customDateRange={customDateRange}
+          onCustomDateChange={(start, end) => setCustomDateRange({ start, end })}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        <AnalyticsCard title="Total Interactions" value={totals.totalCount} icon="🖱️" color="blue" />
+        <AnalyticsCard title="Buckets" value={totals.buckets} icon="🧱" color="purple" />
+        <AnalyticsCard title="Unique Elements" value={totals.uniqueInteractionIds} icon="🎯" color="green" />
+        <AnalyticsCard title="Unique Sections" value={totals.uniqueSections} icon="📍" color="orange" />
+      </div>
+
+      {loading ? (
+        <div className="bg-white rounded-xl border border-gray-200 p-8 text-center text-gray-500">Loading interactions...</div>
+      ) : (
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+          <DataTable title="Top Interactions" data={byInteraction} maxItems={12} showPercentage />
+          <DataTable title="Top Sections" data={bySection} maxItems={12} showPercentage />
+          <DataTable title="Top Paths" data={byPath} maxItems={12} showPercentage />
+          <DataTable title="Top Programs" data={byProgram} maxItems={12} showPercentage />
+        </div>
+      )}
+
+      <div className="mt-6 bg-white rounded-xl border border-gray-200 p-4 text-sm text-gray-600">
+        Showing {rows.length.toLocaleString()} interaction buckets in selected period.
+      </div>
+    </ProtectedAdminLayout>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -30,6 +30,13 @@ export default function AdminHomePage() {
           color="purple"
         />
         <DashboardCard
+          href="/admin/interactions"
+          title="Interactions"
+          subtitle="Track lightweight interaction buckets"
+          icon="🖱️"
+          color="blue"
+        />
+        <DashboardCard
           href="/admin/key-reports"
           title="Key Reports"
           subtitle="Manage all CD key reports (working, expired, limit reached)"

--- a/src/app/api/v1/admin/events/route.ts
+++ b/src/app/api/v1/admin/events/route.ts
@@ -6,7 +6,7 @@ import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 
 type BundledEvent = Record<string, unknown> & { _key?: string };
 
-const SORT_FIELDS = ["createdAt", "event", "programSlug", "path", "social", "interaction"] as const;
+const SORT_FIELDS = ["createdAt", "event", "programSlug", "path", "social"] as const;
 const MAX_PAGE_SIZE = 100;
 const DEFAULT_PAGE_SIZE = 20;
 
@@ -95,7 +95,7 @@ export async function GET(req: NextRequest) {
     const singularFilter =
       term !== ""
         ? `&& (
-          path == $term || programSlug == $term || social == $term || interaction == $term || referrer == $term ||
+          path == $term || programSlug == $term || social == $term || referrer == $term ||
           country == $term || city == $term || keyHash == $term || keyIdentifier == $term ||
           keyNormalized == $term || userAgent == $term || utm_source == $term ||
           utm_medium == $term || utm_campaign == $term
@@ -106,7 +106,7 @@ export async function GET(req: NextRequest) {
 
     const singular = await client.fetch<Array<Record<string, unknown> & { _id: string; _type: string }>>(
       `*[_type == "trackingEvent" ${singularFilter} ${programFilter} ${pathFilter}]{
-        _id, _type, event, programSlug, social, interaction, path, referrer, country, city,
+        _id, _type, event, programSlug, social, path, referrer, country, city,
         keyHash, keyIdentifier, keyNormalized, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt
       } | order(${sort} ${order})`,
       { term, programSlug: programSlug ?? "", path: path ?? "" }
@@ -242,7 +242,7 @@ export async function PATCH(req: NextRequest) {
     }
     if (filter.search) {
       groqFilterParts.push(
-        `(path == $term || programSlug == $term || social == $term || interaction == $term || referrer == $term || country == $term || city == $term || keyHash == $term || keyIdentifier == $term || keyNormalized == $term || userAgent == $term || utm_source == $term || utm_medium == $term || utm_campaign == $term)`
+        `(path == $term || programSlug == $term || social == $term || referrer == $term || country == $term || city == $term || keyHash == $term || keyIdentifier == $term || keyNormalized == $term || userAgent == $term || utm_source == $term || utm_medium == $term || utm_campaign == $term)`
       );
       params.term = filter.search;
     }

--- a/src/app/api/v1/admin/interactions/route.ts
+++ b/src/app/api/v1/admin/interactions/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminSession } from "@/src/lib/admin/adminAuth";
+import { client } from "@/src/sanity/lib/client";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { InteractionEventBucketData } from "@/src/types";
+
+function aggregate(rows: InteractionEventBucketData[], key: keyof InteractionEventBucketData): Array<{ key: string; value: number }> {
+  const map = new Map<string, number>();
+  for (const row of rows) {
+    const k = row[key];
+    if (!k || typeof k !== "string") continue;
+    map.set(k, (map.get(k) || 0) + row.count);
+  }
+  return Array.from(map.entries())
+    .map(([k, v]) => ({ key: k, value: v }))
+    .sort((a, b) => b.value - a.value);
+}
+
+export async function GET(req: NextRequest) {
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const admin = await requireAdminSession();
+  if (admin instanceof Response) return admin;
+
+  const sinceRaw = req.nextUrl.searchParams.get("since");
+  const untilRaw = req.nextUrl.searchParams.get("until");
+  if (!sinceRaw || !untilRaw) return Errors.validation("since and until are required ISO dates");
+  const sinceDate = new Date(sinceRaw);
+  const untilDate = new Date(untilRaw);
+  if (isNaN(sinceDate.getTime()) || isNaN(untilDate.getTime())) {
+    return Errors.validation("since and until must be valid ISO dates");
+  }
+  const since = sinceDate.toISOString();
+  const until = untilDate.toISOString();
+
+  try {
+    const rows = await client.fetch<InteractionEventBucketData[]>(
+      `*[_type=="interactionEventBucket" && lastSeenAt >= $since && lastSeenAt <= $until]{
+        _id, bucketKey, bucketDateHour, pagePath, sectionId, interactionId, programSlug, count, lastSeenAt, createdAt
+      } | order(lastSeenAt desc)`,
+      { since, until }
+    );
+
+    const totalCount = rows.reduce((sum, r) => sum + (r.count || 0), 0);
+    const byInteraction = aggregate(rows, "interactionId");
+    const bySection = aggregate(rows, "sectionId");
+    const byPath = aggregate(rows, "pagePath");
+    const byProgram = aggregate(rows, "programSlug");
+
+    return NextResponse.json({
+      data: {
+        rows,
+        totals: {
+          totalCount,
+          buckets: rows.length,
+          uniqueInteractionIds: byInteraction.length,
+          uniqueSections: bySection.length
+        },
+        byInteraction,
+        bySection,
+        byPath,
+        byProgram
+      },
+      meta: { since, until }
+    });
+  } catch (err) {
+    console.error("[GET /api/v1/admin/interactions]", err);
+    return Errors.internal();
+  }
+}

--- a/src/app/api/v1/analytics/track/route.ts
+++ b/src/app/api/v1/analytics/track/route.ts
@@ -5,6 +5,8 @@ import { TrackRequestBody } from "@/src/types";
 import { getKeyData } from "@/src/lib/keyHashing";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { normalizePath } from "@/src/lib/api/inputNormalize";
+import { isRecentDuplicateRequest } from "@/src/lib/api/shortRequestDedupe";
 import { getClientIp, hashIp, getLocationFromIP } from "@/src/lib/api/requestGeo";
 import { upsertVisitorOnPageView } from "@/src/lib/visitors/upsertVisitorOnPageView";
 import { isProgramSlugPublished } from "@/src/lib/sanity/programSlugExists";
@@ -16,6 +18,8 @@ const ANALYTICS_EVENTS = new Set([
   "page_viewed"
 ]);
 const REPORT_EVENTS = new Set(["report_key_working", "report_key_expired", "report_key_limit_reached"]);
+
+const SHORT_DEDUPE_ANALYTICS_EVENTS = new Set<string>(["copy_cdkey", "download_click", "social_click"]);
 
 export async function POST(req: NextRequest) {
   const { ok: rateOk } = rateLimitMiddleware(req);
@@ -32,9 +36,30 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ data: { accepted: true, skipped: true }, meta: {} });
     }
 
+    const ip = getClientIp(req);
+    const ipHashEarly = hashIp(ip) ?? "unknown";
+
+    if (SHORT_DEDUPE_ANALYTICS_EVENTS.has(body.event)) {
+      const pathNorm = normalizePath(typeof body.meta?.path === "string" ? body.meta.path : "/");
+      const slugPart =
+        typeof body.meta?.programSlug === "string" && body.meta.programSlug.trim()
+          ? body.meta.programSlug.trim()
+          : "-";
+      const socialPart =
+        typeof body.meta?.social === "string" && body.meta.social.trim() ? body.meta.social.trim() : "-";
+      let keyPart = "-";
+      if (body.event === "copy_cdkey" && body.meta?.key) {
+        const kd = getKeyData(body.meta.key);
+        if (kd?.hash) keyPart = kd.hash;
+      }
+      const dedupeKey = `analytics|${body.event}|${ipHashEarly}|${pathNorm}|${slugPart}|${socialPart}|${keyPart}`;
+      if (isRecentDuplicateRequest(dedupeKey)) {
+        return NextResponse.json({ data: { accepted: true, deduped: true }, meta: {} });
+      }
+    }
+
     const ua = req.headers.get("user-agent") || undefined;
     const ref = req.headers.get("referer") || undefined;
-    const ip = getClientIp(req);
 
     let programSlug = body.meta?.programSlug as string | undefined;
     const keyData = body.meta?.key ? getKeyData(body.meta.key) : undefined;
@@ -53,7 +78,7 @@ export async function POST(req: NextRequest) {
       if (!ok) programSlug = undefined;
     }
 
-    const ipHash = hashIp(ip);
+    const ipHash = ipHashEarly;
     const visitor = ipHash
       ? await client.fetch<{ _id?: string; isSpammer?: boolean; country?: string; city?: string } | null>(
           `*[_type == "visitor" && visitorHash == $h][0]{ _id, isSpammer, country, city }`,

--- a/src/app/api/v1/analytics/track/route.ts
+++ b/src/app/api/v1/analytics/track/route.ts
@@ -7,15 +7,13 @@ import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 import { getClientIp, hashIp, getLocationFromIP } from "@/src/lib/api/requestGeo";
 import { upsertVisitorOnPageView } from "@/src/lib/visitors/upsertVisitorOnPageView";
-import { isVisitorSpammerByHash } from "@/src/lib/visitors/isVisitorSpammerByHash";
 import { isProgramSlugPublished } from "@/src/lib/sanity/programSlugExists";
 
 const ANALYTICS_EVENTS = new Set([
   "copy_cdkey",
   "download_click",
   "social_click",
-  "page_viewed",
-  "interaction"
+  "page_viewed"
 ]);
 const REPORT_EVENTS = new Set(["report_key_working", "report_key_expired", "report_key_limit_reached"]);
 
@@ -29,11 +27,6 @@ export async function POST(req: NextRequest) {
       return Errors.validation("Invalid event");
     }
 
-    if (body.event === "interaction") {
-      const id = typeof body.meta?.interaction === "string" ? body.meta.interaction.trim() : "";
-      if (!id) return Errors.validation("interaction id required in meta.interaction");
-    }
-
     const host = req.headers.get("host") || "";
     if (host.startsWith("localhost") || host.includes("127.0.0.1")) {
       return NextResponse.json({ data: { accepted: true, skipped: true }, meta: {} });
@@ -42,12 +35,10 @@ export async function POST(req: NextRequest) {
     const ua = req.headers.get("user-agent") || undefined;
     const ref = req.headers.get("referer") || undefined;
     const ip = getClientIp(req);
-    const location = await getLocationFromIP(ip, "KeyAway Analytics");
 
     let programSlug = body.meta?.programSlug as string | undefined;
-    const keyData = getKeyData(body.meta?.key);
+    const keyData = body.meta?.key ? getKeyData(body.meta.key) : undefined;
     const social = body.meta?.social as string | undefined;
-    const interaction = body.meta?.interaction as string | undefined;
     const path = body.meta?.path as string | undefined;
     const referrer = body.meta?.referrer as string | undefined;
     const utmSource = body.meta?.utm_source as string | undefined;
@@ -57,15 +48,39 @@ export async function POST(req: NextRequest) {
     const isReportEvent = REPORT_EVENTS.has(body.event);
     const slugWasProvided = Boolean(programSlug?.trim());
 
-    if (!isReportEvent && programSlug) {
+    if (body.event === "page_viewed" && programSlug) {
       const ok = await isProgramSlugPublished(programSlug);
       if (!ok) programSlug = undefined;
     }
 
     const ipHash = hashIp(ip);
+    const visitor = ipHash
+      ? await client.fetch<{ _id?: string; isSpammer?: boolean; country?: string; city?: string } | null>(
+          `*[_type == "visitor" && visitorHash == $h][0]{ _id, isSpammer, country, city }`,
+          { h: ipHash }
+        )
+      : null;
+
+    let location: { country?: string; city?: string } | undefined =
+      visitor?.country || visitor?.city ? { country: visitor.country, city: visitor.city } : undefined;
+
+    if (!location) {
+      location = await getLocationFromIP(ip, "KeyAway Analytics");
+      if (visitor?._id && (location?.country || location?.city)) {
+        await client
+          .patch(visitor._id)
+          .set({
+            ...(location.country ? { country: location.country } : {}),
+            ...(location.city ? { city: location.city } : {}),
+            geoUpdatedAt: new Date().toISOString()
+          })
+          .commit();
+      }
+    }
+
     if (
       isReportEvent &&
-      (await isVisitorSpammerByHash(ipHash)) &&
+      visitor?.isSpammer === true &&
       body.event !== "report_key_working"
     ) {
       return NextResponse.json({ data: { accepted: true, skipped: true }, meta: {} });
@@ -95,7 +110,6 @@ export async function POST(req: NextRequest) {
       eventData.keyNormalized = keyData.normalized;
     }
     if (social) eventData.social = social;
-    if (interaction?.trim()) eventData.interaction = interaction.trim();
     if (path) eventData.path = path;
     if (referrer) eventData.referrer = referrer;
     if (utmSource) eventData.utm_source = utmSource;
@@ -108,7 +122,7 @@ export async function POST(req: NextRequest) {
 
     if (body.event === "page_viewed") {
       try {
-        await upsertVisitorOnPageView(ipHash);
+        await upsertVisitorOnPageView(ipHash, location);
       } catch (e) {
         console.error("[track] visitor upsert", e);
       }

--- a/src/app/api/v1/interactions/track/route.ts
+++ b/src/app/api/v1/interactions/track/route.ts
@@ -3,6 +3,7 @@ import { client } from "@/src/sanity/lib/client";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 import { normalizePath, sanitizeTrackingToken } from "@/src/lib/api/inputNormalize";
+import { ALLOWED_INTERACTION_IDS, ALLOWED_SECTION_IDS } from "@/src/lib/analytics/interactionCatalog";
 import { TrackInteractionBody } from "@/src/types";
 
 function hourBucket(date = new Date()): string {
@@ -31,6 +32,12 @@ export async function POST(req: NextRequest) {
     if (!interactionId) return Errors.validation("interactionId required");
     if (!sectionId) return Errors.validation("sectionId required");
     if (interactionId.length > 120 || sectionId.length > 80) return Errors.validation("interaction payload too long");
+    if (!ALLOWED_INTERACTION_IDS.has(interactionId as never)) {
+      return Errors.validation("unknown interactionId");
+    }
+    if (!ALLOWED_SECTION_IDS.has(sectionId as never)) {
+      return Errors.validation("unknown sectionId");
+    }
 
     const host = req.headers.get("host") || "";
     if (host.startsWith("localhost") || host.includes("127.0.0.1")) {

--- a/src/app/api/v1/interactions/track/route.ts
+++ b/src/app/api/v1/interactions/track/route.ts
@@ -4,6 +4,8 @@ import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 import { normalizePath, sanitizeTrackingToken } from "@/src/lib/api/inputNormalize";
 import { ALLOWED_INTERACTION_IDS, ALLOWED_SECTION_IDS } from "@/src/lib/analytics/interactionCatalog";
+import { isRecentDuplicateRequest } from "@/src/lib/api/shortRequestDedupe";
+import { getClientIp, hashIp } from "@/src/lib/api/requestGeo";
 import { TrackInteractionBody } from "@/src/types";
 
 function hourBucket(date = new Date()): string {
@@ -42,6 +44,12 @@ export async function POST(req: NextRequest) {
     const host = req.headers.get("host") || "";
     if (host.startsWith("localhost") || host.includes("127.0.0.1")) {
       return NextResponse.json({ data: { accepted: true, skipped: true }, meta: {} });
+    }
+
+    const ipHash = hashIp(getClientIp(req)) ?? "unknown";
+    const dedupeKey = `interaction|${ipHash}|${interactionId}|${pagePath}|${programSlug ?? "-"}`;
+    if (isRecentDuplicateRequest(dedupeKey)) {
+      return NextResponse.json({ data: { accepted: true, deduped: true }, meta: {} });
     }
 
     const bucketDateHour = hourBucket();

--- a/src/app/api/v1/interactions/track/route.ts
+++ b/src/app/api/v1/interactions/track/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { client } from "@/src/sanity/lib/client";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { normalizePath, sanitizeTrackingToken } from "@/src/lib/api/inputNormalize";
+import { TrackInteractionBody } from "@/src/types";
+
+function hourBucket(date = new Date()): string {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
+  const h = String(date.getUTCHours()).padStart(2, "0");
+  return `${y}-${m}-${d}-${h}`;
+}
+
+function buildBucketDocId(key: string): string {
+  return `interactionEventBucket.${key.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 220)}`;
+}
+
+export async function POST(req: NextRequest) {
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  try {
+    const body = (await req.json()) as TrackInteractionBody;
+    const interactionId = typeof body?.interactionId === "string" ? sanitizeTrackingToken(body.interactionId) : "";
+    const sectionId = typeof body?.sectionId === "string" ? sanitizeTrackingToken(body.sectionId) : "";
+    const pagePath = normalizePath(typeof body?.pagePath === "string" ? body.pagePath : "/");
+    const programSlug = typeof body?.programSlug === "string" ? sanitizeTrackingToken(body.programSlug) : undefined;
+
+    if (!interactionId) return Errors.validation("interactionId required");
+    if (!sectionId) return Errors.validation("sectionId required");
+    if (interactionId.length > 120 || sectionId.length > 80) return Errors.validation("interaction payload too long");
+
+    const host = req.headers.get("host") || "";
+    if (host.startsWith("localhost") || host.includes("127.0.0.1")) {
+      return NextResponse.json({ data: { accepted: true, skipped: true }, meta: {} });
+    }
+
+    const bucketDateHour = hourBucket();
+    const bucketKey = `${bucketDateHour}|${pagePath}|${sectionId}|${interactionId}|${programSlug || "-"}`;
+    const docId = buildBucketDocId(bucketKey);
+    const now = new Date().toISOString();
+
+    await client
+      .transaction()
+      .createIfNotExists({
+        _id: docId,
+        _type: "interactionEventBucket",
+        bucketKey,
+        bucketDateHour,
+        pagePath,
+        sectionId,
+        interactionId,
+        ...(programSlug ? { programSlug } : {}),
+        count: 0,
+        createdAt: now,
+        lastSeenAt: now
+      })
+      .patch(docId, p => p.inc({ count: 1 }).set({ lastSeenAt: now }))
+      .commit();
+
+    return NextResponse.json({ data: { accepted: true }, meta: {} });
+  } catch (err) {
+    console.error("[POST /api/v1/interactions/track]", err);
+    return Errors.internal();
+  }
+}

--- a/src/components/admin/RecentActivity.tsx
+++ b/src/components/admin/RecentActivity.tsx
@@ -60,11 +60,6 @@ export default function RecentActivity({
                         {event.social && (
                           <span className="text-xs text-gray-500 bg-blue-100 px-2 py-1 rounded">{event.social}</span>
                         )}
-                        {event.interaction && (
-                          <span className="text-xs text-cyan-900 bg-cyan-100 px-2 py-1 rounded font-mono">
-                            {event.interaction}
-                          </span>
-                        )}
                       </div>
                       <div className="flex items-center space-x-2 mt-1">
                         {event.country && (

--- a/src/components/admin/events/EventsTable.tsx
+++ b/src/components/admin/events/EventsTable.tsx
@@ -106,13 +106,6 @@ export default function EventsTable({
                     )}
                   </td>
                   <td className="max-w-3xs p-4 text-sm text-gray-900">
-                    {event.interaction ? (
-                      <span className="font-mono text-xs text-cyan-800">{event.interaction}</span>
-                    ) : (
-                      <span className="text-gray-400">-</span>
-                    )}
-                  </td>
-                  <td className="max-w-3xs p-4 text-sm text-gray-900">
                     <span className="font-mono text-xs">{event.path || "/"}</span>
                   </td>
                   <td className="max-w-44 p-4 text-sm text-gray-900">

--- a/src/components/admin/layout/AdminHeader.tsx
+++ b/src/components/admin/layout/AdminHeader.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { HiChartBar, HiViewGrid } from "react-icons/hi";
-import { MdRateReview, MdEventNote } from "react-icons/md";
+import { MdRateReview, MdEventNote, MdTouchApp } from "react-icons/md";
 import { FaKey, FaEnvelopeOpenText } from "react-icons/fa";
 import { useKeyReportAlerts, KeyReportAlertsDesktop, KeyReportAlertsMobile } from "./KeyReportAlerts";
 
@@ -28,6 +28,7 @@ export default function AdminHeader() {
 
   const navLinks: Array<{ href: string; label: string; icon: typeof FaKey; countKey?: "suggestions" | "messages" }> = [
     { href: "/admin/analytics", label: "Analytics", icon: HiChartBar },
+    { href: "/admin/interactions", label: "Interactions", icon: MdTouchApp },
     { href: "/admin/programs", label: "Programs", icon: HiViewGrid },
     { href: "/admin/events", label: "Events", icon: MdEventNote },
     { href: "/admin/key-reports", label: "Key Reports", icon: MdRateReview },

--- a/src/components/contact/ContactModalTrigger.tsx
+++ b/src/components/contact/ContactModalTrigger.tsx
@@ -2,14 +2,15 @@
 
 import { ReactNode } from "react";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
+import { InteractionId, SectionId } from "@/src/lib/analytics/interactionCatalog";
 
 interface ContactModalTriggerProps {
   tab: "contact" | "suggest";
   children: ReactNode;
   className?: string;
   asChild?: boolean;
-  interactionId?: string;
-  sectionId?: string;
+  interactionId?: InteractionId;
+  sectionId?: SectionId;
   pagePath?: string;
   programSlug?: string;
 }

--- a/src/components/contact/ContactModalTrigger.tsx
+++ b/src/components/contact/ContactModalTrigger.tsx
@@ -1,16 +1,33 @@
 "use client";
 
 import { ReactNode } from "react";
+import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 
 interface ContactModalTriggerProps {
   tab: "contact" | "suggest";
   children: ReactNode;
   className?: string;
   asChild?: boolean;
+  interactionId?: string;
+  sectionId?: string;
+  pagePath?: string;
+  programSlug?: string;
 }
 
-export default function ContactModalTrigger({ tab, children, className, asChild }: ContactModalTriggerProps) {
+export default function ContactModalTrigger({
+  tab,
+  children,
+  className,
+  asChild,
+  interactionId,
+  sectionId,
+  pagePath,
+  programSlug
+}: ContactModalTriggerProps) {
   const handleClick = () => {
+    if (interactionId && sectionId) {
+      void trackInteraction({ interactionId, sectionId, pagePath, programSlug });
+    }
     const event = new CustomEvent("openContactModal", { detail: { tab } });
     window.dispatchEvent(event);
   };

--- a/src/components/home/CTASection.tsx
+++ b/src/components/home/CTASection.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { FaGithub, FaHeart, FaCarrot, FaKey, FaArrowRight } from "react-icons/fa";
 import { trackEvent } from "@/src/lib/analytics/trackEvent";
 import { ContactModalTrigger } from "@/src/components/contact";
+import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 
 const supportOptions = [
   {
@@ -66,6 +67,12 @@ export default function CTASection() {
             <div className="flex flex-col xs:flex-row gap-3 sm:gap-4 justify-center">
               <Link
                 href="/programs"
+                onClick={() =>
+                  void trackInteraction({
+                    interactionId: "cta_browse_all_programs",
+                    sectionId: "cta"
+                  })
+                }
                 className="inline-flex items-center justify-center px-6 py-3 sm:px-8 sm:py-4 bg-primary-600 hover:bg-primary-700 text-white font-semibold rounded-lg transition-colors text-sm sm:text-base">
                 Browse All Programs
                 <FaArrowRight className="ml-2 text-sm" />
@@ -146,6 +153,8 @@ export default function CTASection() {
               <div className="mt-8 text-center">
                 <ContactModalTrigger
                   tab="suggest"
+                  interactionId="cta_suggest_cd_key"
+                  sectionId="cta"
                   className="inline-flex items-center justify-center px-6 py-3 bg-primary-600 hover:bg-primary-700 text-white font-semibold rounded-lg transition-colors">
                   <FaKey className="mr-2" />
                   Suggest a CD Key Now

--- a/src/components/home/CTASection.tsx
+++ b/src/components/home/CTASection.tsx
@@ -5,6 +5,7 @@ import { FaGithub, FaHeart, FaCarrot, FaKey, FaArrowRight } from "react-icons/fa
 import { trackEvent } from "@/src/lib/analytics/trackEvent";
 import { ContactModalTrigger } from "@/src/components/contact";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
+import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
 
 const supportOptions = [
   {
@@ -69,8 +70,8 @@ export default function CTASection() {
                 href="/programs"
                 onClick={() =>
                   void trackInteraction({
-                    interactionId: "cta_browse_all_programs",
-                    sectionId: "cta"
+                    interactionId: INTERACTION_IDS.ctaBrowseAllPrograms,
+                    sectionId: SECTIONS.home.cta
                   })
                 }
                 className="inline-flex items-center justify-center px-6 py-3 sm:px-8 sm:py-4 bg-primary-600 hover:bg-primary-700 text-white font-semibold rounded-lg transition-colors text-sm sm:text-base">
@@ -153,8 +154,8 @@ export default function CTASection() {
               <div className="mt-8 text-center">
                 <ContactModalTrigger
                   tab="suggest"
-                  interactionId="cta_suggest_cd_key"
-                  sectionId="cta"
+                  interactionId={INTERACTION_IDS.ctaSuggestCdKey}
+                  sectionId={SECTIONS.home.cta}
                   className="inline-flex items-center justify-center px-6 py-3 bg-primary-600 hover:bg-primary-700 text-white font-semibold rounded-lg transition-colors">
                   <FaKey className="mr-2" />
                   Suggest a CD Key Now

--- a/src/components/home/FeaturedProgramSection.tsx
+++ b/src/components/home/FeaturedProgramSection.tsx
@@ -5,6 +5,7 @@ import { FaStar, FaCheckCircle, FaDownload } from "react-icons/fa";
 import { IdealImage } from "@/src/components/general/IdealImage";
 import { trackEvent } from "@/src/lib/analytics/trackEvent";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
+import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
 
 interface FeaturedProgramSectionProps {
   program: {
@@ -114,8 +115,8 @@ export default function FeaturedProgramSection({ program }: FeaturedProgramSecti
                     href={`/program/${program.slug.current}`}
                     onClick={() =>
                       void trackInteraction({
-                        interactionId: "featured_program_view_keys",
-                        sectionId: "featured_program",
+                        interactionId: INTERACTION_IDS.featuredProgramViewKeys,
+                        sectionId: SECTIONS.home.featuredProgram,
                         programSlug: program.slug.current
                       })
                     }

--- a/src/components/home/FeaturedProgramSection.tsx
+++ b/src/components/home/FeaturedProgramSection.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { FaStar, FaCheckCircle, FaDownload } from "react-icons/fa";
 import { IdealImage } from "@/src/components/general/IdealImage";
+import { trackEvent } from "@/src/lib/analytics/trackEvent";
+import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 
 interface FeaturedProgramSectionProps {
   program: {
@@ -110,6 +112,13 @@ export default function FeaturedProgramSection({ program }: FeaturedProgramSecti
                 <div className="flex flex-col sm:flex-row gap-3">
                   <Link
                     href={`/program/${program.slug.current}`}
+                    onClick={() =>
+                      void trackInteraction({
+                        interactionId: "featured_program_view_keys",
+                        sectionId: "featured_program",
+                        programSlug: program.slug.current
+                      })
+                    }
                     className="inline-flex items-center justify-center bg-linear-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 text-white font-semibold px-5 py-2.5 sm:px-6 sm:py-3 rounded-lg transition-all duration-300 transform hover:scale-[1.02] hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-gray-800 shadow-lg text-sm sm:text-base">
                     View All {program.workingKeys} Working Keys
                   </Link>
@@ -118,6 +127,12 @@ export default function FeaturedProgramSection({ program }: FeaturedProgramSecti
                       href={program.downloadLink}
                       target="_blank"
                       rel="noreferrer"
+                      onClick={() =>
+                        trackEvent("download_click", {
+                          programSlug: program.slug.current,
+                          path: window.location.pathname
+                        })
+                      }
                       className="inline-flex items-center justify-center bg-white/10 hover:bg-white/20 text-white font-semibold px-5 py-2.5 sm:px-6 sm:py-3 rounded-lg border border-white/20 transition-all duration-300 transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-white/50 focus:ring-offset-2 focus:ring-offset-gray-800 text-sm sm:text-base">
                       <FaDownload className="mr-2" />
                       Download Program

--- a/src/components/home/FeaturesSection.tsx
+++ b/src/components/home/FeaturesSection.tsx
@@ -2,6 +2,7 @@
 
 import { FaUsers, FaChartLine, FaShieldAlt, FaClock, FaCheckCircle, FaExclamationTriangle } from "react-icons/fa";
 import { ContactModalTrigger } from "@/src/components/contact";
+import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
 
 export default function FeaturesSection() {
   const features = [
@@ -172,8 +173,8 @@ export default function FeaturesSection() {
               </p>
               <ContactModalTrigger
                 tab="suggest"
-                interactionId="features_suggest_cd_key"
-                sectionId="features"
+                interactionId={INTERACTION_IDS.featuresSuggestCdKey}
+                sectionId={SECTIONS.home.features}
                 className="inline-flex items-center justify-center px-5 py-2.5 sm:px-6 sm:py-3 bg-primary-600 hover:bg-primary-700 text-white font-semibold rounded-lg transition-colors shadow-lg hover:shadow-xl text-sm sm:text-base">
                 <FaCheckCircle className="mr-2 text-sm sm:text-base" />
                 Suggest a CD Key

--- a/src/components/home/FeaturesSection.tsx
+++ b/src/components/home/FeaturesSection.tsx
@@ -172,6 +172,8 @@ export default function FeaturesSection() {
               </p>
               <ContactModalTrigger
                 tab="suggest"
+                interactionId="features_suggest_cd_key"
+                sectionId="features"
                 className="inline-flex items-center justify-center px-5 py-2.5 sm:px-6 sm:py-3 bg-primary-600 hover:bg-primary-700 text-white font-semibold rounded-lg transition-colors shadow-lg hover:shadow-xl text-sm sm:text-base">
                 <FaCheckCircle className="mr-2 text-sm sm:text-base" />
                 Suggest a CD Key

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -8,6 +8,7 @@ import { SocialData } from "@/src/types";
 import VisitorTierHint from "@/src/components/visitors/VisitorTierHint";
 import type { VisitorHintData } from "@/src/lib/visitors/publicVisitorContext";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
+import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
 
 interface HeroSectionProps {
   socialData?: SocialData;
@@ -69,8 +70,8 @@ export default function HeroSection({ socialData, visitorHint }: HeroSectionProp
             <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 pt-2">
               <ContactModalTrigger
                 tab="suggest"
-                interactionId="hero_suggest_cd_key"
-                sectionId="hero"
+                interactionId={INTERACTION_IDS.heroSuggestCdKey}
+                sectionId={SECTIONS.home.hero}
                 className="inline-flex items-center justify-center px-6 py-3 sm:px-6 bg-linear-to-r from-accent-500 to-accent-600 hover:from-accent-600 hover:to-accent-700 text-white font-bold rounded-xl transition-all duration-200 transform hover:scale-[1.03] shadow-2xl text-sm sm:text-base cursor-pointer ring-2 ring-accent-400/50 hover:ring-accent-400/70">
                 <FaKey className="mr-2 sm:mr-3 text-base sm:text-lg" />
                 <span className="whitespace-nowrap">Suggest a CD Key</span>
@@ -78,7 +79,10 @@ export default function HeroSection({ socialData, visitorHint }: HeroSectionProp
 
               <button
                 onClick={() => {
-                  void trackInteraction({ interactionId: "hero_how_it_works", sectionId: "hero" });
+                  void trackInteraction({
+                    interactionId: INTERACTION_IDS.heroHowItWorks,
+                    sectionId: SECTIONS.home.hero
+                  });
                   document.querySelector("#how-it-works")?.scrollIntoView({ behavior: "smooth" });
                 }}
                 className="inline-flex items-center justify-center px-4 py-3 sm:px-6 border-2 border-gray-600 hover:border-gray-500 text-white font-semibold rounded-lg transition-colors text-sm sm:text-base cursor-pointer">

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -7,6 +7,7 @@ import HeroLaptopImage from "./HeroLaptopImage";
 import { SocialData } from "@/src/types";
 import VisitorTierHint from "@/src/components/visitors/VisitorTierHint";
 import type { VisitorHintData } from "@/src/lib/visitors/publicVisitorContext";
+import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 
 interface HeroSectionProps {
   socialData?: SocialData;
@@ -68,6 +69,8 @@ export default function HeroSection({ socialData, visitorHint }: HeroSectionProp
             <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 pt-2">
               <ContactModalTrigger
                 tab="suggest"
+                interactionId="hero_suggest_cd_key"
+                sectionId="hero"
                 className="inline-flex items-center justify-center px-6 py-3 sm:px-6 bg-linear-to-r from-accent-500 to-accent-600 hover:from-accent-600 hover:to-accent-700 text-white font-bold rounded-xl transition-all duration-200 transform hover:scale-[1.03] shadow-2xl text-sm sm:text-base cursor-pointer ring-2 ring-accent-400/50 hover:ring-accent-400/70">
                 <FaKey className="mr-2 sm:mr-3 text-base sm:text-lg" />
                 <span className="whitespace-nowrap">Suggest a CD Key</span>
@@ -75,6 +78,7 @@ export default function HeroSection({ socialData, visitorHint }: HeroSectionProp
 
               <button
                 onClick={() => {
+                  void trackInteraction({ interactionId: "hero_how_it_works", sectionId: "hero" });
                   document.querySelector("#how-it-works")?.scrollIntoView({ behavior: "smooth" });
                 }}
                 className="inline-flex items-center justify-center px-4 py-3 sm:px-6 border-2 border-gray-600 hover:border-gray-500 text-white font-semibold rounded-lg transition-colors text-sm sm:text-base cursor-pointer">

--- a/src/components/home/ProgramCard.tsx
+++ b/src/components/home/ProgramCard.tsx
@@ -2,12 +2,23 @@ import Link from "next/link";
 import { IdealImage } from "@/src/components/general/IdealImage";
 import { FaEye, FaDownload, FaKey, FaChevronRight } from "react-icons/fa";
 import { ProgramCardProps } from "@/src/types/home";
+import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 
-export default function ProgramCard({ program, stats, badges, showStats = true }: ProgramCardProps) {
+export default function ProgramCard({ program, stats, badges, showStats = true, sectionId = "popular_programs" }: ProgramCardProps) {
   return (
     <div className="group bg-white rounded-xl sm:rounded-2xl shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden border-2 border-gray-200 hover:border-primary-400 animate-fade-in flex flex-col transform hover:-translate-y-2 relative before:absolute before:inset-0 before:bg-linear-to-br before:from-primary-50/30 before:to-transparent before:opacity-0 before:group-hover:opacity-100 before:transition-opacity before:duration-300">
       {/* Image Container */}
-      <Link href={`/program/${program.slug.current}`} title={program.title} className="relative overflow-hidden">
+      <Link
+        href={`/program/${program.slug.current}`}
+        title={program.title}
+        className="relative overflow-hidden"
+        onClick={() =>
+          void trackInteraction({
+            interactionId: "program_grid_view_keys_image",
+            sectionId,
+            programSlug: program.slug.current
+          })
+        }>
         {program.image ? (
           <IdealImage
             image={program.image}
@@ -85,6 +96,13 @@ export default function ProgramCard({ program, stats, badges, showStats = true }
         {/* Action Button */}
         <Link
           href={`/program/${program.slug.current}`}
+          onClick={() =>
+            void trackInteraction({
+              interactionId: "program_grid_view_keys_button",
+              sectionId,
+              programSlug: program.slug.current
+            })
+          }
           className="inline-flex items-center justify-center w-full bg-linear-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 text-white font-semibold px-4 sm:px-5 lg:px-6 py-2.5 sm:py-3 text-sm sm:text-base rounded-lg sm:rounded-xl transition-all duration-200 transform hover:scale-[1.02] hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 mt-auto relative overflow-hidden">
           <span className="relative z-10">View Keys</span>
           <FaChevronRight className="ml-1.5 sm:ml-2 w-3 h-3 sm:w-3.5 sm:h-3.5 transition-transform group-hover:translate-x-1 relative z-10" />

--- a/src/components/home/ProgramCard.tsx
+++ b/src/components/home/ProgramCard.tsx
@@ -3,8 +3,15 @@ import { IdealImage } from "@/src/components/general/IdealImage";
 import { FaEye, FaDownload, FaKey, FaChevronRight } from "react-icons/fa";
 import { ProgramCardProps } from "@/src/types/home";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
+import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
 
-export default function ProgramCard({ program, stats, badges, showStats = true, sectionId = "popular_programs" }: ProgramCardProps) {
+export default function ProgramCard({
+  program,
+  stats,
+  badges,
+  showStats = true,
+  sectionId = SECTIONS.home.popularPrograms
+}: ProgramCardProps) {
   return (
     <div className="group bg-white rounded-xl sm:rounded-2xl shadow-xl hover:shadow-2xl transition-all duration-300 overflow-hidden border-2 border-gray-200 hover:border-primary-400 animate-fade-in flex flex-col transform hover:-translate-y-2 relative before:absolute before:inset-0 before:bg-linear-to-br before:from-primary-50/30 before:to-transparent before:opacity-0 before:group-hover:opacity-100 before:transition-opacity before:duration-300">
       {/* Image Container */}
@@ -14,7 +21,7 @@ export default function ProgramCard({ program, stats, badges, showStats = true, 
         className="relative overflow-hidden"
         onClick={() =>
           void trackInteraction({
-            interactionId: "program_grid_view_keys_image",
+              interactionId: INTERACTION_IDS.programGridViewKeysImage,
             sectionId,
             programSlug: program.slug.current
           })
@@ -98,7 +105,7 @@ export default function ProgramCard({ program, stats, badges, showStats = true, 
           href={`/program/${program.slug.current}`}
           onClick={() =>
             void trackInteraction({
-              interactionId: "program_grid_view_keys_button",
+              interactionId: INTERACTION_IDS.programGridViewKeysButton,
               sectionId,
               programSlug: program.slug.current
             })

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,6 +13,7 @@ import { StoreDetails, SanityLink, LogoData, SocialData } from "@/src/types";
 import { Notification } from "@/src/types/notifications";
 import { usePathname } from "next/navigation";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
+import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
 
 interface HeaderProps {
   storeData: StoreDetails;
@@ -22,7 +23,6 @@ interface HeaderProps {
 }
 
 export default function Header({ storeData, logoData, notifications, socialData }: HeaderProps) {
-  const toInteractionToken = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
   const pathname = usePathname();
   const header = storeData?.header;
   let isLogo = false;
@@ -86,8 +86,8 @@ export default function Header({ storeData, logoData, notifications, socialData 
                     href={href || "/"}
                     onClick={() =>
                       void trackInteraction({
-                        interactionId: `header_nav_${toInteractionToken(link.title || "link")}`,
-                        sectionId: "header"
+                        interactionId: INTERACTION_IDS.headerNavLink,
+                        sectionId: SECTIONS.global.header
                       })
                     }
                     className={`hover:text-primary-500 transition-colors ${isActive ? "text-white font-medium" : "text-gray-300"}`}
@@ -102,8 +102,8 @@ export default function Header({ storeData, logoData, notifications, socialData 
           {/* Contact Button */}
           <ContactModalTrigger
             tab="contact"
-            interactionId="header_contact"
-            sectionId="header"
+            interactionId={INTERACTION_IDS.headerContact}
+            sectionId={SECTIONS.global.header}
             className="flex items-center gap-2 px-3 py-2 text-gray-300 hover:text-primary-500 transition-colors cursor-pointer"
             aria-label="Contact us">
             <FaEnvelope className="w-4 h-4" />
@@ -121,8 +121,8 @@ export default function Header({ storeData, logoData, notifications, socialData 
         <div className="md:hidden flex items-center gap-2">
           <ContactModalTrigger
             tab="contact"
-            interactionId="header_contact_mobile"
-            sectionId="header"
+            interactionId={INTERACTION_IDS.headerContactMobile}
+            sectionId={SECTIONS.global.header}
             className="p-2 text-gray-300 hover:text-primary-500 transition-colors cursor-pointer"
             aria-label="Contact us">
             <FaEnvelope className="w-5 h-5" />

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -12,6 +12,7 @@ import { IdealImageClient } from "@/src/components/general/IdealImageClient";
 import { StoreDetails, SanityLink, LogoData, SocialData } from "@/src/types";
 import { Notification } from "@/src/types/notifications";
 import { usePathname } from "next/navigation";
+import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 
 interface HeaderProps {
   storeData: StoreDetails;
@@ -21,6 +22,7 @@ interface HeaderProps {
 }
 
 export default function Header({ storeData, logoData, notifications, socialData }: HeaderProps) {
+  const toInteractionToken = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
   const pathname = usePathname();
   const header = storeData?.header;
   let isLogo = false;
@@ -82,6 +84,12 @@ export default function Header({ storeData, logoData, notifications, socialData 
                   <Link
                     key={i}
                     href={href || "/"}
+                    onClick={() =>
+                      void trackInteraction({
+                        interactionId: `header_nav_${toInteractionToken(link.title || "link")}`,
+                        sectionId: "header"
+                      })
+                    }
                     className={`hover:text-primary-500 transition-colors ${isActive ? "text-white font-medium" : "text-gray-300"}`}
                     target={link.external ? "_blank" : undefined}
                     rel={link.external ? "noreferrer" : undefined}>
@@ -94,6 +102,8 @@ export default function Header({ storeData, logoData, notifications, socialData 
           {/* Contact Button */}
           <ContactModalTrigger
             tab="contact"
+            interactionId="header_contact"
+            sectionId="header"
             className="flex items-center gap-2 px-3 py-2 text-gray-300 hover:text-primary-500 transition-colors cursor-pointer"
             aria-label="Contact us">
             <FaEnvelope className="w-4 h-4" />
@@ -111,6 +121,8 @@ export default function Header({ storeData, logoData, notifications, socialData 
         <div className="md:hidden flex items-center gap-2">
           <ContactModalTrigger
             tab="contact"
+            interactionId="header_contact_mobile"
+            sectionId="header"
             className="p-2 text-gray-300 hover:text-primary-500 transition-colors cursor-pointer"
             aria-label="Contact us">
             <FaEnvelope className="w-5 h-5" />

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -8,6 +8,7 @@ import { FacebookGroupButton } from "@/src/components/social";
 import { ContactModalTrigger } from "@/src/components/contact";
 import { FaEnvelope } from "react-icons/fa";
 import { useEffect } from "react";
+import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 
 interface MobileMenuProps {
   headerLinks?: SanityLink[];
@@ -17,6 +18,7 @@ interface MobileMenuProps {
 }
 
 export default function MobileMenu({ headerLinks, isOpen, onClose, socialData }: MobileMenuProps) {
+  const toInteractionToken = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
   const pathname = usePathname();
 
   // Prevent body scroll when menu is open
@@ -76,7 +78,13 @@ export default function MobileMenu({ headerLinks, isOpen, onClose, socialData }:
                       className={`block px-3 py-2 rounded-lg hover:bg-gray-800 transition-colors cursor-pointer ${
                         isActive ? "text-white bg-gray-800" : "text-gray-300"
                       }`}
-                      onClick={() => onClose()}>
+                      onClick={() => {
+                        void trackInteraction({
+                          interactionId: `mobile_nav_${toInteractionToken(link.title || "link")}`,
+                          sectionId: "header"
+                        });
+                        onClose();
+                      }}>
                       {link.title}
                     </Link>
                   );
@@ -88,7 +96,11 @@ export default function MobileMenu({ headerLinks, isOpen, onClose, socialData }:
               <div
                 className="flex items-center gap-3 w-full px-3 py-2 text-gray-300 hover:text-white hover:bg-gray-800 rounded-lg transition-colors cursor-pointer"
                 onClick={onClose}>
-                <ContactModalTrigger tab="contact" className="flex items-center gap-3 w-full">
+                <ContactModalTrigger
+                  tab="contact"
+                  interactionId="mobile_contact"
+                  sectionId="header"
+                  className="flex items-center gap-3 w-full">
                   <FaEnvelope className="w-4 h-4" />
                   <span>Contact Us</span>
                 </ContactModalTrigger>

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -9,6 +9,7 @@ import { ContactModalTrigger } from "@/src/components/contact";
 import { FaEnvelope } from "react-icons/fa";
 import { useEffect } from "react";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
+import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
 
 interface MobileMenuProps {
   headerLinks?: SanityLink[];
@@ -18,7 +19,6 @@ interface MobileMenuProps {
 }
 
 export default function MobileMenu({ headerLinks, isOpen, onClose, socialData }: MobileMenuProps) {
-  const toInteractionToken = (value: string) => value.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
   const pathname = usePathname();
 
   // Prevent body scroll when menu is open
@@ -80,8 +80,8 @@ export default function MobileMenu({ headerLinks, isOpen, onClose, socialData }:
                       }`}
                       onClick={() => {
                         void trackInteraction({
-                          interactionId: `mobile_nav_${toInteractionToken(link.title || "link")}`,
-                          sectionId: "header"
+                          interactionId: INTERACTION_IDS.mobileNavLink,
+                          sectionId: SECTIONS.global.header
                         });
                         onClose();
                       }}>
@@ -98,8 +98,8 @@ export default function MobileMenu({ headerLinks, isOpen, onClose, socialData }:
                 onClick={onClose}>
                 <ContactModalTrigger
                   tab="contact"
-                  interactionId="mobile_contact"
-                  sectionId="header"
+                  interactionId={INTERACTION_IDS.mobileContact}
+                  sectionId={SECTIONS.global.header}
                   className="flex items-center gap-3 w-full">
                   <FaEnvelope className="w-4 h-4" />
                   <span>Contact Us</span>

--- a/src/components/program/ProgramInformation.tsx
+++ b/src/components/program/ProgramInformation.tsx
@@ -101,12 +101,12 @@ export default function ProgramInformation({
                     href={program.downloadLink}
                     target="_blank"
                     rel="noreferrer"
-                    onClick={() =>
+                    onClick={() => {
                       trackEvent("download_click", {
                         programSlug: program.slug.current,
                         path: window.location.pathname
-                      })
-                    }
+                      });
+                    }}
                     className="inline-flex items-center bg-linear-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 text-white font-semibold px-5 py-3 sm:px-8 sm:py-4 rounded-xl sm:rounded-2xl transition-all duration-300 transform hover:scale-[1.02] hover:shadow-2xl focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 focus:ring-offset-neutral-800 shadow-lg text-sm sm:text-base">
                     <FaDownload size={18} className="mr-2 sm:mr-3" />
                     Download Program

--- a/src/components/programs/BrowseAllCTA.tsx
+++ b/src/components/programs/BrowseAllCTA.tsx
@@ -2,11 +2,22 @@
 
 import Link from "next/link";
 import { FaArrowRight } from "react-icons/fa";
+import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 
-export default function BrowseAllCTA() {
+interface BrowseAllCTAProps {
+  sectionId?: string;
+}
+
+export default function BrowseAllCTA({ sectionId = "programs_page" }: BrowseAllCTAProps) {
   return (
     <Link
       href="/programs"
+      onClick={() =>
+        void trackInteraction({
+          interactionId: "programs_browse_all",
+          sectionId
+        })
+      }
       className="group relative bg-white hover:bg-gray-50 border-2 border-dashed border-gray-300 hover:border-primary-400 rounded-xl sm:rounded-2xl p-6 transition-all duration-300 hover:shadow-xl cursor-pointer flex flex-col items-center justify-center min-h-[280px] text-center">
       <div className="w-16 h-16 bg-primary-600 rounded-2xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300 shadow-lg">
         <FaArrowRight className="w-8 h-8 text-white" />

--- a/src/components/programs/BrowseAllCTA.tsx
+++ b/src/components/programs/BrowseAllCTA.tsx
@@ -3,18 +3,19 @@
 import Link from "next/link";
 import { FaArrowRight } from "react-icons/fa";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
+import { INTERACTION_IDS, SECTIONS, SectionId } from "@/src/lib/analytics/interactionCatalog";
 
 interface BrowseAllCTAProps {
-  sectionId?: string;
+  sectionId?: SectionId;
 }
 
-export default function BrowseAllCTA({ sectionId = "programs_page" }: BrowseAllCTAProps) {
+export default function BrowseAllCTA({ sectionId = SECTIONS.browse.allProgramsGrid }: BrowseAllCTAProps) {
   return (
     <Link
       href="/programs"
       onClick={() =>
         void trackInteraction({
-          interactionId: "programs_browse_all",
+          interactionId: INTERACTION_IDS.programsBrowseAll,
           sectionId
         })
       }

--- a/src/components/programs/ProgramsGrid.tsx
+++ b/src/components/programs/ProgramsGrid.tsx
@@ -4,6 +4,7 @@ import { ProgramCard } from "@/src/components/home";
 import { ProgramsGridProps } from "@/src/types/programs";
 import SuggestKeyCTA from "./SuggestKeyCTA";
 import BrowseAllCTA from "./BrowseAllCTA";
+import { SECTIONS } from "@/src/lib/analytics/interactionCatalog";
 
 export default function ProgramsGrid({
   programs,
@@ -31,7 +32,7 @@ export default function ProgramsGrid({
         <ProgramCard
           key={program.slug.current}
           program={program}
-          sectionId={limit ? "popular_programs" : "programs_page"}
+          sectionId={limit ? SECTIONS.home.popularPrograms : SECTIONS.browse.allProgramsGrid}
           stats={{
             viewCount: program.viewCount,
             downloadCount: program.downloadCount
@@ -45,8 +46,10 @@ export default function ProgramsGrid({
       ))}
 
       {/* CTA Cards */}
-      <SuggestKeyCTA sectionId={limit ? "popular_programs" : "programs_page"} />
-      {showBrowseAllCTA && <BrowseAllCTA sectionId={limit ? "popular_programs" : "programs_page"} />}
+      <SuggestKeyCTA sectionId={limit ? SECTIONS.home.popularPrograms : SECTIONS.browse.allProgramsGrid} />
+      {showBrowseAllCTA && (
+        <BrowseAllCTA sectionId={limit ? SECTIONS.home.popularPrograms : SECTIONS.browse.allProgramsGrid} />
+      )}
     </div>
   );
 }

--- a/src/components/programs/ProgramsGrid.tsx
+++ b/src/components/programs/ProgramsGrid.tsx
@@ -31,6 +31,7 @@ export default function ProgramsGrid({
         <ProgramCard
           key={program.slug.current}
           program={program}
+          sectionId={limit ? "popular_programs" : "programs_page"}
           stats={{
             viewCount: program.viewCount,
             downloadCount: program.downloadCount
@@ -44,8 +45,8 @@ export default function ProgramsGrid({
       ))}
 
       {/* CTA Cards */}
-      <SuggestKeyCTA />
-      {showBrowseAllCTA && <BrowseAllCTA />}
+      <SuggestKeyCTA sectionId={limit ? "popular_programs" : "programs_page"} />
+      {showBrowseAllCTA && <BrowseAllCTA sectionId={limit ? "popular_programs" : "programs_page"} />}
     </div>
   );
 }

--- a/src/components/programs/SuggestKeyCTA.tsx
+++ b/src/components/programs/SuggestKeyCTA.tsx
@@ -3,10 +3,16 @@
 import { FaPlus } from "react-icons/fa";
 import { ContactModalTrigger } from "@/src/components/contact";
 
-export default function SuggestKeyCTA() {
+interface SuggestKeyCTAProps {
+  sectionId?: string;
+}
+
+export default function SuggestKeyCTA({ sectionId = "programs_page" }: SuggestKeyCTAProps) {
   return (
     <ContactModalTrigger
       tab="suggest"
+      interactionId="programs_suggest_cd_key"
+      sectionId={sectionId}
       className="group relative bg-white hover:bg-gray-50 border-2 border-dashed border-gray-300 hover:border-primary-400 rounded-xl sm:rounded-2xl p-6 transition-all duration-300 hover:shadow-xl cursor-pointer flex flex-col items-center justify-center min-h-[280px] text-center">
       <div className="w-16 h-16 bg-primary-600 rounded-2xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300 shadow-lg">
         <FaPlus className="w-8 h-8 text-white" />

--- a/src/components/programs/SuggestKeyCTA.tsx
+++ b/src/components/programs/SuggestKeyCTA.tsx
@@ -2,16 +2,17 @@
 
 import { FaPlus } from "react-icons/fa";
 import { ContactModalTrigger } from "@/src/components/contact";
+import { INTERACTION_IDS, SECTIONS, SectionId } from "@/src/lib/analytics/interactionCatalog";
 
 interface SuggestKeyCTAProps {
-  sectionId?: string;
+  sectionId?: SectionId;
 }
 
-export default function SuggestKeyCTA({ sectionId = "programs_page" }: SuggestKeyCTAProps) {
+export default function SuggestKeyCTA({ sectionId = SECTIONS.browse.allProgramsGrid }: SuggestKeyCTAProps) {
   return (
     <ContactModalTrigger
       tab="suggest"
-      interactionId="programs_suggest_cd_key"
+      interactionId={INTERACTION_IDS.programsSuggestCdKey}
       sectionId={sectionId}
       className="group relative bg-white hover:bg-gray-50 border-2 border-dashed border-gray-300 hover:border-primary-400 rounded-xl sm:rounded-2xl p-6 transition-all duration-300 hover:shadow-xl cursor-pointer flex flex-col items-center justify-center min-h-[280px] text-center">
       <div className="w-16 h-16 bg-primary-600 rounded-2xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform duration-300 shadow-lg">

--- a/src/components/visitors/VisitorTierHint.tsx
+++ b/src/components/visitors/VisitorTierHint.tsx
@@ -14,6 +14,7 @@ import {
 } from "react-icons/fa";
 import type { VisitorHintData } from "@/src/lib/visitors/publicVisitorContext";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
+import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
 
 export type VisitorTierHintVariant = "pill" | "feature";
 
@@ -87,8 +88,8 @@ export default function VisitorTierHint({ hint, variant = "pill" }: VisitorTierH
     setOpen(next);
     if (next) {
       void trackInteraction({
-        interactionId: "hero_visitor_hint_open",
-        sectionId: "hero"
+        interactionId: INTERACTION_IDS.heroVisitorHintOpen,
+        sectionId: SECTIONS.home.hero
       });
     }
   };

--- a/src/components/visitors/VisitorTierHint.tsx
+++ b/src/components/visitors/VisitorTierHint.tsx
@@ -13,6 +13,7 @@ import {
   FaUser
 } from "react-icons/fa";
 import type { VisitorHintData } from "@/src/lib/visitors/publicVisitorContext";
+import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 
 export type VisitorTierHintVariant = "pill" | "feature";
 
@@ -82,7 +83,14 @@ export default function VisitorTierHint({ hint, variant = "pill" }: VisitorTierH
   }, [open]);
 
   const togglePopover = () => {
-    setOpen(!open);
+    const next = !open;
+    setOpen(next);
+    if (next) {
+      void trackInteraction({
+        interactionId: "hero_visitor_hint_open",
+        sectionId: "hero"
+      });
+    }
   };
 
   const statsRow = (

--- a/src/lib/analytics/bundleEvents.ts
+++ b/src/lib/analytics/bundleEvents.ts
@@ -7,7 +7,7 @@ const BUNDLE_SIZE = 1000;
 const MAX_ITERATIONS = 10;
 
 const EVENT_FIELDS =
-  "event, programSlug, notFound, path, referrer, country, city, social, interaction, keyHash, keyIdentifier, keyNormalized, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt";
+  "event, programSlug, notFound, path, referrer, country, city, social, keyHash, keyIdentifier, keyNormalized, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt";
 
 function toBundleEvent(doc: Record<string, unknown> & { _id?: string }, index: number) {
   const id = doc._id ?? `evt-${index}`;
@@ -25,7 +25,6 @@ function toBundleEvent(doc: Record<string, unknown> & { _id?: string }, index: n
     country: doc.country,
     city: doc.city,
     social: doc.social,
-    interaction: doc.interaction,
     keyHash: doc.keyHash,
     keyIdentifier: doc.keyIdentifier,
     keyNormalized: doc.keyNormalized,

--- a/src/lib/analytics/interactionCatalog.ts
+++ b/src/lib/analytics/interactionCatalog.ts
@@ -1,0 +1,57 @@
+/**
+ * Nested section registry for readability; wire components with `SECTIONS.group.key`.
+ * Flat `SECTION_IDS` is the merged map (same string values) for defaults and tooling.
+ */
+export const SECTIONS = {
+  global: {
+    header: "header"
+  },
+  home: {
+    hero: "hero",
+    featuredProgram: "featured_program",
+    popularPrograms: "popular_programs",
+    features: "features",
+    cta: "cta"
+  },
+  browse: {
+    /** Full program grid on /programs (browse-all page), not the homepage popular strip */
+    allProgramsGrid: "all_programs_grid"
+  },
+  program: {
+    /** Main program page panel — `ProgramInformation.tsx` on `/program/[slug]` */
+    programInformation: "program_information"
+  }
+} as const;
+
+export const SECTION_IDS = {
+  ...SECTIONS.global,
+  ...SECTIONS.home,
+  ...SECTIONS.browse,
+  ...SECTIONS.program
+} as const;
+
+export type SectionId = (typeof SECTION_IDS)[keyof typeof SECTION_IDS];
+
+export const INTERACTION_IDS = {
+  heroVisitorHintOpen: "hero_visitor_hint_open",
+  heroSuggestCdKey: "hero_suggest_cd_key",
+  heroHowItWorks: "hero_how_it_works",
+  featuresSuggestCdKey: "features_suggest_cd_key",
+  ctaBrowseAllPrograms: "cta_browse_all_programs",
+  ctaSuggestCdKey: "cta_suggest_cd_key",
+  programsBrowseAll: "programs_browse_all",
+  programsSuggestCdKey: "programs_suggest_cd_key",
+  featuredProgramViewKeys: "featured_program_view_keys",
+  programGridViewKeysImage: "program_grid_view_keys_image",
+  programGridViewKeysButton: "program_grid_view_keys_button",
+  headerNavLink: "header_nav_link",
+  mobileNavLink: "mobile_nav_link",
+  headerContact: "header_contact",
+  headerContactMobile: "header_contact_mobile",
+  mobileContact: "mobile_contact"
+} as const;
+
+export type InteractionId = (typeof INTERACTION_IDS)[keyof typeof INTERACTION_IDS];
+
+export const ALLOWED_SECTION_IDS = new Set<SectionId>(Object.values(SECTION_IDS));
+export const ALLOWED_INTERACTION_IDS = new Set<InteractionId>(Object.values(INTERACTION_IDS));

--- a/src/lib/analytics/trackInteraction.ts
+++ b/src/lib/analytics/trackInteraction.ts
@@ -1,0 +1,27 @@
+import { TrackInteractionBody } from "@/src/types";
+
+type TrackInteractionInput = Omit<TrackInteractionBody, "pagePath"> & { pagePath?: string };
+
+function resolvePath(path?: string): string {
+  const raw = path?.trim() || (typeof window !== "undefined" ? window.location.pathname : "/");
+  if (!raw.startsWith("/")) return `/${raw}`;
+  return raw;
+}
+
+export async function trackInteraction(input: TrackInteractionInput) {
+  try {
+    await fetch("/api/v1/interactions/track", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        interactionId: input.interactionId,
+        sectionId: input.sectionId,
+        pagePath: resolvePath(input.pagePath),
+        programSlug: input.programSlug
+      } satisfies TrackInteractionBody),
+      keepalive: true
+    });
+  } catch (e) {
+    void e;
+  }
+}

--- a/src/lib/analytics/trackInteraction.ts
+++ b/src/lib/analytics/trackInteraction.ts
@@ -1,6 +1,11 @@
 import { TrackInteractionBody } from "@/src/types";
+import { InteractionId, SectionId } from "@/src/lib/analytics/interactionCatalog";
 
-type TrackInteractionInput = Omit<TrackInteractionBody, "pagePath"> & { pagePath?: string };
+type TrackInteractionInput = Omit<TrackInteractionBody, "pagePath" | "interactionId" | "sectionId"> & {
+  interactionId: InteractionId;
+  sectionId: SectionId;
+  pagePath?: string;
+};
 
 function resolvePath(path?: string): string {
   const raw = path?.trim() || (typeof window !== "undefined" ? window.location.pathname : "/");

--- a/src/lib/api/inputNormalize.ts
+++ b/src/lib/api/inputNormalize.ts
@@ -1,0 +1,10 @@
+export function normalizePath(path: string): string {
+  const p = path.trim();
+  if (!p) return "/";
+  if (!p.startsWith("/")) return `/${p}`;
+  return p;
+}
+
+export function sanitizeTrackingToken(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9_\-/]/g, "_").replace(/_+/g, "_");
+}

--- a/src/lib/api/shortRequestDedupe.ts
+++ b/src/lib/api/shortRequestDedupe.ts
@@ -1,0 +1,25 @@
+/** Drop repeat POSTs within this window (double-clicks, duplicate taps). In-memory per process. */
+export const SHORT_REQUEST_DEDUPE_WINDOW_MS = 1500;
+
+const lastAcceptedAt = new Map<string, number>();
+const PRUNE_AT = 10_000;
+
+/**
+ * @returns true if this key was accepted recently — caller should skip the expensive work.
+ */
+export function isRecentDuplicateRequest(key: string, now = Date.now()): boolean {
+  const prev = lastAcceptedAt.get(key);
+  if (prev !== undefined && now - prev < SHORT_REQUEST_DEDUPE_WINDOW_MS) {
+    return true;
+  }
+  lastAcceptedAt.set(key, now);
+
+  if (lastAcceptedAt.size > PRUNE_AT) {
+    const cutoff = now - SHORT_REQUEST_DEDUPE_WINDOW_MS;
+    for (const [k, t] of lastAcceptedAt) {
+      if (t < cutoff) lastAcceptedAt.delete(k);
+    }
+  }
+
+  return false;
+}

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -64,12 +64,12 @@ export const socialLinksQuery = `*[_type=="socialLink"] | order(_createdAt asc) 
 
 /* ------------ Analytics ------------ */
 export const trackingEventsQuery = `*[_type=="trackingEvent" && createdAt >= $since]{
-      _id, event, programSlug, social, interaction, path, referrer, country, city, keyHash, keyIdentifier, keyNormalized, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt
+      _id, event, programSlug, social, path, referrer, country, city, keyHash, keyIdentifier, keyNormalized, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt
     } | order(createdAt desc)`;
 
 /* ------------ Analytics with Custom Date Range ------------ */
 export const trackingEventsWithRangeQuery = `*[_type=="trackingEvent" && createdAt >= $since && createdAt <= $until]{
-      _id, event, programSlug, notFound, social, interaction, path, referrer, country, city, keyHash, keyIdentifier, keyNormalized, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt,
+      _id, event, programSlug, notFound, social, path, referrer, country, city, keyHash, keyIdentifier, keyNormalized, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt,
       "visitTier": *[_type=="visitor" && visitorHash == ^.ipHash][0].visitTier,
       "visitorIsSpammer": *[_type=="visitor" && visitorHash == ^.ipHash][0].isSpammer
     } | order(createdAt desc)`;
@@ -82,7 +82,7 @@ export const bundleCountsQuery = `*[_type == "trackingEventBundle"]{
 /* ------------ Bundled Events (overlaps range, events filtered in-doc) ------------ */
 export const trackingEventBundlesQuery = `*[_type == "trackingEventBundle" && timeRangeEnd >= $since && timeRangeStart <= $until]{
   _id,
-  "events": events[createdAt >= $since && createdAt <= $until]{ event, programSlug, notFound, path, referrer, country, city, social, interaction, keyHash, keyIdentifier, keyNormalized, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt, "visitTier": *[_type=="visitor" && visitorHash == ^.ipHash][0].visitTier, "visitorIsSpammer": *[_type=="visitor" && visitorHash == ^.ipHash][0].isSpammer }
+  "events": events[createdAt >= $since && createdAt <= $until]{ event, programSlug, notFound, path, referrer, country, city, social, keyHash, keyIdentifier, keyNormalized, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt, "visitTier": *[_type=="visitor" && visitorHash == ^.ipHash][0].visitTier, "visitorIsSpammer": *[_type=="visitor" && visitorHash == ^.ipHash][0].isSpammer }
 }`;
 
 /* ------------ Key Reports ------------ */

--- a/src/lib/visitors/upsertVisitorOnPageView.ts
+++ b/src/lib/visitors/upsertVisitorOnPageView.ts
@@ -4,7 +4,10 @@ import { resolveVisitTier } from "@/src/lib/visitors/visitTier";
 const SESSION_GAP_MS = 60 * 60 * 1000;
 
 /** After a stored `page_viewed`, patch or create `visitor` (1h idle = new session, increments visitCount / tier). */
-export async function upsertVisitorOnPageView(visitorHash: string | undefined): Promise<void> {
+export async function upsertVisitorOnPageView(
+  visitorHash: string | undefined,
+  location?: { country?: string; city?: string }
+): Promise<void> {
   if (!visitorHash) return;
 
   const now = new Date().toISOString();
@@ -32,6 +35,9 @@ export async function upsertVisitorOnPageView(visitorHash: string | undefined): 
       reportCount: 0,
       suggestionCount: 0,
       contributionScore: 0,
+      ...(location?.country ? { country: location.country } : {}),
+      ...(location?.city ? { city: location.city } : {}),
+      ...(location?.country || location?.city ? { geoUpdatedAt: now } : {}),
       createdAt: now,
       updatedAt: now
     });
@@ -50,6 +56,9 @@ export async function upsertVisitorOnPageView(visitorHash: string | undefined): 
       visitCount: nextCount,
       lastActivityAt: now,
       visitTier: resolveVisitTier(nextCount, contributionScore, isSpammer),
+      ...(location?.country ? { country: location.country } : {}),
+      ...(location?.city ? { city: location.city } : {}),
+      ...(location?.country || location?.city ? { geoUpdatedAt: now } : {}),
       updatedAt: now
     })
     .commit();

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -17,6 +17,7 @@ import { program } from "./program";
 import { cdKey } from "./cdKey";
 import { featuredProgramSettings } from "./featuredProgramSettings";
 import { visitor } from "./visitor";
+import { interactionEventBucket } from "./interactionEventBucket";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
   types: [
@@ -34,6 +35,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     program,
     cdKey,
     featuredProgramSettings,
-    visitor
+    visitor,
+    interactionEventBucket
   ]
 };

--- a/src/sanity/schemaTypes/interactionEventBucket.ts
+++ b/src/sanity/schemaTypes/interactionEventBucket.ts
@@ -1,0 +1,40 @@
+import { defineType } from "sanity";
+
+export const interactionEventBucket = defineType({
+  name: "interactionEventBucket",
+  title: "Interaction Event Bucket",
+  type: "document",
+  fields: [
+    { name: "bucketKey", title: "Bucket Key", type: "string", validation: Rule => Rule.required() },
+    { name: "bucketDateHour", title: "Bucket Date Hour", type: "string", validation: Rule => Rule.required() },
+    { name: "pagePath", title: "Page Path", type: "string", validation: Rule => Rule.required() },
+    { name: "sectionId", title: "Section Id", type: "string", validation: Rule => Rule.required() },
+    { name: "interactionId", title: "Interaction Id", type: "string", validation: Rule => Rule.required() },
+    { name: "programSlug", title: "Program Slug", type: "string" },
+    { name: "count", title: "Count", type: "number", validation: Rule => Rule.required().min(0) },
+    { name: "lastSeenAt", title: "Last Seen At", type: "datetime", validation: Rule => Rule.required() },
+    { name: "createdAt", title: "Created At", type: "datetime", validation: Rule => Rule.required() }
+  ],
+  preview: {
+    select: {
+      title: "interactionId",
+      subtitle: "sectionId",
+      path: "pagePath",
+      count: "count",
+      hour: "bucketDateHour"
+    },
+    prepare(selection) {
+      const { title, subtitle, path, count, hour } = selection as {
+        title?: string;
+        subtitle?: string;
+        path?: string;
+        count?: number;
+        hour?: string;
+      };
+      return {
+        title: title || "interaction",
+        subtitle: `${subtitle || "section"} • ${path || "/"} • ${hour || ""} • ${count ?? 0}`
+      };
+    }
+  }
+});

--- a/src/sanity/schemaTypes/trackingEvent.ts
+++ b/src/sanity/schemaTypes/trackingEvent.ts
@@ -14,8 +14,7 @@ export const trackingEvent = defineType({
           { title: "Copy CD Key", value: "copy_cdkey" },
           { title: "Download Click", value: "download_click" },
           { title: "Social Click", value: "social_click" },
-          { title: "Page Viewed", value: "page_viewed" },
-          { title: "Interaction", value: "interaction" }
+          { title: "Page Viewed", value: "page_viewed" }
         ]
       },
       validation: Rule => Rule.required()
@@ -31,12 +30,6 @@ export const trackingEvent = defineType({
     { name: "keyIdentifier", title: "Key Identifier", type: "string", description: "Short identifier like ABC***XYZ" },
     { name: "keyNormalized", title: "Key Normalized", type: "string", description: "Normalized key for matching" },
     { name: "social", title: "Social Name", type: "string" },
-    {
-      name: "interaction",
-      title: "Interaction id",
-      type: "string",
-      description: "Stable id for UI engagement (event type interaction), e.g. visitor_hint_visible"
-    },
     { name: "path", title: "Path", type: "string" },
     { name: "referrer", title: "Referrer", type: "url" },
     { name: "userAgent", title: "User Agent", type: "string" },

--- a/src/sanity/schemaTypes/trackingEventBundle.ts
+++ b/src/sanity/schemaTypes/trackingEventBundle.ts
@@ -10,7 +10,6 @@ const bundledEventFields = [
   { name: "country", title: "Country", type: "string" },
   { name: "city", title: "City", type: "string" },
   { name: "social", title: "Social Name", type: "string" },
-  { name: "interaction", title: "Interaction id", type: "string" },
   { name: "keyHash", title: "Key Hash", type: "string" },
   { name: "keyIdentifier", title: "Key Identifier", type: "string" },
   { name: "keyNormalized", title: "Key Normalized", type: "string" },

--- a/src/sanity/schemaTypes/visitor.ts
+++ b/src/sanity/schemaTypes/visitor.ts
@@ -75,6 +75,23 @@ export const visitor = defineType({
       type: "datetime"
     },
     {
+      name: "country",
+      title: "Country",
+      type: "string",
+      description: "Latest resolved visitor country from IP geolocation"
+    },
+    {
+      name: "city",
+      title: "City",
+      type: "string",
+      description: "Latest resolved visitor city from IP geolocation"
+    },
+    {
+      name: "geoUpdatedAt",
+      title: "Geo updated at",
+      type: "datetime"
+    },
+    {
       name: "createdAt",
       title: "Created at",
       type: "datetime",

--- a/src/types/home/index.ts
+++ b/src/types/home/index.ts
@@ -1,4 +1,5 @@
 import { Program } from "@/src/types/program";
+import { SectionId } from "@/src/lib/analytics/interactionCatalog";
 
 export interface ProgramWithStats extends Program {
   viewCount: number;
@@ -19,7 +20,7 @@ export interface ProgramCardProps {
     mostDownloaded?: boolean;
   };
   showStats?: boolean;
-  sectionId?: string;
+  sectionId?: SectionId;
 }
 
 export interface PopularProgramsSectionProps {

--- a/src/types/home/index.ts
+++ b/src/types/home/index.ts
@@ -19,6 +19,7 @@ export interface ProgramCardProps {
     mostDownloaded?: boolean;
   };
   showStats?: boolean;
+  sectionId?: string;
 }
 
 export interface PopularProgramsSectionProps {

--- a/src/types/tracking/index.ts
+++ b/src/types/tracking/index.ts
@@ -7,7 +7,6 @@ export type AnalyticsEvent =
   | "download_click"
   | "social_click"
   | "page_viewed"
-  | "interaction"
   | "facebook_group_click";
 
 export type KeyReportEvent = "report_key_working" | "report_key_expired" | "report_key_limit_reached";
@@ -22,8 +21,6 @@ export interface AnalyticsEventData {
   visitTier?: string;
   visitorIsSpammer?: boolean;
   social?: string;
-  /** Present when `event` is `interaction` (UI / component engagement). */
-  interaction?: string;
   path?: string;
   referrer?: string;
   country?: string;
@@ -65,7 +62,6 @@ export interface TrackEventMeta {
   key?: unknown; // CDKey type
   path?: string;
   social?: string;
-  interaction?: string;
   copyMethod?: "button_click" | "keyboard_or_context_menu";
   referrer?: string;
   utm_source?: string;
@@ -131,4 +127,24 @@ export interface EventAggregation {
   byPath: Map<string, number>;
   uniquePaths: Set<string>;
   uniquePrograms: Set<string>;
+}
+
+export interface TrackInteractionBody {
+  interactionId: string;
+  sectionId: string;
+  pagePath?: string;
+  programSlug?: string;
+}
+
+export interface InteractionEventBucketData {
+  _id: string;
+  bucketKey: string;
+  bucketDateHour: string;
+  pagePath: string;
+  sectionId: string;
+  interactionId: string;
+  programSlug?: string;
+  count: number;
+  lastSeenAt: string;
+  createdAt: string;
 }


### PR DESCRIPTION
## Summary

Adds lightweight hourly interaction bucket counters separate from core analytics, fixes visitor-tier hint firing bogus social_click traffic, and adds short server-side dedupe on noisy actions.

## Changelog

<!-- tags: feat, api, fix, perf -->

### Highlights

- interactionEventBucket documents and POST /api/v1/interactions/track pipeline
- Admin /admin/interactions dashboard with summary cards and filterable table
- 2s dedupe window for interactions and copy_cdkey/download_click/social_click analytics

### Analytics hygiene

- Visitor country/city persisted and reused before geo API calls
- Interactions decoupled from trackingEvent bundle cron
- Visitor hint tracks interaction on popover open only (no mount spam)

---

## Environment Variables

None

## Testing

- Double interaction within 2s returns deduped: true, count increases once
- Invalid interactionId returns validation error
- copy_cdkey double-fire deduped without duplicate trackingEvent

## Technical Details

Later removed in favor of simplified analytics (see PR #96). Historical buckets may show legacy sectionId keys.
