### PR TITLE
ui(program): contribute section, typography polish, and card badge fix

### DIFF
--- a/src/components/home/ProgramCard.tsx
+++ b/src/components/home/ProgramCard.tsx
@@ -62,14 +62,14 @@ export default function ProgramCard({
         </div>
 
         {/* Key Count Badge */}
-        {program.cdKeys?.length && (
+        {program.cdKeys?.length ? (
           <div className="absolute top-2 sm:top-3 lg:top-4 right-2 sm:right-3 lg:right-4">
             <div className="bg-white/95 backdrop-blur-sm text-gray-800 px-2 sm:px-2.5 lg:px-3 py-1 sm:py-1.5 rounded-full text-xs sm:text-sm font-semibold flex items-center space-x-1 shadow-lg border border-gray-200">
               <FaKey className="w-2.5 h-2.5 sm:w-3 sm:h-3 text-primary-600" />
               <span>{program.cdKeys.length}</span>
             </div>
           </div>
-        )}
+        ) : null}
       </Link>
 
       {/* Content */}

--- a/src/components/program/AboutSectionBlock.tsx
+++ b/src/components/program/AboutSectionBlock.tsx
@@ -15,9 +15,11 @@ export default function AboutSectionBlock({ section }: { section: ProgramAboutSe
   const hasImage = hasAsset(image);
 
   const content = (
-    <div className={hasImage ? "text-center lg:text-left" : "mx-auto max-w-3xl text-center"}>
-      {sectionTitle ? <h3 className="text-lg sm:text-xl font-bold text-white mb-3">{sectionTitle}</h3> : null}
-      <p className="text-sm sm:text-base text-gray-300 leading-relaxed whitespace-pre-wrap">{description}</p>
+    <div className="mx-auto max-w-3xl text-start">
+      {sectionTitle ? (
+        <h3 className="text-lg sm:text-xl lg:text-2xl font-bold text-white mb-3">{sectionTitle}</h3>
+      ) : null}
+      <p className="text-sm sm:text-base text-gray-300 leading-snug whitespace-pre-wrap">{description}</p>
       {points && points.length > 0 ? (
         <ul
           className={`mt-4 space-y-2.5 text-sm sm:text-base text-gray-300 ${
@@ -26,15 +28,15 @@ export default function AboutSectionBlock({ section }: { section: ProgramAboutSe
           {points.map((p, i) => (
             <li key={`${p.text}-${i}`} className="flex gap-3 items-start">
               {hasAsset(p.icon) ? (
-                <span className="relative mt-0.5 h-8 w-8 shrink-0 overflow-hidden rounded-md bg-white/5 ring-1 ring-white/10">
+                <span className="relative mt-0.5 h-7 w-7 shrink-0 overflow-hidden">
                   <Image
                     src={urlFor(p.icon as SanityImageSource)
                       .width(64)
                       .height(64)
                       .url()}
                     alt=""
-                    width={32}
-                    height={32}
+                    width={28}
+                    height={28}
                     className="h-full w-full object-contain p-0.5"
                   />
                 </span>

--- a/src/components/program/ContributeBanner.tsx
+++ b/src/components/program/ContributeBanner.tsx
@@ -1,7 +1,40 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { FaKey, FaExclamationCircle } from "react-icons/fa";
 import { ContactModalTrigger } from "@/src/components/contact";
+
+type ContributeSectionProps = {
+  className?: string;
+  iconContainerClassName: string;
+  icon: ReactNode;
+  title: string;
+  description: string;
+  content: ReactNode;
+};
+
+function ContributeSection({
+  className = "",
+  iconContainerClassName,
+  icon,
+  title,
+  description,
+  content
+}: ContributeSectionProps) {
+  return (
+    <div className={`text-center lg:text-left ${className}`}>
+      <div
+        className={`inline-flex items-center justify-center w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 rounded-xl sm:rounded-2xl mb-3 ${iconContainerClassName}`}>
+        {icon}
+      </div>
+      <h3 className="text-lg sm:text-xl lg:text-2xl xl:text-3xl font-bold text-white mb-2 sm:mb-3">{title}</h3>
+      <p className="text-gray-300 text-sm sm:text-base lg:text-lg mb-4 sm:mb-5 lg:mb-6 leading-relaxed">
+        {description}
+      </p>
+      {content}
+    </div>
+  );
+}
 
 export default function ContributeBanner() {
   return (
@@ -9,53 +42,44 @@ export default function ContributeBanner() {
       <div className="max-w-360 mx-auto px-4 sm:px-6 lg:px-8">
         <div className="bg-linear-to-r from-primary-600/20 to-blue-600/20 backdrop-blur-sm rounded-2xl sm:rounded-3xl border border-primary-500/30 p-5 sm:p-6 lg:p-8 xl:p-12">
           <div className="grid md:grid-cols-2 gap-6 sm:gap-8 items-center">
-            {/* Suggest Keys Section */}
-            <div className="text-center lg:text-left">
-              <div className="inline-flex items-center justify-center w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 bg-primary-500/20 rounded-xl sm:rounded-2xl mb-3 sm:mb-4 lg:mb-6">
-                <FaKey className="w-6 h-6 sm:w-7 sm:h-7 lg:w-8 lg:h-8 text-primary-400" />
-              </div>
-              <h3 className="text-lg sm:text-xl lg:text-2xl xl:text-3xl font-bold text-white mb-2 sm:mb-3">
-                Have More Keys to Share?
-              </h3>
-              <p className="text-gray-300 text-sm sm:text-base lg:text-lg mb-4 sm:mb-5 lg:mb-6 leading-relaxed px-2">
-                Know of other free CD keys for this or any other software? Share them with the community and help others
-                unlock premium features!
-              </p>
-              <ContactModalTrigger
-                tab="suggest"
-                className="inline-flex items-center justify-center px-5 py-2.5 sm:px-6 sm:py-3 bg-primary-600 hover:bg-primary-700 text-white font-semibold rounded-lg sm:rounded-xl transition-all duration-200 transform hover:scale-[1.02] shadow-lg hover:shadow-xl cursor-pointer text-sm sm:text-base">
-                <FaKey className="mr-2 text-sm" />
-                Suggest a CD Key
-              </ContactModalTrigger>
-            </div>
+            <ContributeSection
+              iconContainerClassName="bg-primary-500/20"
+              icon={<FaKey className="w-6 h-6 sm:w-7 sm:h-7 lg:w-8 lg:h-8 text-primary-400" />}
+              title="Have More Keys to Share?"
+              description="Know of other free CD keys for this or any other software? Share them with the community and help others unlock premium features!"
+              content={
+                <ContactModalTrigger
+                  tab="suggest"
+                  className="inline-flex items-center justify-center px-5 py-2.5 sm:px-6 sm:py-3 bg-primary-600 hover:bg-primary-700 text-white font-semibold rounded-lg sm:rounded-xl transition-all duration-200 transform hover:scale-[1.02] shadow-lg hover:shadow-xl cursor-pointer text-sm sm:text-base">
+                  <FaKey className="mr-2 text-sm" />
+                  Suggest a CD Key
+                </ContactModalTrigger>
+              }
+            />
 
-            {/* Report Keys Section */}
-            <div className="text-center lg:text-left md:border-l lg:border-white/10 lg:pl-8 pt-6 lg:pt-0 border-t md:border-t-0 border-white/10">
-              <div className="inline-flex items-center justify-center w-12 h-12 sm:w-14 sm:h-14 lg:w-16 lg:h-16 bg-amber-500/20 rounded-xl sm:rounded-2xl mb-3 sm:mb-4 lg:mb-6">
-                <FaExclamationCircle className="w-6 h-6 sm:w-7 sm:h-7 lg:w-8 lg:h-8 text-amber-400" />
-              </div>
-              <h3 className="text-lg sm:text-xl lg:text-2xl xl:text-3xl font-bold text-white mb-2 sm:mb-3">
-                Found a Problem with a Key?
-              </h3>
-              <p className="text-gray-300 text-sm sm:text-base lg:text-lg mb-4 sm:mb-5 lg:mb-6 leading-relaxed px-2">
-                Help keep our database accurate by reporting keys that are expired, reached their limit, or are still
-                working perfectly.
-              </p>
-              <div className="flex flex-wrap justify-center lg:justify-start gap-2 sm:gap-3 text-xs sm:text-sm">
-                <div className="flex items-center px-3 py-1.5 sm:px-4 sm:py-2 bg-green-500/20 border border-green-500/30 rounded-lg">
-                  <div className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-green-400 rounded-full mr-1.5 sm:mr-2"></div>
-                  <span className="text-green-300 font-medium whitespace-nowrap">Report Working</span>
+            <ContributeSection
+              className="md:border-l lg:border-white/10 lg:pl-8 pt-6 lg:pt-0 border-t md:border-t-0 border-white/10"
+              iconContainerClassName="bg-amber-500/20"
+              icon={<FaExclamationCircle className="w-6 h-6 sm:w-7 sm:h-7 lg:w-8 lg:h-8 text-amber-400" />}
+              title="Found a Problem with a Key?"
+              description="Help keep our database accurate by reporting keys that are expired, reached their limit, or are still working perfectly."
+              content={
+                <div className="flex flex-wrap justify-center lg:justify-start gap-2 sm:gap-3 text-xs sm:text-sm">
+                  <div className="flex items-center px-3 py-1.5 sm:px-4 sm:py-2 bg-green-500/20 border border-green-500/30 rounded-lg">
+                    <div className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-green-400 rounded-full mr-1.5 sm:mr-2"></div>
+                    <span className="text-green-300 font-medium whitespace-nowrap">Report Working</span>
+                  </div>
+                  <div className="flex items-center px-3 py-1.5 sm:px-4 sm:py-2 bg-red-500/20 border border-red-500/30 rounded-lg">
+                    <div className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-red-400 rounded-full mr-1.5 sm:mr-2"></div>
+                    <span className="text-red-300 font-medium whitespace-nowrap">Report Expired</span>
+                  </div>
+                  <div className="flex items-center px-3 py-1.5 sm:px-4 sm:py-2 bg-yellow-500/20 border border-yellow-500/30 rounded-lg">
+                    <div className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-yellow-400 rounded-full mr-1.5 sm:mr-2"></div>
+                    <span className="text-yellow-300 font-medium whitespace-nowrap">Report Limit</span>
+                  </div>
                 </div>
-                <div className="flex items-center px-3 py-1.5 sm:px-4 sm:py-2 bg-red-500/20 border border-red-500/30 rounded-lg">
-                  <div className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-red-400 rounded-full mr-1.5 sm:mr-2"></div>
-                  <span className="text-red-300 font-medium whitespace-nowrap">Report Expired</span>
-                </div>
-                <div className="flex items-center px-3 py-1.5 sm:px-4 sm:py-2 bg-yellow-500/20 border border-yellow-500/30 rounded-lg">
-                  <div className="w-1.5 h-1.5 sm:w-2 sm:h-2 bg-yellow-400 rounded-full mr-1.5 sm:mr-2"></div>
-                  <span className="text-yellow-300 font-medium whitespace-nowrap">Report Limit</span>
-                </div>
-              </div>
-            </div>
+              }
+            />
           </div>
         </div>
       </div>

--- a/src/components/program/ProgramAboutSection.tsx
+++ b/src/components/program/ProgramAboutSection.tsx
@@ -9,7 +9,7 @@ export default function ProgramAboutSection({ program }: { program: Program }) {
   return (
     <section className="py-10 sm:py-16 bg-linear-to-b from-gray-900 via-gray-800 to-gray-900 border-t border-white/5">
       <div className="max-w-360 mx-auto px-4 sm:px-6 lg:px-8">
-        <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold text-white mb-10 sm:mb-12 text-center">
+        <h2 className="text-2xl lg:text-3xl xl:text-4xl font-bold text-white mb-10 sm:mb-12 text-center">
           About <span className="text-gradient-pro">{formatProgramDisplayTitle(program)}</span>
         </h2>
         <div className="max-w-2xl lg:max-w-5xl mx-auto space-y-14 sm:space-y-16 lg:space-y-20">

--- a/src/components/program/ProgramFaqSection.tsx
+++ b/src/components/program/ProgramFaqSection.tsx
@@ -10,14 +10,12 @@ export default function ProgramFaqSection({ programTitle, items }: { programTitl
       className="py-8 sm:py-10 bg-linear-to-b from-gray-900 via-gray-800 to-gray-900 border-t border-white/5">
       <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col gap-8 lg:gap-16 xl:gap-24 items-center">
-          <div className="lg:w-[min(100%,420px)] lg:shrink-0">
-            <h2 className="flex flex-col items-center text-2xl lg:text-3xl xl:text-4xl font-bold text-white text-center">
-              <span>{programTitle}</span>
-              <span className="text-gradient-pro">Frequently Asked Questions</span>
-            </h2>
-          </div>
+          <h2 className="flex flex-col items-center text-2xl lg:text-3xl xl:text-4xl font-bold text-white text-center">
+            <span>{programTitle}</span>
+            <span className="text-gradient-pro">Frequently Asked Questions</span>
+          </h2>
 
-          <div className="min-w-0 flex-1 space-y-2">
+          <div className="space-y-2">
             {items.map((item, index) => (
               <FaqAccordionItem key={`${item.question}-${index}`} question={item.question} answer={item.answer} />
             ))}

--- a/src/components/program/ProgramInformation.tsx
+++ b/src/components/program/ProgramInformation.tsx
@@ -63,9 +63,9 @@ export default function ProgramInformation({
   return (
     <section className="bg-linear-to-b from-gray-900 via-gray-800 to-gray-900 py-6 sm:py-10">
       <div className="max-w-3xl lg:max-w-360 mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8 lg:gap-12">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8 lg:gap-12 relative">
           {/* Desktop: program image (left column) */}
-          <div className="hidden lg:order-1 lg:flex flex-col gap-4">
+          <div className="hidden lg:order-1 lg:flex flex-col gap-4 sticky top-20 h-fit">
             <ProgramInformationVisual program={program} variant="desktop" />
             <FacebookGroupHeroPromo socialData={socialData} />
           </div>

--- a/src/components/program/cdkeys/CDKeyTable.tsx
+++ b/src/components/program/cdkeys/CDKeyTable.tsx
@@ -80,7 +80,7 @@ export default function CDKeyTable({
           <div className="px-4 sm:px-6 lg:px-8 py-4 sm:py-5 lg:py-6 border-b border-white/10">
             <div className="flex items-start justify-between gap-3">
               <div className="flex-1 min-w-0">
-                <h2 className="text-lg sm:text-xl lg:text-2xl xl:text-3xl font-bold leading-tight mb-1.5 sm:mb-2">
+                <h2 className="text-2xl lg:text-3xl xl:text-4xl font-bold leading-tight mb-1.5 sm:mb-2">
                   <span className="text-white">{formatProgramDisplayTitle(program)}</span>
                   <span className="text-gray-500 font-normal mx-1 sm:mx-1.5" aria-hidden>
                     —


### PR DESCRIPTION
## Summary

Program page UI polish: reusable contribute section block, tuned section typography, and a guarded key count badge on home program cards.

## Changelog

<!-- tags: ui, fix, enhance -->

### Highlights

- Extracted reusable ContributeBanner / contribute section block
- Program about, FAQ, information, and CD key table typography balance
- Home ProgramCard key count badge render guard

---

## Environment Variables

None

## Testing

- Program page sections render with updated spacing and hierarchy
- Program cards without keys do not show broken badge state

## Technical Details

Touches AboutSectionBlock, ProgramAboutSection, ProgramFaqSection, ProgramInformation, CDKeyTable.
