### PR TITLE
feat(sanity): nested featured data, portable program descriptions, and stronger cd key studio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@giscus/react": "^3.1.0",
+        "@portabletext/react": "^6.0.3",
+        "@portabletext/toolkit": "^5.0.2",
+        "@portabletext/types": "^4.0.2",
         "@sanity/client": "^7.17.0",
         "@sanity/image-url": "^2.0.3",
         "@sanity/vision": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   },
   "dependencies": {
     "@giscus/react": "^3.1.0",
+    "@portabletext/react": "^6.0.3",
+    "@portabletext/toolkit": "^5.0.2",
+    "@portabletext/types": "^4.0.2",
     "@sanity/client": "^7.17.0",
     "@sanity/image-url": "^2.0.3",
     "@sanity/vision": "^5.15.0",

--- a/src/app/admin/programs/page.tsx
+++ b/src/app/admin/programs/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { FaWrench } from "react-icons/fa";
 import { IdealImage } from "@/src/components/general/IdealImage";
 import ProgramEditModal from "@/src/components/admin/programs/ProgramEditModal";
+import { portableTextExcerpt } from "@/src/lib/portableText/toPlainText";
 import FeaturedProgramSettings from "@/src/components/admin/programs/FeaturedProgramSettings";
 import { getWorkingKeysCount } from "@/src/lib/admin/adminHelpers";
 
@@ -111,7 +112,7 @@ export default function ProgramsPage() {
         {filteredPrograms.map(program => (
           <div
             key={program._id ?? program.slug.current}
-            className="bg-white rounded-xl shadow-soft border border-gray-200 overflow-hidden">
+            className="bg-white rounded-xl shadow-soft border border-gray-200 overflow-hidden flex flex-col">
             {/* Program Image */}
             <div className="h-48 bg-linear-to-br from-blue-500 to-purple-600 flex items-center justify-center">
               {program.image ? (
@@ -122,12 +123,12 @@ export default function ProgramsPage() {
             </div>
 
             {/* Program Content */}
-            <div className="p-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-2 line-clamp-1">{program.title}</h3>
-              <p className="text-sm text-gray-600 mb-4 line-clamp-2">{program.description}</p>
+            <div className="py-4 sm:py-5 lg:py-6 px-4 sm:px-5 flex flex-col grow bg-linear-to-b from-white to-gray-50/50">
+              <h3 className="text-lg font-semibold text-gray-900 mb-2 line-clamp-2">{program.title}</h3>
+              <p className="text-sm text-gray-600 mb-4 line-clamp-2">{portableTextExcerpt(program.description, 200)}</p>
 
               {/* Program Stats */}
-              <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center justify-between mb-4 mt-auto">
                 <div className="text-sm text-gray-500">
                   <span className="font-medium">{program.cdKeys?.length || 0}</span> CD Keys
                 </div>

--- a/src/app/api/v1/admin/programs/[id]/route.ts
+++ b/src/app/api/v1/admin/programs/[id]/route.ts
@@ -39,7 +39,14 @@ function parseBody(body: unknown): Record<string, unknown> {
     out.description = typeof b.description === "string" ? b.description.trim() : "";
   }
   if (b.featuredDescription !== undefined) {
-    out.featuredDescription = typeof b.featuredDescription === "string" ? b.featuredDescription.trim() : undefined;
+    if (b.featuredDescription === null) {
+      out.featuredDescription = null;
+    } else if (typeof b.featuredDescription === "string") {
+      const t = b.featuredDescription.trim();
+      out.featuredDescription = t.length ? t : null;
+    } else {
+      out.featuredDescription = null;
+    }
   }
   if (b.downloadLink !== undefined) {
     const v = typeof b.downloadLink === "string" ? b.downloadLink.trim() : "";
@@ -124,14 +131,31 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     if (updates.title !== undefined) patch.set({ title: updates.title as string });
     if (updates.slug !== undefined) patch.set({ slug: { _type: "slug", current: updates.slug as string } });
     if (updates.description !== undefined) patch.set({ description: updates.description as string });
-    if (updates.featuredDescription !== undefined)
-      patch.set({ featuredDescription: (updates.featuredDescription as string) ?? null });
     if (updates.downloadLink !== undefined) patch.set({ downloadLink: (updates.downloadLink as string) ?? null });
     if (updates.imageAssetId !== undefined) {
       patch.set({ image: buildImageReference(updates.imageAssetId as string | null) });
     }
-    if (updates.showcaseGifAssetId !== undefined) {
-      patch.set({ showcaseGif: buildImageReference(updates.showcaseGifAssetId as string | null) });
+    if (updates.featuredDescription !== undefined || updates.showcaseGifAssetId !== undefined) {
+      type FeaturedRow = {
+        featured?: { featuredDescription?: string | null; showcaseGif?: unknown } | null;
+        featuredDescription?: string | null;
+        showcaseGif?: unknown;
+      };
+      const row = await client.fetch<FeaturedRow | null>(
+        `*[_type == "program" && _id == $id][0]{ featured, featuredDescription, showcaseGif }`,
+        { id }
+      );
+      const prevDesc = row?.featured?.featuredDescription ?? row?.featuredDescription ?? null;
+      const prevGif = row?.featured?.showcaseGif ?? row?.showcaseGif ?? null;
+      const nextFeatured = {
+        featuredDescription:
+          updates.featuredDescription !== undefined ? (updates.featuredDescription as string | null) : prevDesc,
+        showcaseGif:
+          updates.showcaseGifAssetId !== undefined
+            ? buildImageReference(updates.showcaseGifAssetId as string | null)
+            : prevGif
+      };
+      patch.set({ featured: nextFeatured });
     }
 
     const result = await patch.commit();

--- a/src/app/api/v1/admin/programs/[id]/route.ts
+++ b/src/app/api/v1/admin/programs/[id]/route.ts
@@ -3,6 +3,7 @@ import { revalidatePath } from "next/cache";
 import { requireAdminSession } from "@/src/lib/admin/adminAuth";
 import { client } from "@/src/sanity/lib/client";
 import { buildImageReference } from "@/src/lib/admin/adminHelpers";
+import { plainTextToPortableText } from "@/src/lib/portableText/plainTextToPortableText";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 
@@ -130,7 +131,9 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     const patch = client.patch(id);
     if (updates.title !== undefined) patch.set({ title: updates.title as string });
     if (updates.slug !== undefined) patch.set({ slug: { _type: "slug", current: updates.slug as string } });
-    if (updates.description !== undefined) patch.set({ description: updates.description as string });
+    if (updates.description !== undefined) {
+      patch.set({ description: plainTextToPortableText(updates.description as string) });
+    }
     if (updates.downloadLink !== undefined) patch.set({ downloadLink: (updates.downloadLink as string) ?? null });
     if (updates.imageAssetId !== undefined) {
       patch.set({ image: buildImageReference(updates.imageAssetId as string | null) });

--- a/src/app/api/v1/admin/programs/[id]/route.ts
+++ b/src/app/api/v1/admin/programs/[id]/route.ts
@@ -138,15 +138,13 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     if (updates.featuredDescription !== undefined || updates.showcaseGifAssetId !== undefined) {
       type FeaturedRow = {
         featured?: { featuredDescription?: string | null; showcaseGif?: unknown } | null;
-        featuredDescription?: string | null;
-        showcaseGif?: unknown;
       };
       const row = await client.fetch<FeaturedRow | null>(
-        `*[_type == "program" && _id == $id][0]{ featured, featuredDescription, showcaseGif }`,
+        `*[_type == "program" && _id == $id][0]{ featured }`,
         { id }
       );
-      const prevDesc = row?.featured?.featuredDescription ?? row?.featuredDescription ?? null;
-      const prevGif = row?.featured?.showcaseGif ?? row?.showcaseGif ?? null;
+      const prevDesc = row?.featured?.featuredDescription ?? null;
+      const prevGif = row?.featured?.showcaseGif ?? null;
       const nextFeatured = {
         featuredDescription:
           updates.featuredDescription !== undefined ? (updates.featuredDescription as string | null) : prevDesc,

--- a/src/app/api/v1/admin/programs/route.ts
+++ b/src/app/api/v1/admin/programs/route.ts
@@ -3,6 +3,7 @@ import { revalidatePath } from "next/cache";
 import { requireAdminSession } from "@/src/lib/admin/adminAuth";
 import { client } from "@/src/sanity/lib/client";
 import { buildImageReference } from "@/src/lib/admin/adminHelpers";
+import { plainTextToPortableText } from "@/src/lib/portableText/plainTextToPortableText";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 
@@ -91,7 +92,7 @@ export async function POST(req: NextRequest) {
       _type: "program",
       title,
       slug: { _type: "slug", current: slug },
-      description,
+      description: plainTextToPortableText(description),
       ...(Object.keys(featured).length > 0 ? { featured } : {}),
       ...(downloadLink && { downloadLink }),
       ...(buildImageReference(imageAssetId) && { image: buildImageReference(imageAssetId) }),

--- a/src/app/api/v1/admin/programs/route.ts
+++ b/src/app/api/v1/admin/programs/route.ts
@@ -79,15 +79,22 @@ export async function POST(req: NextRequest) {
       ]);
     }
 
+    const featured: {
+      featuredDescription?: string;
+      showcaseGif?: NonNullable<ReturnType<typeof buildImageReference>>;
+    } = {};
+    if (featuredDescription) featured.featuredDescription = featuredDescription;
+    const showcaseRef = buildImageReference(showcaseGifAssetId);
+    if (showcaseRef) featured.showcaseGif = showcaseRef;
+
     const doc = await client.create({
       _type: "program",
       title,
       slug: { _type: "slug", current: slug },
       description,
-      ...(featuredDescription && { featuredDescription }),
+      ...(Object.keys(featured).length > 0 ? { featured } : {}),
       ...(downloadLink && { downloadLink }),
       ...(buildImageReference(imageAssetId) && { image: buildImageReference(imageAssetId) }),
-      ...(buildImageReference(showcaseGifAssetId) && { showcaseGif: buildImageReference(showcaseGifAssetId) }),
       cdKeys: []
     });
 

--- a/src/app/program/[slug]/page.tsx
+++ b/src/app/program/[slug]/page.tsx
@@ -36,73 +36,68 @@ export async function generateMetadata({ params }: ProgramPageProps) {
 }
 
 export default async function ProgramPage({ params }: ProgramPageProps) {
-  try {
-    const { slug } = await params;
+  const { slug } = await params;
 
-    const program = await getProgramWithUpdatedKeys(slug);
+  const program = await getProgramWithUpdatedKeys(slug);
 
-    if (!program) return notFound();
+  if (!program) return notFound();
 
-    const sortedCdKeys = sortCdKeysByStatus(program.cdKeys || []);
+  const sortedCdKeys = sortCdKeysByStatus(program.cdKeys || []);
 
-    const totalKeys = sortedCdKeys.length;
-    const workingKeys = sortedCdKeys.filter((cd: CDKey) => cd.status === "active" || cd.status === "new").length;
-    const highestKeyVersion = getHighestKeyVersion(sortedCdKeys);
-    const vendorReleaseForIntro = getCdKeyTableIntroVendorRelease(program, highestKeyVersion);
-    const introVersionConfirmation = getCdKeyTableIntroVersionConfirmation(program, highestKeyVersion);
-    const versionSummaryLine = formatVersionSummaryLine(program, highestKeyVersion);
+  const totalKeys = sortedCdKeys.length;
+  const workingKeys = sortedCdKeys.filter((cd: CDKey) => cd.status === "active" || cd.status === "new").length;
+  const highestKeyVersion = getHighestKeyVersion(sortedCdKeys);
+  const vendorReleaseForIntro = getCdKeyTableIntroVendorRelease(program, highestKeyVersion);
+  const introVersionConfirmation = getCdKeyTableIntroVersionConfirmation(program, highestKeyVersion);
+  const versionSummaryLine = formatVersionSummaryLine(program, highestKeyVersion);
 
-    const [allPrograms, storeData, socialLinks] = await Promise.all([
-      client.fetch(popularProgramsQuery),
-      client.fetch(storeDetailsQuery),
-      client.fetch(socialLinksQuery)
-    ]);
+  const [allPrograms, storeData, socialLinks] = await Promise.all([
+    client.fetch(popularProgramsQuery),
+    client.fetch(storeDetailsQuery),
+    client.fetch(socialLinksQuery)
+  ]);
 
-    const socialData: SocialData = {
-      socialLinks: socialLinks || []
-    };
+  const socialData: SocialData = {
+    socialLinks: socialLinks || []
+  };
 
-    const hdrs = await headers();
-    const { isSpammer, visitorHint } = await getVisitorContextForPublicPage(hdrs);
-    const relatedPrograms = allPrograms
-      .filter((p: { slug: { current: string } }) => p.slug.current !== slug)
-      .slice(0, 5);
+  const hdrs = await headers();
+  const { isSpammer, visitorHint } = await getVisitorContextForPublicPage(hdrs);
+  const relatedPrograms = allPrograms
+    .filter((p: { slug: { current: string } }) => p.slug.current !== slug)
+    .slice(0, 5);
 
-    const storeInfo = storeData?.[0] || { title: "KeyAway" };
-    const jsonLd = generateProgramPageJsonLd(program, workingKeys, totalKeys, storeInfo);
+  const storeInfo = storeData?.[0] || { title: "KeyAway" };
+  const jsonLd = generateProgramPageJsonLd(program, workingKeys, totalKeys, storeInfo);
 
-    return (
-      <>
-        <JsonLd data={jsonLd} />
-        <main className="min-h-screen bg-linear-to-b from-gray-900 via-gray-800 to-gray-900">
-          <ProgramInformation
-            program={program}
-            totalKeys={totalKeys}
-            workingKeys={workingKeys}
-            socialData={socialData}
-            visitorHint={visitorHint}
-          />
-          <CDKeyTable
-            cdKeys={sortedCdKeys}
-            slug={slug}
-            program={program}
-            programTitle={program.title}
-            isSpammerVisitor={isSpammer}
-            vendorReleaseForIntro={vendorReleaseForIntro}
-            introVersionConfirmation={introVersionConfirmation}
-            versionSummaryLine={versionSummaryLine}
-          />
-          <ContributeBanner />
-          <ProgramAboutSection program={program} />
-          <ActivationInstructions programTitle={program.title} downloadLink={program.downloadLink} />
-          <ProgramFaqSection programTitle={program.title} items={program.faq ?? []} />
-          <RelatedPrograms programs={relatedPrograms} />
-          <CommentsSection />
-        </main>
-      </>
-    );
-  } catch (error) {
-    console.error("Error in ProgramPage:", error);
-    return notFound();
-  }
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+      <main className="min-h-screen bg-linear-to-b from-gray-900 via-gray-800 to-gray-900">
+        <ProgramInformation
+          program={program}
+          totalKeys={totalKeys}
+          workingKeys={workingKeys}
+          socialData={socialData}
+          visitorHint={visitorHint}
+        />
+        <CDKeyTable
+          cdKeys={sortedCdKeys}
+          slug={slug}
+          program={program}
+          programTitle={program.title}
+          isSpammerVisitor={isSpammer}
+          vendorReleaseForIntro={vendorReleaseForIntro}
+          introVersionConfirmation={introVersionConfirmation}
+          versionSummaryLine={versionSummaryLine}
+        />
+        <ContributeBanner />
+        <ProgramAboutSection program={program} />
+        <ActivationInstructions programTitle={program.title} downloadLink={program.downloadLink} />
+        <ProgramFaqSection programTitle={program.title} items={program.faq ?? []} />
+        <RelatedPrograms programs={relatedPrograms} />
+        <CommentsSection />
+      </main>
+    </>
+  );
 }

--- a/src/components/admin/programs/FeaturedProgramSettings.tsx
+++ b/src/components/admin/programs/FeaturedProgramSettings.tsx
@@ -7,6 +7,7 @@ import { client } from "@/src/sanity/lib/client";
 import { featuredProgramSettingsQuery } from "@/src/lib/sanity/queries";
 import { IdealImage } from "@/src/components/general/IdealImage";
 import { getWorkingKeysCount } from "@/src/lib/admin/adminHelpers";
+import type { PortableTextBlock } from "@portabletext/types";
 import type { Program, ProgramFeatured } from "@/src/types/program";
 
 interface FeaturedProgramSettingsData {
@@ -15,7 +16,7 @@ interface FeaturedProgramSettingsData {
     _id: string;
     title: string;
     slug: { current: string };
-    description?: string;
+    description?: PortableTextBlock[] | string;
     featured?: ProgramFeatured;
     image?: { asset: { _ref: string } };
     cdKeys?: Array<{ status: string }>;

--- a/src/components/admin/programs/FeaturedProgramSettings.tsx
+++ b/src/components/admin/programs/FeaturedProgramSettings.tsx
@@ -7,7 +7,7 @@ import { client } from "@/src/sanity/lib/client";
 import { featuredProgramSettingsQuery } from "@/src/lib/sanity/queries";
 import { IdealImage } from "@/src/components/general/IdealImage";
 import { getWorkingKeysCount } from "@/src/lib/admin/adminHelpers";
-import type { Program } from "@/src/types/program";
+import type { Program, ProgramFeatured } from "@/src/types/program";
 
 interface FeaturedProgramSettingsData {
   _id?: string;
@@ -16,9 +16,8 @@ interface FeaturedProgramSettingsData {
     title: string;
     slug: { current: string };
     description?: string;
-    featuredDescription?: string;
+    featured?: ProgramFeatured;
     image?: { asset: { _ref: string } };
-    showcaseGif?: { asset: { _ref: string } };
     cdKeys?: Array<{ status: string }>;
   };
   rotationSchedule?: "weekly" | "biweekly" | "monthly";

--- a/src/components/admin/programs/ProgramEditModal.tsx
+++ b/src/components/admin/programs/ProgramEditModal.tsx
@@ -43,10 +43,10 @@ export default function ProgramEditModal({ program, isOpen, onClose, onSaved, on
       setTitle(program.title);
       setSlug(program.slug?.current ?? "");
       setDescription(program.description ?? "");
-      setFeaturedDescription(program.featuredDescription ?? "");
+      setFeaturedDescription(program.featured?.featuredDescription?.trim() ?? "");
       setDownloadLink(program.downloadLink ?? "");
       setImageAssetId(program.image?.asset?._ref ?? null);
-      setShowcaseGifAssetId(program.showcaseGif?.asset?._ref ?? null);
+      setShowcaseGifAssetId(program.featured?.showcaseGif?.asset?._ref ?? null);
       setDeleteExpanded(false);
       setDeleteConfirm("");
       setDeleteError(null);
@@ -116,7 +116,11 @@ export default function ProgramEditModal({ program, isOpen, onClose, onSaved, on
         title: title.trim(),
         slug: slugValidation.normalized,
         description: description.trim(),
-        featuredDescription: featuredDescription.trim() || undefined,
+        ...(program?._id
+          ? { featuredDescription: featuredDescription.trim() }
+          : featuredDescription.trim()
+            ? { featuredDescription: featuredDescription.trim() }
+            : {}),
         downloadLink: downloadLink.trim() || undefined,
         ...(program?._id ? { imageAssetId: imageAssetId ?? null } : imageAssetId ? { imageAssetId } : {}),
         ...(program?._id

--- a/src/components/admin/programs/ProgramEditModal.tsx
+++ b/src/components/admin/programs/ProgramEditModal.tsx
@@ -8,6 +8,7 @@ import DeleteProgramModal from "./DeleteProgramModal";
 import SlugChangeConfirmModal from "./SlugChangeConfirmModal";
 import ImageLibraryModal from "./ImageLibraryModal";
 import ProgramImageField from "./ProgramImageField";
+import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
 
 interface ProgramEditModalProps {
   program: Program | null;
@@ -42,8 +43,12 @@ export default function ProgramEditModal({ program, isOpen, onClose, onSaved, on
     if (program) {
       setTitle(program.title);
       setSlug(program.slug?.current ?? "");
-      setDescription(program.description ?? "");
-      setFeaturedDescription(program.featured?.featuredDescription?.trim() ?? "");
+      setDescription(portableTextToPlainText(program.description));
+      setFeaturedDescription(
+        typeof program.featured?.featuredDescription === "string"
+          ? program.featured.featuredDescription.trim()
+          : portableTextToPlainText(program.featured?.featuredDescription)
+      );
       setDownloadLink(program.downloadLink ?? "");
       setImageAssetId(program.image?.asset?._ref ?? null);
       setShowcaseGifAssetId(program.featured?.showcaseGif?.asset?._ref ?? null);

--- a/src/components/home/FeaturedProgramSection.tsx
+++ b/src/components/home/FeaturedProgramSection.tsx
@@ -6,14 +6,17 @@ import { IdealImage } from "@/src/components/general/IdealImage";
 import { trackEvent } from "@/src/lib/analytics/trackEvent";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
+import type { PortableTextBlock } from "@portabletext/types";
 import type { ProgramFeatured } from "@/src/types/program";
+import RichText from "@/src/components/portableText/RichText";
+import { portableTextHasContent } from "@/src/lib/portableText/toPlainText";
 
 interface FeaturedProgramSectionProps {
   program: {
     _id: string;
     title: string;
     slug: { current: string };
-    description: string;
+    description: PortableTextBlock[] | string;
     featured?: ProgramFeatured;
     image?: { asset: { url?: string; _ref?: string } };
     downloadLink?: string;
@@ -27,7 +30,10 @@ interface FeaturedProgramSectionProps {
 export default function FeaturedProgramSection({ program }: FeaturedProgramSectionProps) {
   if (!program) return null;
 
-  const description = program.featured?.featuredDescription?.trim() || program.description;
+  const fd = program.featured?.featuredDescription;
+  const useFeatured =
+    typeof fd === "string" ? fd.trim().length > 0 : portableTextHasContent(fd ?? null);
+  const introBody = useFeatured ? fd : program.description;
   const imageSource = program.featured?.showcaseGif || program.image;
 
   return (
@@ -73,7 +79,10 @@ export default function FeaturedProgramSection({ program }: FeaturedProgramSecti
                 <div>
                   <h3 className="text-2xl lg:text-3xl font-bold text-white mb-2 sm:mb-3">{program.title}</h3>
                   <div className="text-sm sm:text-base text-gray-300 leading-relaxed space-y-3">
-                    <p>{description}</p>
+                    <RichText
+                      value={introBody}
+                      className="[&_a]:text-primary-300 [&_blockquote]:border-white/20"
+                    />
                     <p>
                       With {program.workingKeys} verified working CD keys available, you can unlock the full premium
                       features of this professional software at no cost. Our community has verified these keys, ensuring

--- a/src/components/home/FeaturedProgramSection.tsx
+++ b/src/components/home/FeaturedProgramSection.tsx
@@ -6,6 +6,7 @@ import { IdealImage } from "@/src/components/general/IdealImage";
 import { trackEvent } from "@/src/lib/analytics/trackEvent";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
+import type { ProgramFeatured } from "@/src/types/program";
 
 interface FeaturedProgramSectionProps {
   program: {
@@ -13,23 +14,21 @@ interface FeaturedProgramSectionProps {
     title: string;
     slug: { current: string };
     description: string;
-    featuredDescription?: string;
+    featured?: ProgramFeatured;
     image?: { asset: { url?: string; _ref?: string } };
     downloadLink?: string;
     totalKeys: number;
     workingKeys: number;
     viewCount: number;
     downloadCount: number;
-    showcaseGif?: { asset: { url?: string; _ref?: string } };
   } | null;
 }
 
 export default function FeaturedProgramSection({ program }: FeaturedProgramSectionProps) {
   if (!program) return null;
 
-  // Use featuredDescription from program if available, otherwise use regular description
-  const description = program.featuredDescription || program.description;
-  const imageSource = program.showcaseGif || program.image;
+  const description = program.featured?.featuredDescription?.trim() || program.description;
+  const imageSource = program.featured?.showcaseGif || program.image;
 
   return (
     <section

--- a/src/components/home/ProgramCard.tsx
+++ b/src/components/home/ProgramCard.tsx
@@ -4,6 +4,7 @@ import { FaEye, FaDownload, FaKey, FaChevronRight } from "react-icons/fa";
 import { ProgramCardProps } from "@/src/types/home";
 import { trackInteraction } from "@/src/lib/analytics/trackInteraction";
 import { INTERACTION_IDS, SECTIONS } from "@/src/lib/analytics/interactionCatalog";
+import { portableTextHasContent, portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
 
 export default function ProgramCard({
   program,
@@ -73,18 +74,20 @@ export default function ProgramCard({
       </Link>
 
       {/* Content */}
-      <div className="py-4 sm:py-5 lg:py-6 px-4 sm:px-5 flex flex-col flex-grow bg-linear-to-b from-white to-gray-50/50">
-        <h2 className="text-base sm:text-lg lg:text-xl font-bold text-gray-900 mb-2 sm:mb-3 line-clamp-2 group-hover:text-primary-700 transition-colors leading-tight">
+      <div className="p-5 flex flex-col grow bg-linear-to-b from-white to-gray-50/50">
+        <h2 className="text-base sm:text-lg lg:text-xl font-bold text-gray-900 mb-1 line-clamp-2 group-hover:text-primary-700 transition-colors leading-tight">
           {program.title}
         </h2>
 
-        <p className="text-gray-600 text-xs sm:text-sm mb-3 sm:mb-4 line-clamp-3 sm:line-clamp-4 leading-relaxed">
-          {program.description}
-        </p>
+        {portableTextHasContent(program.description) ? (
+          <p className="text-gray-600 text-xs sm:text-sm mb-2 line-clamp-3 sm:line-clamp-4 leading-relaxed">
+            {portableTextToPlainText(program.description)}
+          </p>
+        ) : null}
 
         {/* Stats above CTA */}
         {showStats && (stats?.viewCount !== undefined || stats?.downloadCount !== undefined) && (
-          <div className="flex items-center justify-center gap-3 sm:gap-4 text-xs text-gray-500 mb-3 sm:mb-4 bg-gray-50/80 rounded-lg py-1.5 sm:py-2 px-2 sm:px-3">
+          <div className="flex items-center justify-center gap-3 sm:gap-4 text-xs text-gray-500 mb-2 mt-auto bg-gray-50/80 rounded-lg py-1.5 sm:py-2 px-2 sm:px-3">
             {stats?.viewCount !== undefined && (
               <div className="flex items-center space-x-1">
                 <FaEye className="w-2.5 h-2.5 sm:w-3 sm:h-3 text-blue-500" />
@@ -110,7 +113,7 @@ export default function ProgramCard({
               programSlug: program.slug.current
             })
           }
-          className="inline-flex items-center justify-center w-full bg-linear-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 text-white font-semibold px-4 sm:px-5 lg:px-6 py-2.5 sm:py-3 text-sm sm:text-base rounded-lg sm:rounded-xl transition-all duration-200 transform hover:scale-[1.02] hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 mt-auto relative overflow-hidden">
+          className="inline-flex items-center justify-center w-full bg-linear-to-r from-primary-600 to-primary-700 hover:from-primary-700 hover:to-primary-800 text-white font-semibold px-4 sm:px-5 lg:px-6 py-2.5 sm:py-3 text-sm sm:text-base rounded-lg sm:rounded-xl transition-all duration-200 transform hover:scale-[1.02] hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 relative overflow-hidden">
           <span className="relative z-10">View Keys</span>
           <FaChevronRight className="ml-1.5 sm:ml-2 w-3 h-3 sm:w-3.5 sm:h-3.5 transition-transform group-hover:translate-x-1 relative z-10" />
           {/* Button shine effect */}

--- a/src/components/portableText/RichText.tsx
+++ b/src/components/portableText/RichText.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { PortableText, type PortableTextComponents } from "@portabletext/react";
+import type { PortableTextBlock } from "@portabletext/types";
+
+import { portableTextHasContent } from "@/src/lib/portableText/toPlainText";
+
+function valueToBlocks(value: unknown): PortableTextBlock[] | null {
+  if (value == null) return null;
+  if (typeof value === "string") {
+    const t = value.trim();
+    if (!t) return null;
+    return [
+      {
+        _type: "block",
+        _key: "legacy-str",
+        style: "normal",
+        markDefs: [],
+        children: [{ _type: "span", _key: "legacy-span", text: t, marks: [] }]
+      } as PortableTextBlock
+    ];
+  }
+  if (Array.isArray(value) && value.length > 0) return value as PortableTextBlock[];
+  if (typeof value === "object" && value !== null && "_type" in value) {
+    return [value as PortableTextBlock];
+  }
+  return null;
+}
+
+const components: Partial<PortableTextComponents> = {
+  marks: {
+    link: ({ children, value }) => {
+      const href = typeof value?.href === "string" ? value.href : "";
+      if (!href) return <span>{children}</span>;
+      const external = /^https?:\/\//i.test(href) || href.startsWith("mailto:") || href.startsWith("tel:");
+      return (
+        <a
+          href={href}
+          className="text-primary-400 underline decoration-primary-400/60 underline-offset-2 hover:text-primary-300"
+          {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}>
+          {children}
+        </a>
+      );
+    },
+    strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+    em: ({ children }) => <em className="italic">{children}</em>,
+    code: ({ children }) => (
+      <code className="rounded bg-black/30 px-1 py-0.5 font-mono text-[0.9em] text-gray-200">{children}</code>
+    ),
+    underline: ({ children }) => <span className="underline">{children}</span>,
+    "strike-through": ({ children }) => <span className="line-through opacity-80">{children}</span>
+  },
+  block: {
+    normal: ({ children }) => <p className="mb-3 last:mb-0 leading-relaxed">{children}</p>,
+    h1: ({ children }) => <h4 className="mb-2 mt-4 text-2xl font-bold first:mt-0">{children}</h4>,
+    h2: ({ children }) => <h4 className="mb-2 mt-4 text-xl font-bold first:mt-0">{children}</h4>,
+    h3: ({ children }) => <h4 className="mb-2 mt-3 text-lg font-semibold first:mt-0">{children}</h4>,
+    h4: ({ children }) => <h4 className="mb-2 mt-3 text-base font-semibold first:mt-0">{children}</h4>,
+    blockquote: ({ children }) => (
+      <blockquote className="my-3 border-l-4 border-primary-500/60 pl-4 opacity-90 italic">{children}</blockquote>
+    )
+  },
+  list: {
+    bullet: ({ children }) => <ul className="my-3 list-disc space-y-1 pl-5">{children}</ul>,
+    number: ({ children }) => <ol className="my-3 list-decimal space-y-1 pl-5">{children}</ol>
+  },
+  listItem: {
+    bullet: ({ children }) => <li className="leading-relaxed">{children}</li>,
+    number: ({ children }) => <li className="leading-relaxed">{children}</li>
+  }
+};
+
+export default function RichText({ value, className }: { value: unknown; className?: string }) {
+  const blocks = valueToBlocks(value);
+  if (!blocks || !portableTextHasContent(blocks)) return null;
+  return (
+    <div className={className}>
+      <PortableText value={blocks} components={components} />
+    </div>
+  );
+}

--- a/src/components/program/ProgramInformation.tsx
+++ b/src/components/program/ProgramInformation.tsx
@@ -11,6 +11,8 @@ import TrustpilotReviewWidget from "@/src/components/trustpilot/TrustpilotReview
 import { getTrustpilotReviewUrl, hasFacebookSocialLink } from "@/src/lib/social/socialUtils";
 import VisitorTierHint from "@/src/components/visitors/VisitorTierHint";
 import type { VisitorHintData } from "@/src/lib/visitors/publicVisitorContext";
+import RichText from "@/src/components/portableText/RichText";
+import { portableTextHasContent } from "@/src/lib/portableText/toPlainText";
 
 interface ProgramInformationProps {
   program: Program;
@@ -92,11 +94,12 @@ export default function ProgramInformation({
                 </div>
               </div>
 
-              {program.description && (
-                <p className="text-sm sm:text-base text-gray-300 leading-relaxed whitespace-pre-wrap">
-                  {program.description}
-                </p>
-              )}
+              {portableTextHasContent(program.description) ? (
+                <RichText
+                  value={program.description}
+                  className="text-sm sm:text-base text-gray-300 [&_p]:leading-relaxed [&_li]:text-gray-300"
+                />
+              ) : null}
 
               {/* Download Link and Facebook Group Button */}
               <div className="flex flex-col sm:flex-row gap-4 sm:gap-6 justify-center sm:justify-evenly items-center">

--- a/src/components/program/RelatedPrograms.tsx
+++ b/src/components/program/RelatedPrograms.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import { IdealImage } from "@/src/components/general/IdealImage";
 import { Program } from "@/src/types";
+import { portableTextExcerpt, portableTextHasContent } from "@/src/lib/portableText/toPlainText";
 
 interface RelatedProgramsProps {
   programs: Program[];
@@ -105,11 +106,11 @@ export default function RelatedPrograms({ programs }: RelatedProgramsProps) {
                         <h3 className="text-base sm:text-lg font-semibold text-white mb-2 group-hover:text-primary-400 transition-colors duration-200 line-clamp-1">
                           {program.title}
                         </h3>
-                        {program.description && (
+                        {portableTextHasContent(program.description) ? (
                           <p className="text-gray-400 text-xs sm:text-sm line-clamp-2 mb-3 sm:mb-4 leading-tight">
-                            {program.description}
+                            {portableTextExcerpt(program.description, 180)}
                           </p>
-                        )}
+                        ) : null}
 
                         {/* Stats */}
                         <div className="flex items-center justify-between text-xs sm:text-sm text-gray-500">

--- a/src/components/program/cdkeys/CDKeyItem.tsx
+++ b/src/components/program/cdkeys/CDKeyItem.tsx
@@ -3,7 +3,7 @@
 import { CDKeyItemProps } from "@/src/types";
 import CDKeyActions from "@/src/components/program/cdkeys/CDKeyActions";
 import ReportProgressBar from "@/src/components/program/cdkeys/ReportProgressBar";
-import { getStatusColor } from "@/src/lib/program/cdKeyUtils";
+import { formatValidUntilDisplay, getStatusColor } from "@/src/lib/program/cdKeyUtils";
 import { useCopyTracking } from "@/src/hooks/useCopyTracking";
 
 export default function CDKeyItem({
@@ -43,7 +43,7 @@ export default function CDKeyItem({
         {cdKey.validFrom?.split("T")[0]}
       </td>
       <td className={`px-6 py-4 text-center text-sm ${isDisabled ? "text-neutral-500" : "text-neutral-300"}`}>
-        {cdKey.validUntil?.split("T")[0]}
+        {formatValidUntilDisplay(cdKey.validUntil)}
       </td>
       {!isDisabled && (
         <td className="px-6 py-4 text-center">

--- a/src/components/program/cdkeys/CDKeyMobileCard.tsx
+++ b/src/components/program/cdkeys/CDKeyMobileCard.tsx
@@ -3,7 +3,7 @@
 import { CDKey, ReportData } from "@/src/types";
 import CDKeyActions from "./CDKeyActions";
 import ReportProgressBar from "./ReportProgressBar";
-import { getStatusColor } from "@/src/lib/program/cdKeyUtils";
+import { formatValidUntilDisplay, getStatusColor } from "@/src/lib/program/cdKeyUtils";
 import { useCopyTracking } from "@/src/hooks/useCopyTracking";
 
 interface CDKeyMobileCardProps {
@@ -59,7 +59,7 @@ export default function CDKeyMobileCard({
           </div>
           <div>
             <span className="text-neutral-500">Valid Until:</span>
-            <div className="text-white font-medium">{cdKey.validUntil?.split("T")[0]}</div>
+            <div className="text-white font-medium">{formatValidUntilDisplay(cdKey.validUntil)}</div>
           </div>
         </div>
       </div>

--- a/src/hooks/useKeyReportData.ts
+++ b/src/hooks/useKeyReportData.ts
@@ -31,6 +31,7 @@ export function useKeyReportData(programSlug: string, currentCdKeys?: Array<{ ke
         // Initialize with current keys
         if (currentCdKeys) {
           for (const cdKey of currentCdKeys) {
+            if (!cdKey?.key?.trim()) continue;
             const keyHash = await hashCDKeyClient(cdKey.key);
             keyReportData.set(keyHash, { working: 0, expired: 0, limit_reached: 0 });
           }

--- a/src/lib/portableText/index.ts
+++ b/src/lib/portableText/index.ts
@@ -1,0 +1,2 @@
+export { portableTextExcerpt, portableTextHasContent, portableTextToPlainText } from "./toPlainText";
+export { plainTextToPortableText } from "./plainTextToPortableText";

--- a/src/lib/portableText/plainTextToPortableText.ts
+++ b/src/lib/portableText/plainTextToPortableText.ts
@@ -1,0 +1,26 @@
+import type { PortableTextBlock } from "@portabletext/types";
+
+function mkKey(): string {
+  return `k${Math.random().toString(36).slice(2, 11)}`;
+}
+
+/** Admin / API: turn a textarea string into Sanity Portable Text (paragraphs from blank-line breaks). */
+export function plainTextToPortableText(text: string): PortableTextBlock[] {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  if (!normalized) return [];
+  const paragraphs = normalized.split(/\n\s*\n+/);
+  return paragraphs.map(paragraph => ({
+    _type: "block",
+    _key: mkKey(),
+    style: "normal",
+    markDefs: [],
+    children: [
+      {
+        _type: "span",
+        _key: mkKey(),
+        text: paragraph.replace(/\n/g, " ").trim(),
+        marks: []
+      }
+    ]
+  })) as PortableTextBlock[];
+}

--- a/src/lib/portableText/toPlainText.ts
+++ b/src/lib/portableText/toPlainText.ts
@@ -1,0 +1,42 @@
+import { toPlainText } from "@portabletext/toolkit";
+import type { PortableTextBlock } from "@portabletext/types";
+
+function normalizeWhitespace(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Portable Text array / single block → plain string (previews, SEO, JSON-LD, search, excerpts).
+ * Pass-through for legacy plain `string` fields until migrated.
+ */
+export function portableTextToPlainText(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return normalizeWhitespace(value);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "";
+    try {
+      return normalizeWhitespace(toPlainText(value as PortableTextBlock[]));
+    } catch {
+      return "";
+    }
+  }
+  if (typeof value === "object" && "_type" in (value as object)) {
+    try {
+      return normalizeWhitespace(toPlainText(value as PortableTextBlock));
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+export function portableTextHasContent(value: unknown): boolean {
+  return portableTextToPlainText(value).length > 0;
+}
+
+export function portableTextExcerpt(value: unknown, maxLen: number): string {
+  const t = portableTextToPlainText(value);
+  if (t.length <= maxLen) return t;
+  const slice = t.slice(0, maxLen - 1).trimEnd();
+  return slice ? `${slice}…` : "…";
+}

--- a/src/lib/program/cdKeyUtils.ts
+++ b/src/lib/program/cdKeyUtils.ts
@@ -64,6 +64,21 @@ export function getStatusTextFromCDKeyStatus(status: CDKeyStatus): string {
   return CDKEY_STATUS_DISPLAY_TEXT[status];
 }
 
+/** True when `validUntil` is a real expiry (empty / missing = no expiry in CMS). */
+export function cdKeyHasExpiry(validUntil?: string | null): boolean {
+  if (validUntil == null || typeof validUntil !== "string") return false;
+  const t = validUntil.trim();
+  if (!t) return false;
+  const d = new Date(t);
+  return !Number.isNaN(d.getTime());
+}
+
+/** `YYYY-MM-DD` from ISO `validUntil`, or `Lifetime` when unset. */
+export function formatValidUntilDisplay(validUntil?: string | null): string {
+  if (!cdKeyHasExpiry(validUntil)) return "Lifetime";
+  return String(validUntil).split("T")[0] ?? "Lifetime";
+}
+
 // Check if a key is expiring soon (existing function from cdKeyUtils.ts)
 /**
  * Checks if a CD key is expiring within 30 days
@@ -71,13 +86,13 @@ export function getStatusTextFromCDKeyStatus(status: CDKeyStatus): string {
  * @returns true if the key expires within 30 days (but not yet expired)
  */
 export function isKeyExpiringSoon(key: { validUntil?: string }): boolean {
-  if (!key.validUntil) return false;
+  if (!cdKeyHasExpiry(key.validUntil)) return false;
 
-  const validUntil = new Date(key.validUntil);
+  const validUntil = new Date(key.validUntil as string);
   const now = new Date();
   const daysUntilExpiry = Math.ceil((validUntil.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
 
-  return daysUntilExpiry <= 30 && daysUntilExpiry > 0;
+  return Number.isFinite(daysUntilExpiry) && daysUntilExpiry <= 30 && daysUntilExpiry > 0;
 }
 
 /**
@@ -85,31 +100,38 @@ export function isKeyExpiringSoon(key: { validUntil?: string }): boolean {
  * @param cdKeys - Array of CD keys to check
  * @returns A message describing how soon keys are expiring, or null if no expiring keys
  */
-export function getExpiringKeysMessage(cdKeys: Array<{ validUntil?: string }>): string | null {
+export function getExpiringKeysMessage(cdKeys: Array<{ validUntil?: string }> | null | undefined): string | null {
+  if (!Array.isArray(cdKeys) || cdKeys.length === 0) return null;
+  // No expiry dates (e.g. all lifetime keys) → nothing is "expiring soon"
+  if (!cdKeys.some(k => cdKeyHasExpiry(k.validUntil))) return null;
+
   const expiringKeys = cdKeys.filter(isKeyExpiringSoon);
   if (expiringKeys.length === 0) return null;
 
-  // Find the soonest expiring key
   const now = new Date();
   let minDays = Infinity;
 
-  expiringKeys.forEach(key => {
-    if (key.validUntil) {
-      const validUntil = new Date(key.validUntil);
-      const daysUntilExpiry = Math.ceil((validUntil.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
-      if (daysUntilExpiry < minDays) minDays = daysUntilExpiry;
+  for (const key of expiringKeys) {
+    if (!cdKeyHasExpiry(key.validUntil)) continue;
+    const validUntil = new Date(key.validUntil as string);
+    const daysUntilExpiry = Math.ceil((validUntil.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+    if (Number.isFinite(daysUntilExpiry) && daysUntilExpiry > 0 && daysUntilExpiry < minDays) {
+      minDays = daysUntilExpiry;
     }
-  });
+  }
+
+  if (!Number.isFinite(minDays) || minDays === Infinity || minDays <= 0) return null;
 
   if (minDays === 1) {
     return "Some keys expire in 24 hours. Activate them now before they expire!";
-  } else if (minDays <= 3) {
-    return `Some keys expire in ${minDays} days. Activate them soon before they expire!`;
-  } else if (minDays <= 7) {
-    return "Some keys expire within a week. Activate them before they expire!";
-  } else {
-    return `Some keys expire within a month (${minDays} days). Activate them before they expire!`;
   }
+  if (minDays <= 3) {
+    return `Some keys expire in ${minDays} days. Activate them soon before they expire!`;
+  }
+  if (minDays <= 7) {
+    return "Some keys expire within a week. Activate them before they expire!";
+  }
+  return `Some keys expire within a month (${minDays} days). Activate them before they expire!`;
 }
 
 // Get status color classes (existing function from cdKeyUtils.ts)

--- a/src/lib/program/programUtils.ts
+++ b/src/lib/program/programUtils.ts
@@ -1,4 +1,5 @@
 import { Program } from "@/src/types";
+import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
 
 export interface ProgramWithStats extends Program {
   viewCount: number;
@@ -99,9 +100,10 @@ export function searchPrograms(programs: ProgramWithStats[], searchTerm: string)
   if (!searchTerm.trim()) return programs;
 
   const term = searchTerm.toLowerCase();
-  return programs.filter(
-    program => program.title.toLowerCase().includes(term) || program.description.toLowerCase().includes(term)
-  );
+  return programs.filter(program => {
+    const desc = portableTextToPlainText(program.description).toLowerCase();
+    return program.title.toLowerCase().includes(term) || desc.includes(term);
+  });
 }
 
 /**

--- a/src/lib/program/versionSummary.ts
+++ b/src/lib/program/versionSummary.ts
@@ -1,5 +1,6 @@
 import semver from "semver";
 import type { CDKey, Program } from "@/src/types";
+import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
 
 /** Working keys only: semver-coerced max of `version` (invalid strings skipped). */
 export function getHighestKeyVersion(cdKeys: CDKey[]): string | null {
@@ -87,7 +88,7 @@ export function buildSoftwareApplicationDescription(program: Program): string {
     ?.map(s => s.description?.trim())
     .filter(Boolean)
     .join("\n\n");
-  const base = program.description?.trim() ?? "";
+  const base = portableTextToPlainText(program.description);
   if (aboutBlob && base) {
     const combined = `${base}\n\n${aboutBlob}`;
     return combined.length > 320 ? `${combined.slice(0, 317)}…` : combined;

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -40,11 +40,10 @@ export const footerLinksQuery = `*[_type=="footerLink"] | order(_createdAt asc) 
 }`;
 
 /* ------------ Programs ------------ */
-/** Nested `featured` plus legacy top-level `featuredDescription` / `showcaseGif` until migrated. */
 export const featuredBlockProjection = `
-"featured": {
-  "featuredDescription": coalesce(featured.featuredDescription, featuredDescription),
-  "showcaseGif": coalesce(featured.showcaseGif, showcaseGif)
+featured{
+  featuredDescription,
+  showcaseGif
 }`;
 
 export const allProgramsQuery = `

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -40,9 +40,18 @@ export const footerLinksQuery = `*[_type=="footerLink"] | order(_createdAt asc) 
 }`;
 
 /* ------------ Programs ------------ */
+/** Nested `featured` plus legacy top-level `featuredDescription` / `showcaseGif` until migrated. */
+export const featuredBlockProjection = `
+"featured": {
+  "featuredDescription": coalesce(featured.featuredDescription, featuredDescription),
+  "showcaseGif": coalesce(featured.showcaseGif, showcaseGif)
+}`;
+
 export const allProgramsQuery = `
 *[_type == "program"]{
-  title, slug, description, featuredDescription, image, showcaseGif, cdKeys[]
+  title, slug, description,
+  ${featuredBlockProjection},
+  image, cdKeys[]
 }
 `;
 export const adminProgramsQuery = `
@@ -52,13 +61,12 @@ export const adminProgramsQuery = `
   slug,
   _updatedAt,
   description,
-  featuredDescription,
+  ${featuredBlockProjection},
   latestOfficialVersion,
   seo,
   aboutSections,
   faq,
   image,
-  showcaseGif,
   downloadLink,
   cdKeys[]
 }
@@ -70,13 +78,12 @@ export const programBySlugQuery = `
   slug,
   _updatedAt,
   description,
-  featuredDescription,
+  ${featuredBlockProjection},
   latestOfficialVersion,
   seo,
   aboutSections,
   faq,
   image,
-  showcaseGif,
   downloadLink,
   cdKeys[]
 }
@@ -137,7 +144,9 @@ export const popularProgramsQuery = `*[_type == "program"] | order(_createdAt de
 
 /* ------------ Popular Programs by Page Views ------------ */
 export const popularProgramsByViewsQuery = `*[_type == "program"]{
-  title, slug, description, featuredDescription, image, showcaseGif, cdKeys[],
+  title, slug, description,
+  ${featuredBlockProjection},
+  image, cdKeys[],
   "viewCount": count(*[_type == "trackingEvent" && event == "page_viewed" && programSlug == ^.slug.current && (notFound != true)]),
   "downloadCount": count(*[_type == "trackingEvent" && event == "download_click" && programSlug == ^.slug.current]),
   "hasKeys": count(cdKeys[]) > 0,
@@ -158,7 +167,9 @@ export const recentReportsQuery = `*[_type == "keyReport" && createdAt >= $weekA
 
 /* ------------ Programs with Filtering ------------ */
 export const programsWithStatsQuery = `*[_type == "program"]{
-  title, slug, description, featuredDescription, image, showcaseGif, cdKeys[], _createdAt,
+  title, slug, description,
+  ${featuredBlockProjection},
+  image, cdKeys[], _createdAt,
   "viewCount": count(*[_type == "trackingEvent" && event == "page_viewed" && programSlug == ^.slug.current && (notFound != true)]),
   "downloadCount": count(*[_type == "trackingEvent" && event == "download_click" && programSlug == ^.slug.current]),
   "hasKeys": count(cdKeys[]) > 0,
@@ -175,9 +186,8 @@ export const featuredProgramSettingsQuery = `*[_type == "featuredProgramSettings
     title,
     slug,
     description,
-    featuredDescription,
+    ${featuredBlockProjection},
     image,
-    showcaseGif,
     cdKeys[]
   },
   rotationSchedule,
@@ -207,9 +217,8 @@ export const programsForAutoSelectionQuery = `*[_type == "program"]{
   title,
   slug,
   description,
-  featuredDescription,
+  ${featuredBlockProjection},
   image,
-  showcaseGif,
   downloadLink,
   cdKeys[],
   "totalKeys": count(cdKeys[]),

--- a/src/lib/sanity/sanityActions.ts
+++ b/src/lib/sanity/sanityActions.ts
@@ -43,7 +43,7 @@ export async function updateAllExpiredKeys(): Promise<void> {
         let updatedKey = { ...key };
 
         // Check if key should be expired based on validUntil date
-        if (key.status.toLowerCase() !== "expired" && key.validUntil) {
+        if (key.status !== "expired" && key.validUntil) {
           const validUntil = new Date(key.validUntil);
           if (now > validUntil) {
             hasUpdates = true;
@@ -52,7 +52,7 @@ export async function updateAllExpiredKeys(): Promise<void> {
         }
 
         // Check if "new" key is older than 1 month and convert to "active"
-        if (key.status.toLowerCase() === "new") {
+        if (updatedKey.status === "new") {
           // Check createdAt first, then fall back to validFrom
           const keyDate = key.createdAt || key.validFrom;
           if (keyDate) {
@@ -100,7 +100,7 @@ export async function getProgramWithUpdatedKeys(slug: string) {
       let updatedKey = { ...key };
 
       // Check if key should be expired based on validUntil date
-      if (key.status.toLowerCase() !== "expired" && key.validUntil) {
+      if (key.status !== "expired" && key.validUntil) {
         const validUntil = new Date(key.validUntil);
         if (now > validUntil) {
           hasUpdates = true;
@@ -109,7 +109,7 @@ export async function getProgramWithUpdatedKeys(slug: string) {
       }
 
       // Check if "new" key is older than 1 month and convert to "active"
-      if (key.status.toLowerCase() === "new") {
+      if (updatedKey.status === "new") {
         // Check createdAt first, then fall back to validFrom
         const keyDate = key.createdAt || key.validFrom;
         if (keyDate) {

--- a/src/lib/seo/jsonLd.ts
+++ b/src/lib/seo/jsonLd.ts
@@ -1,4 +1,5 @@
 import { Program } from "@/src/types";
+import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
 import { urlFor } from "@/src/sanity/lib/image";
 import { cdKeyHasExpiry } from "@/src/lib/program/cdKeyUtils";
 import { buildSoftwareApplicationDescription, getSoftwareVersionForSchema } from "@/src/lib/program/versionSummary";
@@ -50,7 +51,7 @@ export function generateProgramsPageJsonLd(programs: Program[], totalCount: numb
   const programItems = programs.slice(0, 20).map(program => ({
     "@type": "SoftwareApplication",
     name: program.title,
-    description: program.description,
+    description: portableTextToPlainText(program.description),
     url: `${BASE_URL}/program/${program.slug.current}`,
     image: program.image ? urlFor(program.image).width(400).height(400).url() : undefined,
     applicationCategory: "SoftwareApplication",

--- a/src/lib/seo/jsonLd.ts
+++ b/src/lib/seo/jsonLd.ts
@@ -1,5 +1,6 @@
 import { Program } from "@/src/types";
 import { urlFor } from "@/src/sanity/lib/image";
+import { cdKeyHasExpiry } from "@/src/lib/program/cdKeyUtils";
 import { buildSoftwareApplicationDescription, getSoftwareVersionForSchema } from "@/src/lib/program/versionSummary";
 
 // Base URL for the site
@@ -121,14 +122,14 @@ export function generateProgramPageJsonLd(
     .slice(0, 10) // Limit to first 10 working keys for performance
     .map(cdKey => ({
       "@type": "Offer",
-      sku: `key-${cdKey.key.slice(-8)}`, // Use last 8 chars as SKU
+      sku: `key-${cdKey.key.slice(-8)}`,
       price: "0",
       priceCurrency: "USD",
       availability: "https://schema.org/InStock",
       description: `Free CD Key for ${program.title}`,
       itemCondition: "https://schema.org/NewCondition",
-      validFrom: cdKey.validFrom,
-      validThrough: cdKey.validUntil
+      ...(cdKey.validFrom ? { validFrom: cdKey.validFrom } : {}),
+      ...(cdKeyHasExpiry(cdKey.validUntil) ? { validThrough: cdKey.validUntil } : {})
     }));
 
   const softwareApp: JsonLdData = {

--- a/src/sanity/inputs/CdKeysArrayInput.tsx
+++ b/src/sanity/inputs/CdKeysArrayInput.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useMemo } from "react";
+import type { ArrayOfObjectsInputProps } from "sanity";
+
+type CdKeyRow = {
+  _key?: string;
+  status?: string;
+  createdAt?: string;
+};
+
+/** Studio list order: new → active → limit → expired, then newest `createdAt` first within each group. */
+function statusRank(status: string | undefined): number {
+  const s = (status ?? "").toLowerCase().trim();
+  const map: Record<string, number> = {
+    new: 0,
+    active: 1,
+    limit: 2,
+    limit_reached: 2,
+    expired: 3
+  };
+  return map[s] ?? 99;
+}
+
+function createdAtMs(row: CdKeyRow | undefined): number {
+  if (!row?.createdAt) return 0;
+  const t = new Date(row.createdAt).getTime();
+  return Number.isFinite(t) ? t : 0;
+}
+
+function compareCdKeys(a: CdKeyRow, b: CdKeyRow): number {
+  const ra = statusRank(a.status);
+  const rb = statusRank(b.status);
+  if (ra !== rb) return ra - rb;
+  return createdAtMs(b) - createdAtMs(a);
+}
+
+export function CdKeysArrayInput(props: ArrayOfObjectsInputProps) {
+  const { members, value, renderDefault } = props;
+
+  const sortedMembers = useMemo(() => {
+    if (!members?.length) return members;
+    const rows = (Array.isArray(value) ? value : []) as CdKeyRow[];
+    const sortedKeys = [...rows].sort(compareCdKeys).map(r => r._key).filter(Boolean) as string[];
+    const byKey = Object.fromEntries(members.map(m => [m.key, m]));
+    const ordered = sortedKeys.map(k => byKey[k]).filter(Boolean);
+    if (ordered.length !== members.length) return members;
+    return ordered;
+  }, [members, value]);
+
+  return renderDefault({ ...props, members: sortedMembers });
+}

--- a/src/sanity/schemaTypes/aboutSection.ts
+++ b/src/sanity/schemaTypes/aboutSection.ts
@@ -21,9 +21,10 @@ export const aboutPoint = defineType({
     })
   ],
   preview: {
-    select: { t: "text" },
-    prepare({ t }: { t?: string }) {
-      return { title: t || "Point" };
+    select: { t: "text", media: "icon" },
+    prepare(selection) {
+      const { t, media } = selection;
+      return { title: (typeof t === "string" && t.trim()) || "Point", media };
     }
   }
 });
@@ -78,11 +79,14 @@ export const aboutSection = defineType({
     })
   ],
   preview: {
-    select: { title: "sectionTitle", desc: "description" },
-    prepare({ title, desc }: { title?: string; desc?: string }) {
+    select: { title: "sectionTitle", desc: "description", media: "image" },
+    prepare(selection) {
+      const { title, desc, media } = selection;
+      const d = typeof desc === "string" ? desc : "";
       return {
-        title: title || "About block",
-        subtitle: desc?.slice(0, 72) ?? ""
+        title: (typeof title === "string" && title.trim()) || "About block",
+        subtitle: d ? `${d.trim().slice(0, 72)}${d.trim().length > 72 ? "…" : ""}` : "",
+        media
       };
     }
   }

--- a/src/sanity/schemaTypes/cdKey.ts
+++ b/src/sanity/schemaTypes/cdKey.ts
@@ -1,27 +1,49 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
+
+import type { CDKeyStatus } from "@/src/types/program";
+
+const STATUS_LIST: { title: string; value: CDKeyStatus }[] = [
+  { title: "New", value: "new" },
+  { title: "Active", value: "active" },
+  { title: "Expired", value: "expired" },
+  { title: "Limit Reached", value: "limit" }
+];
 
 export const cdKey = defineType({
   name: "cdKey",
   title: "CD Key",
   type: "object",
   fields: [
-    { name: "key", title: "Key", type: "string" },
-    {
+    defineField({
+      name: "key",
+      title: "Key",
+      type: "string",
+      validation: Rule => Rule.required().min(1)
+    }),
+    defineField({
       name: "status",
       title: "Status",
       type: "string",
-      options: {
-        list: [
-          { title: "New", value: "new" },
-          { title: "Active", value: "active" },
-          { title: "Expired", value: "expired" },
-          { title: "Limit Reached", value: "limit" }
-        ]
-      }
-    },
-    { name: "version", title: "Program Version", type: "string" },
-    { name: "validFrom", title: "Valid From", type: "datetime" },
-    {
+      options: { list: STATUS_LIST, layout: "radio" },
+      initialValue: "new",
+      validation: Rule =>
+        Rule.required().custom((value: unknown) => {
+          if (typeof value !== "string") return "Status is required";
+          if (!STATUS_LIST.some(s => s.value === value)) return "Pick a valid status";
+          return true;
+        })
+    }),
+    defineField({
+      name: "version",
+      title: "Program Version",
+      type: "string"
+    }),
+    defineField({
+      name: "validFrom",
+      title: "Valid From",
+      type: "datetime"
+    }),
+    defineField({
       name: "validUntil",
       title: "Valid Until",
       type: "datetime",
@@ -32,14 +54,23 @@ export const cdKey = defineType({
           }
           return true;
         })
-    },
-    {
+    }),
+    defineField({
       name: "createdAt",
       title: "Created At",
       type: "datetime",
       description: "When this key was first added (auto-filled on creation)",
       initialValue: () => new Date().toISOString(),
       readOnly: ({ parent }) => !!parent?.createdAt
+    })
+  ],
+  preview: {
+    select: { key: "key", status: "status", version: "version" },
+    prepare({ key, status, version }: { key?: string; status?: string; version?: string }) {
+      return {
+        title: key ? `${key.slice(0, 12)}${key.length > 12 ? "…" : ""}` : "CD key",
+        subtitle: [status, version].filter(Boolean).join(" · ") || "No status"
+      };
     }
-  ]
+  }
 });

--- a/src/sanity/schemaTypes/cdKey.ts
+++ b/src/sanity/schemaTypes/cdKey.ts
@@ -1,5 +1,6 @@
 import { defineField, defineType } from "sanity";
 
+import { formatValidUntilDisplay } from "@/src/lib/program/cdKeyUtils";
 import type { CDKeyStatus } from "@/src/types/program";
 
 const STATUS_LIST: { title: string; value: CDKeyStatus }[] = [
@@ -47,6 +48,7 @@ export const cdKey = defineType({
       name: "validUntil",
       title: "Valid Until",
       type: "datetime",
+      description: "Leave empty for a lifetime key (no fixed expiry).",
       validation: Rule =>
         Rule.custom(value => {
           if (value && typeof value === "string" && isNaN(new Date(value).getTime())) {
@@ -65,11 +67,24 @@ export const cdKey = defineType({
     })
   ],
   preview: {
-    select: { key: "key", status: "status", version: "version" },
-    prepare({ key, status, version }: { key?: string; status?: string; version?: string }) {
+    select: {
+      key: "key",
+      status: "status",
+      version: "version",
+      validUntil: "validUntil",
+      createdAt: "createdAt"
+    },
+    prepare(selection) {
+      const { key, status, version, validUntil, createdAt } = selection;
+      const k = typeof key === "string" ? key : "";
+      const expiry = formatValidUntilDisplay(typeof validUntil === "string" ? validUntil : undefined);
+      const created =
+        createdAt != null && typeof createdAt === "string" && createdAt.trim()
+          ? `created ${createdAt.trim().split("T")[0]}`
+          : null;
       return {
-        title: key ? `${key.slice(0, 12)}${key.length > 12 ? "…" : ""}` : "CD key",
-        subtitle: [status, version].filter(Boolean).join(" · ") || "No status"
+        title: k ? `${k.slice(0, 12)}${k.length > 12 ? "…" : ""}` : "CD key",
+        subtitle: [status, version, `until ${expiry}`, created].filter(Boolean).join(" · ") || "No status"
       };
     }
   }

--- a/src/sanity/schemaTypes/contactMessage.ts
+++ b/src/sanity/schemaTypes/contactMessage.ts
@@ -1,33 +1,33 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export default defineType({
   name: "contactMessage",
   title: "Contact Messages",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "title",
       title: "Title",
       type: "string",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "message",
       title: "Message",
       type: "text",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "name",
       title: "Name",
       type: "string"
-    },
-    {
+    }),
+    defineField({
       name: "email",
       title: "Email",
       type: "string"
-    },
-    {
+    }),
+    defineField({
       name: "status",
       title: "Status",
       type: "string",
@@ -40,19 +40,19 @@ export default defineType({
         ]
       },
       initialValue: "new"
-    },
-    {
+    }),
+    defineField({
       name: "createdAt",
       title: "Created At",
       type: "datetime",
       initialValue: () => new Date().toISOString()
-    },
-    {
+    }),
+    defineField({
       name: "ipHash",
       title: "Visitor Hash",
       type: "string",
       description: "Hashed IP + salt. Used to associate messages with visitor records."
-    }
+    })
   ],
   preview: {
     select: {
@@ -60,7 +60,7 @@ export default defineType({
       subtitle: "message",
       status: "status"
     },
-    prepare({ title, subtitle, status }) {
+    prepare({ title, subtitle, status }: { title?: string; subtitle?: string; status?: string }) {
       return {
         title: title || "Untitled Message",
         subtitle: `${status} - ${subtitle?.slice(0, 60)}...`

--- a/src/sanity/schemaTypes/cronRun.ts
+++ b/src/sanity/schemaTypes/cronRun.ts
@@ -1,4 +1,4 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const cronRun = defineType({
   name: "cronRun",
@@ -6,7 +6,7 @@ export const cronRun = defineType({
   type: "document",
   readOnly: true,
   fields: [
-    {
+    defineField({
       name: "job",
       title: "Job",
       type: "string",
@@ -17,8 +17,8 @@ export const cronRun = defineType({
         ]
       },
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "source",
       title: "Source",
       type: "string",
@@ -31,8 +31,8 @@ export const cronRun = defineType({
         ]
       },
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "status",
       title: "Status",
       type: "string",
@@ -43,23 +43,23 @@ export const cronRun = defineType({
         ]
       },
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "details",
       title: "Details",
       type: "string",
       description: "Optional result summary (e.g. bundled 5 events)"
-    },
-    {
+    }),
+    defineField({
       name: "ranAt",
       title: "Ran At",
       type: "datetime",
       validation: Rule => Rule.required()
-    }
+    })
   ],
   preview: {
     select: { job: "job", source: "source", status: "status", ranAt: "ranAt" },
-    prepare({ job, source, status, ranAt }) {
+    prepare({ job, source, status, ranAt }: { job?: string; source?: string; status?: string; ranAt?: string }) {
       const d = ranAt ? new Date(ranAt).toLocaleString() : "";
       return {
         title: `${job} (${status})`,

--- a/src/sanity/schemaTypes/featuredProgramSettings.ts
+++ b/src/sanity/schemaTypes/featuredProgramSettings.ts
@@ -1,19 +1,19 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const featuredProgramSettings = defineType({
   name: "featuredProgramSettings",
   title: "Featured Program Settings",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "currentFeaturedProgram",
       title: "Current Featured Program",
       type: "reference",
       to: [{ type: "program" }],
       description:
         "The currently featured program. You can manually set this, or leave empty for auto-selection. Once rotation interval passes, it will automatically rotate based on the selected criteria."
-    },
-    {
+    }),
+    defineField({
       name: "rotationSchedule",
       title: "Rotation Schedule",
       type: "string",
@@ -26,15 +26,15 @@ export const featuredProgramSettings = defineType({
       },
       initialValue: "weekly",
       description: "How often to rotate the featured program. Rotation happens automatically based on lastRotationDate."
-    },
-    {
+    }),
+    defineField({
       name: "lastRotationDate",
       title: "Last Rotation Date",
       type: "datetime",
       description:
         "When the featured program was last rotated (automatically updated). Set this when manually changing the program to reset the rotation timer."
-    },
-    {
+    }),
+    defineField({
       name: "autoSelectCriteria",
       title: "Auto-Select Criteria",
       type: "string",
@@ -47,7 +47,7 @@ export const featuredProgramSettings = defineType({
       },
       initialValue: "highest_working_keys",
       description: "Criteria for auto-selecting featured program when rotation interval passes"
-    }
+    })
   ],
   preview: {
     select: {
@@ -55,7 +55,7 @@ export const featuredProgramSettings = defineType({
       schedule: "rotationSchedule",
       criteria: "autoSelectCriteria"
     },
-    prepare({ program, schedule, criteria }) {
+    prepare({ program, schedule, criteria }: { program?: string; schedule?: string; criteria?: string }) {
       return {
         title: program || `Auto: ${criteria}`,
         subtitle: `Rotation: ${schedule || "weekly"}`

--- a/src/sanity/schemaTypes/footer.ts
+++ b/src/sanity/schemaTypes/footer.ts
@@ -1,21 +1,21 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const footer = defineType({
   name: "footer",
   title: "Footer",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "isLogo",
       title: "Show Logo?",
       type: "boolean",
       initialValue: true
-    },
-    {
+    }),
+    defineField({
       name: "footerLinks",
       title: "Footer Links",
       type: "array",
       of: [{ type: "link" }]
-    }
+    })
   ]
 });

--- a/src/sanity/schemaTypes/header.ts
+++ b/src/sanity/schemaTypes/header.ts
@@ -1,21 +1,21 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const header = defineType({
   name: "header",
   title: "Header",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "isLogo",
       title: "Show Logo?",
       type: "boolean",
       initialValue: true
-    },
-    {
+    }),
+    defineField({
       name: "headerLinks",
       title: "Header Links",
       type: "array",
       of: [{ type: "link" }]
-    }
+    })
   ]
 });

--- a/src/sanity/schemaTypes/interactionEventBucket.ts
+++ b/src/sanity/schemaTypes/interactionEventBucket.ts
@@ -1,19 +1,59 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const interactionEventBucket = defineType({
   name: "interactionEventBucket",
   title: "Interaction Event Bucket",
   type: "document",
   fields: [
-    { name: "bucketKey", title: "Bucket Key", type: "string", validation: Rule => Rule.required() },
-    { name: "bucketDateHour", title: "Bucket Date Hour", type: "string", validation: Rule => Rule.required() },
-    { name: "pagePath", title: "Page Path", type: "string", validation: Rule => Rule.required() },
-    { name: "sectionId", title: "Section Id", type: "string", validation: Rule => Rule.required() },
-    { name: "interactionId", title: "Interaction Id", type: "string", validation: Rule => Rule.required() },
-    { name: "programSlug", title: "Program Slug", type: "string" },
-    { name: "count", title: "Count", type: "number", validation: Rule => Rule.required().min(0) },
-    { name: "lastSeenAt", title: "Last Seen At", type: "datetime", validation: Rule => Rule.required() },
-    { name: "createdAt", title: "Created At", type: "datetime", validation: Rule => Rule.required() }
+    defineField({
+      name: "bucketKey",
+      title: "Bucket Key",
+      type: "string",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "bucketDateHour",
+      title: "Bucket Date Hour",
+      type: "string",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "pagePath",
+      title: "Page Path",
+      type: "string",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "sectionId",
+      title: "Section Id",
+      type: "string",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "interactionId",
+      title: "Interaction Id",
+      type: "string",
+      validation: Rule => Rule.required()
+    }),
+    defineField({ name: "programSlug", title: "Program Slug", type: "string" }),
+    defineField({
+      name: "count",
+      title: "Count",
+      type: "number",
+      validation: Rule => Rule.required().min(0)
+    }),
+    defineField({
+      name: "lastSeenAt",
+      title: "Last Seen At",
+      type: "datetime",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "createdAt",
+      title: "Created At",
+      type: "datetime",
+      validation: Rule => Rule.required()
+    })
   ],
   preview: {
     select: {

--- a/src/sanity/schemaTypes/keyReport.ts
+++ b/src/sanity/schemaTypes/keyReport.ts
@@ -1,11 +1,11 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const keyReport = defineType({
   name: "keyReport",
   title: "Key Report",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "eventType",
       title: "Report Type",
       type: "string",
@@ -17,94 +17,94 @@ export const keyReport = defineType({
         ]
       },
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "programSlug",
       title: "Program Slug",
       type: "string",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "keyHash",
       title: "Key Hash",
       type: "string",
       description: "SHA-256 hash of the CD key for privacy",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "keyIdentifier",
       title: "Key Identifier",
       type: "string",
       description: "Short identifier like ABC***XYZ",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "keyNormalized",
       title: "Key Normalized",
       type: "string",
       description: "Normalized key for matching",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "path",
       title: "Path",
       type: "string",
       description: "Page where the report was submitted"
-    },
-    {
+    }),
+    defineField({
       name: "referrer",
       title: "Referrer",
       type: "url",
       description: "Page that referred the user"
-    },
-    {
+    }),
+    defineField({
       name: "userAgent",
       title: "User Agent",
       type: "string",
       description: "Browser information"
-    },
-    {
+    }),
+    defineField({
       name: "country",
       title: "Country",
       type: "string",
       description: "User's country based on IP geolocation"
-    },
-    {
+    }),
+    defineField({
       name: "city",
       title: "City",
       type: "string",
       description: "User's city based on IP geolocation"
-    },
-    {
+    }),
+    defineField({
       name: "utm_source",
       title: "UTM Source",
       type: "string",
       description: "UTM source parameter from URL"
-    },
-    {
+    }),
+    defineField({
       name: "utm_medium",
       title: "UTM Medium",
       type: "string",
       description: "UTM medium parameter from URL"
-    },
-    {
+    }),
+    defineField({
       name: "utm_campaign",
       title: "UTM Campaign",
       type: "string",
       description: "UTM campaign parameter from URL"
-    },
-    {
+    }),
+    defineField({
       name: "ipHash",
       title: "Visitor Hash",
       type: "string",
       description: "Hashed IP + salt. Used for deduping without storing raw IP."
-    },
-    {
+    }),
+    defineField({
       name: "createdAt",
       title: "Created At",
       type: "datetime",
       initialValue: () => new Date().toISOString()
-    }
+    })
   ],
   preview: {
     select: {
@@ -112,7 +112,7 @@ export const keyReport = defineType({
       subtitle: "programSlug",
       media: "eventType"
     },
-    prepare(selection) {
+    prepare(selection: { title?: string; subtitle?: string }) {
       const { title, subtitle } = selection;
       const eventLabels = {
         report_key_working: "✅ Working",

--- a/src/sanity/schemaTypes/keySuggestion.ts
+++ b/src/sanity/schemaTypes/keySuggestion.ts
@@ -1,50 +1,50 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export default defineType({
   name: "keySuggestion",
   title: "Key Suggestions",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "cdKey",
       title: "Suggested CD Key",
       type: "string",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "programName",
       title: "Program Name",
       type: "string",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "programVersion",
       title: "Program Version",
       type: "string",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "programLink",
       title: "Program/Download Link",
       type: "url",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "name",
       title: "Contact Name",
       type: "string"
-    },
-    {
+    }),
+    defineField({
       name: "email",
       title: "Contact Email",
       type: "string"
-    },
-    {
+    }),
+    defineField({
       name: "message",
       title: "Additional Message",
       type: "text"
-    },
-    {
+    }),
+    defineField({
       name: "status",
       title: "Status",
       type: "string",
@@ -57,19 +57,19 @@ export default defineType({
         ]
       },
       initialValue: "new"
-    },
-    {
+    }),
+    defineField({
       name: "createdAt",
       title: "Created At",
       type: "datetime",
       initialValue: () => new Date().toISOString()
-    },
-    {
+    }),
+    defineField({
       name: "ipHash",
       title: "Visitor Hash",
       type: "string",
       description: "Hashed IP + salt. Used to attribute suggestions to visitor records."
-    }
+    })
   ],
   preview: {
     select: {
@@ -77,7 +77,7 @@ export default defineType({
       subtitle: "programVersion",
       status: "status"
     },
-    prepare({ title, subtitle, status }) {
+    prepare({ title, subtitle, status }: { title?: string; subtitle?: string; status?: string }) {
       return {
         title: title || "Untitled Suggestion",
         subtitle: `${status} - v${subtitle}`

--- a/src/sanity/schemaTypes/link.ts
+++ b/src/sanity/schemaTypes/link.ts
@@ -1,35 +1,35 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const link = defineType({
   name: "link",
   title: "Link",
   type: "object",
   fields: [
-    {
+    defineField({
       name: "title",
       title: "Link Title",
       type: "string",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "slug",
       title: "Slug / URL",
       type: "slug",
       options: { source: "title", maxLength: 50 },
       hidden: ({ parent }) => parent?.external === true
-    },
-    {
+    }),
+    defineField({
       name: "external",
       title: "External Link?",
       type: "boolean",
       description: "Check if this link is to an external site",
       initialValue: false
-    },
-    {
+    }),
+    defineField({
       name: "url",
       title: "External URL",
       type: "url",
       hidden: ({ parent }) => !parent?.external
-    }
+    })
   ]
 });

--- a/src/sanity/schemaTypes/program.ts
+++ b/src/sanity/schemaTypes/program.ts
@@ -1,5 +1,6 @@
 import { defineField, defineType } from "sanity";
 
+import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
 import { CdKeysArrayInput } from "../inputs/CdKeysArrayInput";
 
 const MAX_META_TITLE = 70;
@@ -39,7 +40,8 @@ export const program = defineType({
     defineField({
       name: "description",
       title: "Description",
-      type: "text",
+      type: "array",
+      of: [{ type: "block" }],
       description:
         "Short summary shown on the program page. Unique to this program; mention category and who it is for.",
       validation: Rule => Rule.required()
@@ -218,9 +220,12 @@ export const program = defineType({
       const { title, description, latestOfficialVersion, media, cdKeys } = selection;
       const n = Array.isArray(cdKeys) ? cdKeys.length : 0;
       const keyLine = `${n} CD key${n === 1 ? "" : "s"}`;
-      const versionPart = latestOfficialVersion?.trim() ? `v${latestOfficialVersion.trim()}` : null;
-      const descTrimmed = description?.trim() ?? "";
-      const descPart = descTrimmed ? descTrimmed.slice(0, 72) + (descTrimmed.length > 72 ? "…" : "") : null;
+      const versionPart =
+        typeof latestOfficialVersion === "string" && latestOfficialVersion.trim()
+          ? `v${latestOfficialVersion.trim()}`
+          : null;
+      const descPlain = portableTextToPlainText(description);
+      const descPart = descPlain ? (descPlain.length > 72 ? `${descPlain.slice(0, 72)}…` : descPlain) : null;
       const subtitle = [keyLine, versionPart, descPart].filter(Boolean).join(" · ");
       return {
         title: title || "Program",

--- a/src/sanity/schemaTypes/program.ts
+++ b/src/sanity/schemaTypes/program.ts
@@ -1,5 +1,7 @@
 import { defineField, defineType } from "sanity";
 
+import { CdKeysArrayInput } from "../inputs/CdKeysArrayInput";
+
 const MAX_META_TITLE = 70;
 const MAX_META_DESC = 160;
 
@@ -22,6 +24,19 @@ export const program = defineType({
       validation: Rule => Rule.required()
     }),
     defineField({
+      name: "latestOfficialVersion",
+      title: "Latest official version",
+      type: "string",
+      description:
+        "Current product version from the vendor site (e.g. 18.5). Used for honest copy and SEO; CD keys keep their own version fields."
+    }),
+    defineField({
+      name: "downloadLink",
+      title: "Download Link",
+      type: "url",
+      description: "External link for users to download the program"
+    }),
+    defineField({
       name: "description",
       title: "Description",
       type: "text",
@@ -30,24 +45,11 @@ export const program = defineType({
       validation: Rule => Rule.required()
     }),
     defineField({
-      name: "featuredDescription",
-      title: "Featured Description",
-      type: "text",
-      description:
-        "Optional description to display when this program is featured. Should include what the program does, its capabilities. If empty, the regular description will be used."
-    }),
-    defineField({
-      name: "latestOfficialVersion",
-      title: "Latest official version",
-      type: "string",
-      description:
-        "Current product version from the vendor site (e.g. 18.5). Used for honest copy and SEO; CD keys keep their own version fields."
-    }),
-    defineField({
       name: "seo",
       title: "SEO",
       type: "object",
       options: { collapsible: true, collapsed: true },
+      description: "Optional search metadata overrides for this program (title/description shown in search results).",
       fields: [
         defineField({
           name: "metaTitle",
@@ -67,6 +69,14 @@ export const program = defineType({
             Rule.max(MAX_META_DESC).warning(`Prefer ${MAX_META_DESC} characters or fewer for Google snippets.`)
         })
       ]
+    }),
+    defineField({
+      name: "image",
+      title: "Image",
+      type: "image",
+      options: {
+        hotspot: true
+      }
     }),
     defineField({
       name: "aboutSections",
@@ -103,9 +113,15 @@ export const program = defineType({
             })
           ],
           preview: {
-            select: { title: "question" },
-            prepare({ title }: { title?: string }) {
-              return { title: title || "FAQ item" };
+            select: { question: "question", answer: "answer" },
+            prepare(selection) {
+              const { question, answer } = selection;
+              const q = typeof question === "string" ? question.trim() : "";
+              const a = typeof answer === "string" ? answer.trim().replace(/\s+/g, " ") : "";
+              return {
+                title: q || "FAQ item",
+                subtitle: a ? (a.length > 96 ? `${a.slice(0, 96)}…` : a) : undefined
+              };
             }
           }
         }
@@ -120,30 +136,48 @@ export const program = defineType({
         })
     }),
     defineField({
-      name: "image",
-      title: "Image",
-      type: "image",
-      options: {
-        hotspot: true
+      name: "featured",
+      title: "Featured Section",
+      type: "object",
+      options: { collapsible: true, collapsed: true },
+      description: "Optional: Overrides for featured section for this program (copy + GIF).",
+      fields: [
+        defineField({
+          name: "featuredDescription",
+          title: "Featured Description",
+          type: "text",
+          description:
+            "Optional description when this program is featured on the homepage. If empty, the regular description is used."
+        }),
+        defineField({
+          name: "showcaseGif",
+          title: "Showcase GIF",
+          type: "image",
+          description: "Optional GIF demonstrating the program (shown when featured)."
+        })
+      ],
+      preview: {
+        select: {
+          featuredDescription: "featuredDescription",
+          media: "showcaseGif"
+        },
+        prepare(selection) {
+          const desc = typeof selection.featuredDescription === "string" ? selection.featuredDescription.trim() : "";
+          const subtitle = desc ? (desc.length > 72 ? `${desc.slice(0, 72)}…` : desc) : "No featured description";
+          return {
+            title: "Featured Section",
+            subtitle,
+            media: selection.media
+          };
+        }
       }
-    }),
-    defineField({
-      name: "showcaseGif",
-      title: "Showcase GIF",
-      type: "image",
-      description: "Optional GIF demonstrating the program in action (used when featured)"
-    }),
-    defineField({
-      name: "downloadLink",
-      title: "Download Link",
-      type: "url",
-      description: "External link for users to download the program"
     }),
     defineField({
       name: "cdKeys",
       title: "CD Keys",
       type: "array",
       of: [{ type: "cdKey" }],
+      components: { input: CdKeysArrayInput },
       validation: Rule =>
         Rule.custom((keys: { key?: string; status?: string }[] | undefined) => {
           if (!keys || keys.length === 0) return true;
@@ -175,9 +209,24 @@ export const program = defineType({
   preview: {
     select: {
       title: "title",
-      subtitle: "description",
+      description: "description",
       latestOfficialVersion: "latestOfficialVersion",
-      media: "image"
+      media: "image",
+      cdKeys: "cdKeys"
+    },
+    prepare(selection) {
+      const { title, description, latestOfficialVersion, media, cdKeys } = selection;
+      const n = Array.isArray(cdKeys) ? cdKeys.length : 0;
+      const keyLine = `${n} CD key${n === 1 ? "" : "s"}`;
+      const versionPart = latestOfficialVersion?.trim() ? `v${latestOfficialVersion.trim()}` : null;
+      const descTrimmed = description?.trim() ?? "";
+      const descPart = descTrimmed ? descTrimmed.slice(0, 72) + (descTrimmed.length > 72 ? "…" : "") : null;
+      const subtitle = [keyLine, versionPart, descPart].filter(Boolean).join(" · ");
+      return {
+        title: title || "Program",
+        subtitle: subtitle || keyLine,
+        media
+      };
     }
   }
 });

--- a/src/sanity/schemaTypes/program.ts
+++ b/src/sanity/schemaTypes/program.ts
@@ -145,9 +145,23 @@ export const program = defineType({
       type: "array",
       of: [{ type: "cdKey" }],
       validation: Rule =>
-        Rule.custom((keys: { key?: string }[] | undefined) => {
+        Rule.custom((keys: { key?: string; status?: string }[] | undefined) => {
           if (!keys || keys.length === 0) return true;
-          const normalized = (keys ?? [])
+          const allowed = new Set(["new", "active", "expired", "limit"]);
+          for (let i = 0; i < keys.length; i++) {
+            const k = keys[i];
+            const label = `Key #${i + 1}`;
+            if (typeof k?.key !== "string" || !k.key.trim()) {
+              return `${label}: key text is required.`;
+            }
+            if (typeof k?.status !== "string" || !k.status.trim()) {
+              return `${label}: status is required (New / Active / Expired / Limit).`;
+            }
+            if (!allowed.has(k.status.trim().toLowerCase())) {
+              return `${label}: status must be one of new, active, expired, limit.`;
+            }
+          }
+          const normalized = keys
             .map(k => (typeof k?.key === "string" ? k.key.trim().toUpperCase().replace(/\s+/g, "") : ""))
             .filter(Boolean);
           const unique = new Set(normalized);

--- a/src/sanity/schemaTypes/socialLink.ts
+++ b/src/sanity/schemaTypes/socialLink.ts
@@ -1,11 +1,11 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const socialLink = defineType({
   name: "socialLink",
   title: "Social Link",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "platform",
       title: "Platform",
       type: "string",
@@ -23,8 +23,8 @@ export const socialLink = defineType({
         layout: "dropdown"
       },
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "url",
       title: "URL",
       type: "url",
@@ -32,7 +32,7 @@ export const socialLink = defineType({
         Rule.required().uri({
           scheme: ["http", "https", "mailto"]
         })
-    }
+    })
   ],
   preview: {
     select: {

--- a/src/sanity/schemaTypes/storeDetails.ts
+++ b/src/sanity/schemaTypes/storeDetails.ts
@@ -1,41 +1,41 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const storeDetails = defineType({
   name: "storeDetails",
   title: "Store Details",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "title",
       title: "Store Title",
       type: "string"
-    },
-    {
+    }),
+    defineField({
       name: "description",
       title: "Store Description",
       type: "text"
-    },
-    {
+    }),
+    defineField({
       name: "logo",
       title: "Logo",
       type: "image"
-    },
-    {
+    }),
+    defineField({
       name: "logoLight",
       title: "Logo Light (Optional)",
       type: "image"
-    },
-    {
+    }),
+    defineField({
       name: "header",
       title: "Header",
       type: "reference",
       to: [{ type: "header" }]
-    },
-    {
+    }),
+    defineField({
       name: "footer",
       title: "Footer",
       type: "reference",
       to: [{ type: "footer" }]
-    }
+    })
   ]
 });

--- a/src/sanity/schemaTypes/trackingEvent.ts
+++ b/src/sanity/schemaTypes/trackingEvent.ts
@@ -1,11 +1,11 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 export const trackingEvent = defineType({
   name: "trackingEvent",
   title: "Analytics Event",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "event",
       title: "Event Name",
       type: "string",
@@ -18,62 +18,77 @@ export const trackingEvent = defineType({
         ]
       },
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "notFound",
       title: "Not found page view",
       type: "boolean",
       description: "True for 404 / invalid program URL on a page_viewed event (no program slug stored)."
-    },
-    { name: "programSlug", title: "Program Slug", type: "string" },
-    { name: "keyHash", title: "Key Hash", type: "string", description: "SHA-256 hash of the CD key for privacy" },
-    { name: "keyIdentifier", title: "Key Identifier", type: "string", description: "Short identifier like ABC***XYZ" },
-    { name: "keyNormalized", title: "Key Normalized", type: "string", description: "Normalized key for matching" },
-    { name: "social", title: "Social Name", type: "string" },
-    { name: "path", title: "Path", type: "string" },
-    { name: "referrer", title: "Referrer", type: "url" },
-    { name: "userAgent", title: "User Agent", type: "string" },
-    {
+    }),
+    defineField({ name: "programSlug", title: "Program Slug", type: "string" }),
+    defineField({
+      name: "keyHash",
+      title: "Key Hash",
+      type: "string",
+      description: "SHA-256 hash of the CD key for privacy"
+    }),
+    defineField({
+      name: "keyIdentifier",
+      title: "Key Identifier",
+      type: "string",
+      description: "Short identifier like ABC***XYZ"
+    }),
+    defineField({
+      name: "keyNormalized",
+      title: "Key Normalized",
+      type: "string",
+      description: "Normalized key for matching"
+    }),
+    defineField({ name: "social", title: "Social Name", type: "string" }),
+    defineField({ name: "path", title: "Path", type: "string" }),
+    defineField({ name: "referrer", title: "Referrer", type: "url" }),
+    defineField({ name: "userAgent", title: "User Agent", type: "string" }),
+    defineField({
       name: "country",
       title: "Country",
       type: "string",
       description: "User's country based on IP geolocation"
-    },
-    {
+    }),
+    defineField({
       name: "city",
       title: "City",
       type: "string",
       description: "User's city based on IP geolocation"
-    },
-    {
+    }),
+    defineField({
       name: "utm_source",
       title: "UTM Source",
       type: "string",
       description: "UTM source parameter from URL"
-    },
-    {
+    }),
+    defineField({
       name: "utm_medium",
       title: "UTM Medium",
       type: "string",
       description: "UTM medium parameter from URL"
-    },
-    {
+    }),
+    defineField({
       name: "utm_campaign",
       title: "UTM Campaign",
       type: "string",
       description: "UTM campaign parameter from URL"
-    },
-    {
+    }),
+    defineField({
       name: "ipHash",
       title: "Visitor Hash",
       type: "string",
       description: "Hashed IP + salt. Used for deduping without storing raw IP."
-    },
-    {
+    }),
+    defineField({
       name: "createdAt",
       title: "Created At",
       type: "datetime",
       initialValue: () => new Date().toISOString()
-    }
+    })
   ]
 });

--- a/src/sanity/schemaTypes/trackingEventBundle.ts
+++ b/src/sanity/schemaTypes/trackingEventBundle.ts
@@ -1,23 +1,23 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 // All fields optional - track API only includes fields that have values. event + createdAt always present in source.
 const bundledEventFields = [
-  { name: "event", title: "Event Name", type: "string" },
-  { name: "createdAt", title: "Created At", type: "datetime" },
-  { name: "programSlug", title: "Program Slug", type: "string" },
-  { name: "path", title: "Path", type: "string" },
-  { name: "referrer", title: "Referrer", type: "string" },
-  { name: "country", title: "Country", type: "string" },
-  { name: "city", title: "City", type: "string" },
-  { name: "social", title: "Social Name", type: "string" },
-  { name: "keyHash", title: "Key Hash", type: "string" },
-  { name: "keyIdentifier", title: "Key Identifier", type: "string" },
-  { name: "keyNormalized", title: "Key Normalized", type: "string" },
-  { name: "userAgent", title: "User Agent", type: "string" },
-  { name: "ipHash", title: "Visitor Hash", type: "string" },
-  { name: "utm_source", title: "UTM Source", type: "string" },
-  { name: "utm_medium", title: "UTM Medium", type: "string" },
-  { name: "utm_campaign", title: "UTM Campaign", type: "string" }
+  defineField({ name: "event", title: "Event Name", type: "string" }),
+  defineField({ name: "createdAt", title: "Created At", type: "datetime" }),
+  defineField({ name: "programSlug", title: "Program Slug", type: "string" }),
+  defineField({ name: "path", title: "Path", type: "string" }),
+  defineField({ name: "referrer", title: "Referrer", type: "string" }),
+  defineField({ name: "country", title: "Country", type: "string" }),
+  defineField({ name: "city", title: "City", type: "string" }),
+  defineField({ name: "social", title: "Social Name", type: "string" }),
+  defineField({ name: "keyHash", title: "Key Hash", type: "string" }),
+  defineField({ name: "keyIdentifier", title: "Key Identifier", type: "string" }),
+  defineField({ name: "keyNormalized", title: "Key Normalized", type: "string" }),
+  defineField({ name: "userAgent", title: "User Agent", type: "string" }),
+  defineField({ name: "ipHash", title: "Visitor Hash", type: "string" }),
+  defineField({ name: "utm_source", title: "UTM Source", type: "string" }),
+  defineField({ name: "utm_medium", title: "UTM Medium", type: "string" }),
+  defineField({ name: "utm_campaign", title: "UTM Campaign", type: "string" })
 ];
 
 export const trackingEventBundle = defineType({
@@ -25,42 +25,42 @@ export const trackingEventBundle = defineType({
   title: "Analytics Event Bundle",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "updatedAt",
       title: "Updated At",
       type: "datetime",
       description: "Last time cron added events to this bundle",
       readOnly: true
-    },
-    {
+    }),
+    defineField({
       name: "bundledAt",
       title: "Bundled At",
       type: "datetime",
       readOnly: true
-    },
-    {
+    }),
+    defineField({
       name: "timeRangeStart",
       title: "Time Range Start",
       type: "datetime",
       description: "Oldest event in this bundle"
-    },
-    {
+    }),
+    defineField({
       name: "timeRangeEnd",
       title: "Time Range End",
       type: "datetime",
       description: "Newest event in this bundle"
-    },
-    {
+    }),
+    defineField({
       name: "eventCount",
       title: "Event Count",
       type: "number",
       description: "Number of events in this bundle"
-    },
-    {
+    }),
+    defineField({
       name: "events",
       title: "Events",
       type: "array",
       of: [{ type: "object", fields: bundledEventFields }]
-    }
+    })
   ]
 });

--- a/src/sanity/schemaTypes/visitor.ts
+++ b/src/sanity/schemaTypes/visitor.ts
@@ -1,4 +1,4 @@
-import { defineType } from "sanity";
+import { defineField, defineType } from "sanity";
 
 const VISIT_TIERS = [
   { title: "New (0-1 sessions)", value: "new" },
@@ -12,101 +12,101 @@ export const visitor = defineType({
   title: "Visitor",
   type: "document",
   fields: [
-    {
+    defineField({
       name: "visitorHash",
       title: "Visitor hash",
       type: "string",
       description: "SHA-256 of IP + ANALYTICS_SALT (same as trackingEvent.ipHash)",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "visitCount",
       title: "Visit count (sessions)",
       type: "number",
       description: "Increments when last activity was more than 1 hour ago",
       initialValue: 1,
       validation: Rule => Rule.required().min(0)
-    },
-    {
+    }),
+    defineField({
       name: "lastActivityAt",
       title: "Last activity",
       type: "datetime",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "visitTier",
       title: "Visit tier",
       type: "string",
       options: { list: [...VISIT_TIERS] },
       initialValue: "new",
       validation: Rule => Rule.required()
-    },
-    {
+    }),
+    defineField({
       name: "isSpammer",
       title: "Spammer",
       type: "boolean",
       initialValue: false
-    },
-    {
+    }),
+    defineField({
       name: "reportCount",
       title: "Key reports submitted",
       type: "number",
       initialValue: 0,
       validation: Rule => Rule.required().min(0)
-    },
-    {
+    }),
+    defineField({
       name: "suggestionCount",
       title: "Key suggestions submitted",
       type: "number",
       initialValue: 0,
       validation: Rule => Rule.required().min(0)
-    },
-    {
+    }),
+    defineField({
       name: "contributionScore",
       title: "Contribution score",
       type: "number",
       description: "Incremented for each valid key report and key suggestion.",
       initialValue: 0,
       validation: Rule => Rule.required().min(0)
-    },
-    {
+    }),
+    defineField({
       name: "spamMarkedAt",
       title: "Marked spam at",
       type: "datetime"
-    },
-    {
+    }),
+    defineField({
       name: "country",
       title: "Country",
       type: "string",
       description: "Latest resolved visitor country from IP geolocation"
-    },
-    {
+    }),
+    defineField({
       name: "city",
       title: "City",
       type: "string",
       description: "Latest resolved visitor city from IP geolocation"
-    },
-    {
+    }),
+    defineField({
       name: "geoUpdatedAt",
       title: "Geo updated at",
       type: "datetime"
-    },
-    {
+    }),
+    defineField({
       name: "createdAt",
       title: "Created at",
       type: "datetime",
       initialValue: () => new Date().toISOString()
-    },
-    {
+    }),
+    defineField({
       name: "updatedAt",
       title: "Updated at",
       type: "datetime",
       initialValue: () => new Date().toISOString()
-    }
+    })
   ],
   preview: {
     select: { hash: "visitorHash", count: "visitCount", tier: "visitTier", spam: "isSpammer" },
-    prepare({ hash, count, tier, spam }) {
+    prepare({ hash, count, tier, spam }: { hash?: string; count?: number; tier?: string; spam?: boolean }) {
       const short = typeof hash === "string" ? `${hash.slice(0, 10)}…` : "?";
       return {
         title: `${short} · ${count ?? 0} visits`,

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -10,8 +10,9 @@ export interface CDKey {
   key: string;
   status: CDKeyStatus;
   version: string;
-  validFrom: string;
-  validUntil: string;
+  validFrom?: string;
+  /** Empty / omitted = lifetime (no fixed expiry). */
+  validUntil?: string;
   createdAt?: string;
 }
 
@@ -39,12 +40,19 @@ export interface ProgramAboutSectionBlock {
   points?: ProgramAboutPoint[];
 }
 
+/** Homepage featured block (Sanity `program.featured`). */
+export interface ProgramFeatured {
+  featuredDescription?: string | null;
+  showcaseGif?: SanityImageField;
+}
+
 export interface Program {
   _id: string;
   title: string;
   slug: { current: string };
   description: string;
-  featuredDescription?: string;
+  /** Homepage featured copy + GIF (nested in CMS like `seo`). */
+  featured?: ProgramFeatured;
   /** Vendor-reported current version (e.g. from product page). */
   latestOfficialVersion?: string;
   seo?: {
@@ -55,7 +63,6 @@ export interface Program {
   aboutSections?: ProgramAboutSectionBlock[];
   faq?: ProgramFaqItem[];
   image?: { asset: { url?: string; _ref?: string } };
-  showcaseGif?: { asset: { url?: string; _ref?: string } };
   downloadLink?: string;
   cdKeys: CDKey[];
   _updatedAt?: string;

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -40,7 +40,6 @@ export interface ProgramAboutSectionBlock {
   points?: ProgramAboutPoint[];
 }
 
-/** Homepage featured block (Sanity `program.featured`). */
 export interface ProgramFeatured {
   featuredDescription?: string | null;
   showcaseGif?: SanityImageField;
@@ -51,7 +50,6 @@ export interface Program {
   title: string;
   slug: { current: string };
   description: string;
-  /** Homepage featured copy + GIF (nested in CMS like `seo`). */
   featured?: ProgramFeatured;
   /** Vendor-reported current version (e.g. from product page). */
   latestOfficialVersion?: string;

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Program/CDKey shapes and props for program UI.
  */
+import type { PortableTextBlock } from "@portabletext/types";
 import type { VisitorHintData } from "@/src/lib/visitors/publicVisitorContext";
 import type { SocialData } from "../layout";
 
@@ -41,7 +42,7 @@ export interface ProgramAboutSectionBlock {
 }
 
 export interface ProgramFeatured {
-  featuredDescription?: string | null;
+  featuredDescription?: PortableTextBlock[] | string | null;
   showcaseGif?: SanityImageField;
 }
 
@@ -49,7 +50,7 @@ export interface Program {
   _id: string;
   title: string;
   slug: { current: string };
-  description: string;
+  description: PortableTextBlock[] | string;
   featured?: ProgramFeatured;
   /** Vendor-reported current version (e.g. from product page). */
   latestOfficialVersion?: string;


### PR DESCRIPTION
## Summary

Aligns the public program experience with Sanity by nesting featured fields, rendering descriptions as Portable Text, and tightening CD key authoring in Studio with validation, previews, and custom array input.

## Changelog

<!-- tags: feat, ui, enhance -->

### Highlights

- Featured marketing fields nested under program.featured in GROQ and Studio
- Program description as Portable Text on site and in admin APIs
- CdKeysArrayInput with typed status lists and richer Studio previews

### CMS & program pages

- Shared featured projection for showcaseGif and featuredDescription
- RichText on program and home featured sections; plain-text fallbacks for cards and JSON-LD
- Admin program create/update persists textarea as portable text blocks

---

## Environment Variables

None

## Testing

- Edit description with bold/links in Studio; confirm list previews and public page formatting
- Featured home block resolves nested featured fields
- PATCH description from admin modal updates public page

## Technical Details

Legacy string-only descriptions still handled in plain-text paths; migrate long-term to blocks.
