### PR TITLE
feat(seo): integrate indexnow automation and admin submission tools

### DIFF
--- a/public/c2ead36245bf40d2b1f28d4b3ec68d09.txt
+++ b/public/c2ead36245bf40d2b1f28d4b3ec68d09.txt
@@ -1,0 +1,1 @@
+c2ead36245bf40d2b1f28d4b3ec68d09

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,6 +3,7 @@ import DashboardCard from "@/src/components/admin/DashboardCard";
 import CronStatusCard from "@/src/components/admin/CronStatusCard";
 import QuickOverviewStats from "@/src/components/admin/QuickOverviewStats";
 import WelcomeHeader from "@/src/components/admin/WelcomeHeader";
+import IndexNowSubmitCard from "@/src/components/admin/IndexNowSubmitCard";
 
 export default function AdminHomePage() {
   return (
@@ -70,6 +71,13 @@ export default function AdminHomePage() {
         <h3 className="text-xl font-semibold text-gray-900 mb-4 md:mb-6">System</h3>
         <div className="grid grid-cols-1 gap-4 md:gap-6">
           <CronStatusCard />
+        </div>
+      </div>
+
+      <div className="mt-8 md:mt-12">
+        <h3 className="text-xl font-semibold text-gray-900 mb-4 md:mb-6">SEO</h3>
+        <div className="grid grid-cols-1 gap-4 md:gap-6">
+          <IndexNowSubmitCard />
         </div>
       </div>
     </ProtectedAdminLayout>

--- a/src/app/api/v1/admin/indexnow/route.ts
+++ b/src/app/api/v1/admin/indexnow/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminSession } from "@/src/lib/admin/adminAuth";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { Errors } from "@/src/lib/api/errors";
+import { client } from "@/src/sanity/lib/client";
+import { buildSiteUrl, submitIndexNow } from "@/src/lib/seo/indexnow";
+
+type SubmitMode = "all" | "programs" | "non_programs" | "custom";
+
+const NON_PROGRAM_PATHS = ["/", "/privacy", "/terms"] as const;
+
+function unique<T>(items: T[]): T[] {
+  return [...new Set(items)];
+}
+
+function parseCustomUrls(input: string): string[] {
+  return input
+    .split(/[\n,]/g)
+    .map(item => item.trim())
+    .filter(Boolean)
+    .map(item => {
+      if (item.startsWith("/")) return buildSiteUrl(item);
+      if (item.startsWith("http://") || item.startsWith("https://")) return item;
+      return buildSiteUrl(`/${item.replace(/^\/+/, "")}`);
+    });
+}
+
+async function getProgramUrls(): Promise<string[]> {
+  const programs = await client.fetch<Array<{ slug?: { current?: string } }>>(
+    `*[_type == "program" && defined(slug.current)]{ slug }`
+  );
+  const urls = [buildSiteUrl("/programs")];
+  for (const program of programs) {
+    const slug = program.slug?.current?.trim();
+    if (slug) urls.push(buildSiteUrl(`/program/${slug}`));
+  }
+  return unique(urls);
+}
+
+function getNonProgramUrls(): string[] {
+  return NON_PROGRAM_PATHS.map(path => buildSiteUrl(path));
+}
+
+/** POST /api/v1/admin/indexnow - submit URL set to IndexNow */
+export async function POST(req: NextRequest) {
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const admin = await requireAdminSession();
+  if (admin instanceof Response) return admin;
+
+  try {
+    const body = (await req.json().catch(() => ({}))) as { mode?: SubmitMode; customUrls?: string };
+    const mode = body?.mode;
+
+    if (!mode || !["all", "programs", "non_programs", "custom"].includes(mode)) {
+      return Errors.validation("mode must be one of: all, programs, non_programs, custom");
+    }
+
+    const programUrls = mode === "programs" || mode === "all" ? await getProgramUrls() : [];
+    const nonProgramUrls = mode === "non_programs" || mode === "all" ? getNonProgramUrls() : [];
+    const customUrls = mode === "custom" ? parseCustomUrls(body?.customUrls ?? "") : [];
+
+    const urls = unique([...programUrls, ...nonProgramUrls, ...customUrls]);
+    if (urls.length === 0) return Errors.validation("No URLs to submit");
+
+    await submitIndexNow(urls);
+    return NextResponse.json({
+      data: {
+        mode,
+        submittedCount: urls.length,
+        urls
+      },
+      meta: {}
+    });
+  } catch (error) {
+    console.error("[POST /api/v1/admin/indexnow]", error);
+    return Errors.internal();
+  }
+}

--- a/src/app/api/v1/admin/programs/[id]/route.ts
+++ b/src/app/api/v1/admin/programs/[id]/route.ts
@@ -6,6 +6,7 @@ import { buildImageReference } from "@/src/lib/admin/adminHelpers";
 import { plainTextToPortableText } from "@/src/lib/portableText/plainTextToPortableText";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { buildSiteUrl, submitIndexNow } from "@/src/lib/seo/indexnow";
 
 const SLUG_REGEX = /^[a-z0-9-]+$/;
 const URL_REGEX = /^https?:\/\/[^\s]+$/;
@@ -106,6 +107,12 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   try {
     const { id } = await params;
     if (!id) return Errors.badRequest("id is required");
+    const existingProgram = await client.fetch<{ slug?: { current?: string } } | null>(
+      `*[_type == "program" && _id == $id][0]{ slug }`,
+      { id }
+    );
+    if (!existingProgram) return Errors.notFound("Program not found");
+    const oldSlug = existingProgram.slug?.current?.trim() || "";
 
     const body = await req.json().catch(() => ({}));
     const updates = parseBody(body);
@@ -142,17 +149,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       type FeaturedRow = {
         featured?: { description?: unknown; showcaseGif?: unknown } | null;
       };
-      const row = await client.fetch<FeaturedRow | null>(
-        `*[_type == "program" && _id == $id][0]{ featured }`,
-        { id }
-      );
+      const row = await client.fetch<FeaturedRow | null>(`*[_type == "program" && _id == $id][0]{ featured }`, { id });
       const rawDesc = row?.featured?.description;
       const prevDesc =
-        typeof rawDesc === "string"
-          ? plainTextToPortableText(rawDesc)
-          : Array.isArray(rawDesc)
-            ? rawDesc
-            : [];
+        typeof rawDesc === "string" ? plainTextToPortableText(rawDesc) : Array.isArray(rawDesc) ? rawDesc : [];
       const prevGif = row?.featured?.showcaseGif ?? null;
       const nextDescription =
         updates.featuredCopy !== undefined
@@ -172,6 +172,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 
     const result = await patch.commit();
     revalidatePath("/sitemap.xml");
+    const nextSlug = typeof updates.slug === "string" ? updates.slug : oldSlug;
+    const urls = [buildSiteUrl(`/program/${nextSlug}`), buildSiteUrl("/programs"), buildSiteUrl("/")];
+    if (oldSlug && oldSlug !== nextSlug) urls.push(buildSiteUrl(`/program/${oldSlug}`));
+    void submitIndexNow(urls);
     return NextResponse.json({ data: result, meta: {} });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Failed to update program";
@@ -195,13 +199,18 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
     const { id } = await params;
     if (!id) return Errors.badRequest("id is required");
 
-    const existing = await client.fetch<{ _id: string } | null>(`*[_type == "program" && _id == $id][0]{ _id }`, {
-      id
-    });
+    const existing = await client.fetch<{ _id: string; slug?: { current?: string } } | null>(
+      `*[_type == "program" && _id == $id][0]{ _id, slug }`,
+      { id }
+    );
     if (!existing) return Errors.notFound("Program not found");
+    const oldSlug = existing.slug?.current?.trim() || "";
 
     await client.delete(id);
     revalidatePath("/sitemap.xml");
+    const urls = [buildSiteUrl("/programs"), buildSiteUrl("/")];
+    if (oldSlug) urls.push(buildSiteUrl(`/program/${oldSlug}`));
+    void submitIndexNow(urls);
     return new NextResponse(null, { status: 204 });
   } catch (err) {
     console.error("[DELETE /api/v1/admin/programs/[id]]", err);

--- a/src/app/api/v1/admin/programs/route.ts
+++ b/src/app/api/v1/admin/programs/route.ts
@@ -6,6 +6,7 @@ import { buildImageReference } from "@/src/lib/admin/adminHelpers";
 import { plainTextToPortableText } from "@/src/lib/portableText/plainTextToPortableText";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { buildSiteUrl, submitIndexNow } from "@/src/lib/seo/indexnow";
 
 const SLUG_REGEX = /^[a-z0-9-]+$/;
 const URL_REGEX = /^https?:\/\/[^\s]+$/;
@@ -100,6 +101,7 @@ export async function POST(req: NextRequest) {
     });
 
     revalidatePath("/sitemap.xml");
+    void submitIndexNow([buildSiteUrl(`/program/${slug}`), buildSiteUrl("/programs"), buildSiteUrl("/")]);
     return NextResponse.json({ data: doc, meta: {} }, { status: 201 });
   } catch (err) {
     console.error("[POST /api/v1/admin/programs]", err);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,6 +29,37 @@ const geistMono = Geist_Mono({
 
 export const revalidate = 60;
 
+type HeadMetaTag = {
+  name?: string;
+  property?: string;
+  content: string;
+  condition?: boolean;
+};
+
+const HEAD_METADATA_GROUPS: Record<string, HeadMetaTag[]> = {
+  verification: [
+    { name: "google-site-verification", content: "jCM2s4y7bLvOzH32pe8QtRIdwbgEOmntka957Z-tXKI" },
+    { name: "facebook-domain-verification", content: "r1iisd1vo2n1fuctve43oc853x7k3p" },
+    { name: "yandex-verification", content: "28d6f2a8e0d52c05" }
+  ],
+  technologyStack: [
+    { name: "generator", content: "Next.js" },
+    { name: "powered-by", content: "Next.js" },
+    { name: "cms", content: "Sanity.io" },
+    { name: "hosting", content: "Vercel" },
+    { name: "framework", content: "Next.js" },
+    { name: "platform", content: "Vercel" }
+  ],
+  additionalTechnology: [
+    { name: "build-tool", content: "Next.js" },
+    { name: "deployment-platform", content: "Vercel" },
+    { name: "content-management", content: "Sanity.io" },
+    { name: "database", content: "Sanity.io" },
+    { name: "cdn", content: "Vercel Edge Network" }
+  ],
+  social: [{ property: "fb:app_id", content: process.env.NEXT_PUBLIC_FB_APP_ID ?? "", condition: !!process.env.NEXT_PUBLIC_FB_APP_ID }]
+};
+
 export async function generateMetadata(): Promise<Metadata> {
   return generateHomePageMetadata();
 }
@@ -70,32 +101,22 @@ export default async function RootLayout({
   const socialData: SocialData = {
     socialLinks: storeData?.socialLinks ?? []
   };
+  const renderedHeadMetaTags = Object.entries(HEAD_METADATA_GROUPS).flatMap(([groupName, tags]) =>
+    tags
+      .filter((tag) => tag.condition !== false)
+      .map((tag, index) => (
+        <meta
+          key={`${groupName}-${tag.name ?? tag.property}-${index}`}
+          {...(tag.name ? { name: tag.name } : { property: tag.property })}
+          content={tag.content}
+        />
+      ))
+  );
 
   return (
     <html lang="en">
       <head>
-        {/* Verification Metadata */}
-        <meta name="google-site-verification" content="jCM2s4y7bLvOzH32pe8QtRIdwbgEOmntka957Z-tXKI" />
-        <meta name="facebook-domain-verification" content="r1iisd1vo2n1fuctve43oc853x7k3p" />
-        <meta name="yandex-verification" content="28d6f2a8e0d52c05" /> {/* www. */}
-
-        {/* Technology Stack Metadata */}
-        <meta name="generator" content="Next.js" />
-        <meta name="powered-by" content="Next.js" />
-        <meta name="cms" content="Sanity.io" />
-        <meta name="hosting" content="Vercel" />
-        <meta name="framework" content="Next.js" />
-        <meta name="platform" content="Vercel" />
-
-        {/* Additional Technology Information */}
-        <meta name="build-tool" content="Next.js" />
-        <meta name="deployment-platform" content="Vercel" />
-        <meta name="content-management" content="Sanity.io" />
-        <meta name="database" content="Sanity.io" />
-        <meta name="cdn" content="Vercel Edge Network" />
-
-        {/* Facebook App ID Metadata */}
-        {process.env.NEXT_PUBLIC_FB_APP_ID && <meta property="fb:app_id" content={process.env.NEXT_PUBLIC_FB_APP_ID} />}
+        {renderedHeadMetaTags}
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <SessionProvider session={session}>

--- a/src/components/admin/IndexNowSubmitCard.tsx
+++ b/src/components/admin/IndexNowSubmitCard.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+type SubmitMode = "all" | "programs" | "non_programs" | "custom";
+
+const MODE_OPTIONS: Array<{ value: SubmitMode; label: string }> = [
+  { value: "all", label: "All" },
+  { value: "programs", label: "Programs" },
+  { value: "non_programs", label: "Non Programs" },
+  { value: "custom", label: "Custom" }
+];
+
+export default function IndexNowSubmitCard() {
+  const [mode, setMode] = useState<SubmitMode>("all");
+  const [customUrls, setCustomUrls] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const isCustom = useMemo(() => mode === "custom", [mode]);
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const response = await fetch("/api/v1/admin/indexnow", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode, customUrls })
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const message = payload?.error?.message ?? payload?.error ?? "Failed to submit IndexNow URLs";
+        setError(message);
+        return;
+      }
+
+      const count = payload?.data?.submittedCount ?? 0;
+      setResult(`submitted ${count} url${count === 1 ? "" : "s"} to indexnow`);
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : "Failed to submit IndexNow URLs");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6">
+      <h4 className="text-lg font-semibold text-gray-900 mb-2">IndexNow Submit</h4>
+      <p className="text-sm text-gray-600 mb-4">Push updated URLs to Bing IndexNow without waiting for recrawl.</p>
+
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="indexnow-mode" className="block text-sm font-medium text-gray-700 mb-2">
+            URL set
+          </label>
+          <select
+            id="indexnow-mode"
+            value={mode}
+            onChange={e => setMode(e.target.value as SubmitMode)}
+            disabled={submitting}
+            className="w-full md:w-72 px-3 py-2 border border-gray-300 rounded-lg bg-white text-gray-900 text-sm cursor-pointer disabled:opacity-50">
+            {MODE_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {isCustom && (
+          <div>
+            <label htmlFor="indexnow-custom-urls" className="block text-sm font-medium text-gray-700 mb-2">
+              Custom URLs
+            </label>
+            <textarea
+              id="indexnow-custom-urls"
+              value={customUrls}
+              onChange={e => setCustomUrls(e.target.value)}
+              disabled={submitting}
+              rows={5}
+              placeholder={
+                "https://www.keyaway.app/programs\nhttps://www.keyaway.app/program/itop-vpn\n/program/some-slug"
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-gray-900 text-sm disabled:opacity-50"
+            />
+            <p className="text-xs text-gray-500 mt-2">
+              Use one URL per line (or comma-separated). Relative paths are supported.
+            </p>
+          </div>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || (isCustom && customUrls.trim().length === 0)}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer">
+            {submitting ? "Submitting..." : "Submit to IndexNow"}
+          </button>
+          {result && <p className="text-sm text-green-700">{result}</p>}
+          {error && <p className="text-sm text-red-600">{error}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/general/IdealImage.tsx
+++ b/src/components/general/IdealImage.tsx
@@ -55,6 +55,7 @@ export const IdealImage = ({
       {...shared}
       width={getImageDimensions(image).width}
       height={getImageDimensions(image).height}
+      {...(src.includes(".gif") ? { unoptimized: true } : {})}
     />
   );
 };

--- a/src/lib/seo/indexnow.ts
+++ b/src/lib/seo/indexnow.ts
@@ -1,0 +1,77 @@
+import { DEFAULT_SITE_URL } from "@/src/lib/seo/storeSeoResolve";
+
+const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
+const INDEXNOW_KEY = "c2ead36245bf40d2b1f28d4b3ec68d09";
+const INDEXNOW_KEY_FILE = `${INDEXNOW_KEY}.txt`;
+
+function resolveSiteBaseUrl(): URL {
+  const configured = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  const fallback = DEFAULT_SITE_URL;
+
+  try {
+    return new URL(configured || fallback);
+  } catch {
+    return new URL(fallback);
+  }
+}
+
+export function buildSiteUrl(pathname: string): string {
+  const base = resolveSiteBaseUrl();
+  return new URL(pathname, base).toString();
+}
+
+function normalizeIndexNowUrls(urls: string[], siteHost: string): string[] {
+  const deduped = new Set<string>();
+
+  for (const raw of urls) {
+    if (!raw) continue;
+    try {
+      const parsed = new URL(raw);
+      if (!["http:", "https:"].includes(parsed.protocol)) continue;
+      if (parsed.host !== siteHost) continue;
+      deduped.add(parsed.toString());
+    } catch {
+      continue;
+    }
+  }
+
+  return [...deduped];
+}
+
+export async function submitIndexNow(urls: string[]): Promise<void> {
+  const siteBase = resolveSiteBaseUrl();
+  const urlList = normalizeIndexNowUrls(urls, siteBase.host);
+  if (urlList.length === 0) return;
+
+  const keyLocation = buildSiteUrl(`/${INDEXNOW_KEY_FILE}`);
+
+  try {
+    const response = await fetch(INDEXNOW_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify({
+        host: siteBase.host,
+        key: INDEXNOW_KEY,
+        keyLocation,
+        urlList
+      })
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      console.warn("[indexnow] submit failed", {
+        status: response.status,
+        reason: body.slice(0, 300),
+        count: urlList.length
+      });
+      return;
+    }
+
+    console.info("[indexnow] submit ok", { count: urlList.length });
+  } catch (error) {
+    console.warn("[indexnow] submit error", {
+      error: error instanceof Error ? error.message : String(error),
+      count: urlList.length
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Introduces IndexNow automation that submits affected URLs on program changes, plus an admin SEO card for manual bulk submissions. Includes IdealImage GIF and head metadata rendering fixes.

## Changelog

<!-- tags: feat, api, fix, enhance -->

### Highlights

- Automatic IndexNow submission on admin program create/update/delete
- Admin dashboard SEO card with all/programs/non_programs/custom modes
- IndexNow key hosted at site root

### SEO

- Server helper submits normalized same-host URL lists
- Slug changes submit both old and new program URLs
- IdealImage bypasses optimization for GIF sources
- Head metadata uses grouped mapped tags to avoid whitespace nodes

---

## Environment Variables

None (uses existing NEXT_PUBLIC_SITE_URL when available)

## Testing

- Key file reachable at /{key}.txt
- Admin SEO card mode switching and custom URL textarea
- Program mutations trigger non-blocking IndexNow submissions

## Technical Details

Non-blocking IndexNow calls on admin program mutations.
