### PR TITLE
feat: visitor bundling, shorter retention, and homepage popular sort fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ src/
       analytics, events, programs, key-reports, key-suggestions, messages
     api/v1/                       # API
       analytics/track, key-reports, key-suggestions, contact
-      cron/update-expired-keys, cron/bundle-events, cron/prune-cron-runs
+      cron/update-expired-keys, cron/bundle-events, cron/bundle-visitors, cron/prune-cron-runs
       webhooks/revalidate
       admin/*                     # Protected admin APIs
   components/                     # UI (layout, program, admin, home)
@@ -155,7 +155,7 @@ In Studio, create **Program** documents and add CD keys (key, status, version, v
 
 - Set all required env vars in the Vercel project.
 - Build command: `npm run build`; output: default Next.js.
-- Optional: Vercel Cron for `/api/v1/cron/update-expired-keys`, `/api/v1/cron/bundle-events`, and `/api/v1/cron/prune-cron-runs` (use `CRON_SECRET` or Vercel’s cron headers).
+- Optional: Vercel Cron for `/api/v1/cron/update-expired-keys`, `/api/v1/cron/bundle-events`, `/api/v1/cron/bundle-visitors`, and `/api/v1/cron/prune-cron-runs` (use `CRON_SECRET` or Vercel’s cron headers).
 - **Webhook:** Point Sanity revalidate webhook to `https://yourdomain.com/api/v1/webhooks/revalidate` and set `SANITY_WEBHOOK_SECRET`.
 
 ---

--- a/src/app/api/v1/admin/events/route.ts
+++ b/src/app/api/v1/admin/events/route.ts
@@ -3,6 +3,7 @@ import { requireAdminSession } from "@/src/lib/admin/adminAuth";
 import { client } from "@/src/sanity/lib/client";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { visitorFieldsFromHashProjection } from "@/src/lib/sanity/queries";
 
 type BundledEvent = Record<string, unknown> & { _key?: string };
 
@@ -107,13 +108,14 @@ export async function GET(req: NextRequest) {
     const singular = await client.fetch<Array<Record<string, unknown> & { _id: string; _type: string }>>(
       `*[_type == "trackingEvent" ${singularFilter} ${programFilter} ${pathFilter}]{
         _id, _type, event, programSlug, notFound, social, path, referrer, country, city,
-        key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt
+        key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt,
+        ${visitorFieldsFromHashProjection}
       } | order(${sort} ${order})`,
       { term, programSlug: programSlug ?? "", path: path ?? "" }
     );
 
     const allBundles = await client.fetch<Array<{ _id: string; events: BundledEvent[] }>>(
-      `*[_type == "trackingEventBundle"]{ _id, "events": events[] }`
+      `*[_type == "trackingEventBundle"]{ _id, "events": events[]{ event, programSlug, notFound, social, path, referrer, country, city, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt, _key, ${visitorFieldsFromHashProjection} } }`
     );
 
     const matchingFromBundles: Array<{ bundleId: string; event: BundledEvent }> = [];

--- a/src/app/api/v1/admin/visitor-spammer/route.ts
+++ b/src/app/api/v1/admin/visitor-spammer/route.ts
@@ -5,6 +5,7 @@ import { client } from "@/src/sanity/lib/client";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 import { resolveVisitTier } from "@/src/lib/visitors/visitTier";
+import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
 
 export async function PATCH(req: NextRequest) {
   const { ok: rateOk } = rateLimitMiddleware(req);
@@ -22,35 +23,35 @@ export async function PATCH(req: NextRequest) {
     if (!visitorHash) return Errors.validation("visitorHash required");
 
     const now = new Date().toISOString();
-    const docId = await client.fetch<string | null>(`*[_type == "visitor" && visitorHash == $h][0]._id`, {
-      h: visitorHash
-    });
+    const resolved = await fetchVisitorByHash(visitorHash);
+    const docId = resolved?.source === "live" ? resolved._id : undefined;
 
     if (!docId) {
-      if (!isSpammer) return Errors.notFound("No visitor document for this hash");
+      if (!isSpammer && !resolved) return Errors.notFound("No visitor document for this hash");
+      const visitCount = resolved?.visitCount ?? 0;
+      const contributionScore = resolved?.contributionScore ?? 0;
+      const visitTier = resolveVisitTier(visitCount, contributionScore, isSpammer);
       await client.create({
         _type: "visitor",
         visitorHash,
-        visitCount: 0,
-        lastActivityAt: now,
-        visitTier: "new",
-        isSpammer: true,
-        reportCount: 0,
-        suggestionCount: 0,
-        contributionScore: 0,
-        spamMarkedAt: now,
+        visitCount,
+        lastActivityAt: resolved?.lastActivityAt ?? now,
+        visitTier,
+        isSpammer,
+        reportCount: resolved?.reportCount ?? 0,
+        suggestionCount: resolved?.suggestionCount ?? 0,
+        contributionScore,
+        ...(isSpammer ? { spamMarkedAt: now } : {}),
+        ...(resolved?.country ? { country: resolved.country } : {}),
+        ...(resolved?.city ? { city: resolved.city } : {}),
         createdAt: now,
         updatedAt: now
       });
-      return NextResponse.json({ data: { ok: true, visitorHash, isSpammer: true }, meta: {} });
+      return NextResponse.json({ data: { ok: true, visitorHash, isSpammer }, meta: {} });
     }
 
-    const current = await client.fetch<{ visitCount?: number; contributionScore?: number } | null>(
-      `*[_type == "visitor" && _id == $id][0]{ visitCount, contributionScore }`,
-      { id: docId }
-    );
-    const visitCount = current?.visitCount ?? 0;
-    const contributionScore = current?.contributionScore ?? 0;
+    const visitCount = resolved?.visitCount ?? 0;
+    const contributionScore = resolved?.contributionScore ?? 0;
     const visitTier = resolveVisitTier(visitCount, contributionScore, isSpammer);
 
     if (isSpammer) {

--- a/src/app/api/v1/analytics/track/route.ts
+++ b/src/app/api/v1/analytics/track/route.ts
@@ -10,6 +10,7 @@ import { isRecentDuplicateRequest } from "@/src/lib/api/shortRequestDedupe";
 import { isAutomatedAnalyticsRequest } from "@/src/lib/api/isAutomatedAnalyticsRequest";
 import { getClientIp, hashIp, getLocationFromIP } from "@/src/lib/api/requestGeo";
 import { upsertVisitorOnPageView } from "@/src/lib/visitors/upsertVisitorOnPageView";
+import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
 import { isProgramSlugPublished } from "@/src/lib/sanity/programSlugExists";
 
 const ANALYTICS_EVENTS = new Set([
@@ -136,12 +137,18 @@ export async function POST(req: NextRequest) {
     }
 
     const ipHash = ipHashEarly;
-    const visitor = ipHash
-      ? await client.fetch<{ _id?: string; isSpammer?: boolean; country?: string; city?: string } | null>(
-          `*[_type == "visitor" && visitorHash == $h][0]{ _id, isSpammer, country, city }`,
-          { h: ipHash }
-        )
-      : null;
+    const resolvedVisitor = ipHash ? await fetchVisitorByHash(ipHash) : null;
+    const visitor =
+      resolvedVisitor?.source === "live" && resolvedVisitor._id
+        ? {
+            _id: resolvedVisitor._id,
+            isSpammer: resolvedVisitor.isSpammer,
+            country: resolvedVisitor.country,
+            city: resolvedVisitor.city
+          }
+        : resolvedVisitor
+          ? { isSpammer: resolvedVisitor.isSpammer, country: resolvedVisitor.country, city: resolvedVisitor.city }
+          : null;
 
     let location: { country?: string; city?: string } | undefined =
       visitor?.country || visitor?.city ? { country: visitor.country, city: visitor.city } : undefined;

--- a/src/app/api/v1/cron/bundle-visitors/route.ts
+++ b/src/app/api/v1/cron/bundle-visitors/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { client } from "@/src/sanity/lib/client";
+import { runBundleVisitors } from "@/src/lib/visitors/bundleVisitors";
+import { verifyCronAuth, logCronRun } from "@/src/lib/api/cronUtils";
+import { Errors } from "@/src/lib/api/errors";
+
+/** GET /api/v1/cron/bundle-visitors - Cron: bundle inactive visitor documents */
+export async function GET(req: NextRequest) {
+  const { ok, source } = verifyCronAuth(req);
+  if (!ok) return Errors.unauthorized("Cron auth required");
+
+  try {
+    const result = await runBundleVisitors(false);
+
+    if (!result.ok) {
+      await logCronRun(client, {
+        job: "bundle-visitors",
+        source,
+        status: "error",
+        details: result.error ?? `created=${result.created} appended=${result.appended}`
+      });
+      return NextResponse.json(
+        {
+          error: {
+            code: "BUNDLE_FAILED",
+            message: result.error ?? "Bundle failed",
+            details: [{ created: result.created, appended: result.appended }]
+          }
+        },
+        { status: 500 }
+      );
+    }
+
+    const details =
+      result.created > 0 || result.appended > 0
+        ? `${result.created} new, ${result.appended} appended`
+        : "No visitors to bundle";
+    await logCronRun(client, { job: "bundle-visitors", source, status: "ok", details });
+
+    return NextResponse.json({
+      data: {
+        created: result.created,
+        appended: result.appended,
+        message:
+          result.created > 0 || result.appended > 0
+            ? `Bundled ${result.created} new bundle(s), appended ${result.appended} visitors`
+            : "No visitors to bundle."
+      },
+      meta: {}
+    });
+  } catch (err) {
+    console.error("[GET /api/v1/cron/bundle-visitors]", err);
+    await logCronRun(client, {
+      job: "bundle-visitors",
+      source,
+      status: "error",
+      details: err instanceof Error ? err.message : "Unknown error"
+    }).catch(() => {});
+    return Errors.internal();
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,9 @@
 /** @fileoverview Homepage: parallel Sanity fetch, bundle merge for popular programs, visitor hint, JSON-LD. */
 import { client } from "@/src/sanity/lib/client";
-import { popularProgramsByViewsQuery, siteStatsQuery } from "@lib/sanity/queries";
+import { programsWithStatsQuery, siteStatsQuery } from "@lib/sanity/queries";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
 import { getBundleCountsByProgram, mergeProgramStats } from "@/src/lib/analytics/eventsApi";
+import { sortPrograms } from "@/src/lib/program/programUtils";
 import type { ProgramWithStats } from "@/src/types/home";
 import { generateHomePageMetadata } from "@/src/lib/seo/metadata";
 import { generateHomePageJsonLd } from "@/src/lib/seo/jsonLd";
@@ -21,6 +22,8 @@ import { TAG_HOMEPAGE_PROGRAMS, TAG_HOMEPAGE_STATS } from "@/src/lib/cache/cache
 /** Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
 export const revalidate = 300;
 
+const HOMEPAGE_POPULAR_LIMIT = 8;
+
 export async function generateMetadata() {
   return generateHomePageMetadata();
 }
@@ -31,16 +34,17 @@ export default async function HomePage() {
   const weekAgoISO = weekAgo.toISOString();
 
   const [rawPopularPrograms, bundleCounts, stats, store, featuredProgram] = await Promise.all([
-    client.fetch(popularProgramsByViewsQuery, {}, { next: { tags: [TAG_HOMEPAGE_PROGRAMS] } }),
+    client.fetch(programsWithStatsQuery, {}, { next: { tags: [TAG_HOMEPAGE_PROGRAMS] } }),
     getBundleCountsByProgram(),
     client.fetch(siteStatsQuery, { weekAgo: weekAgoISO }, { next: { tags: [TAG_HOMEPAGE_STATS] } }),
     getCachedStoreDetailsDocument(),
     getFeaturedProgram()
   ]);
 
-  const popularPrograms = mergeProgramStats((rawPopularPrograms ?? []) as ProgramWithStats[], bundleCounts)
-    .sort((a, b) => (b.popularityScore ?? 0) - (a.popularityScore ?? 0))
-    .slice(0, 6) as ProgramWithStats[];
+  const popularPrograms = sortPrograms(
+    mergeProgramStats((rawPopularPrograms ?? []) as ProgramWithStats[], bundleCounts),
+    "popular"
+  ).slice(0, HOMEPAGE_POPULAR_LIMIT) as ProgramWithStats[];
 
   const normalizedPopularPrograms = popularPrograms.map(program => ({
     ...program,

--- a/src/components/admin/CronStatusCard.tsx
+++ b/src/components/admin/CronStatusCard.tsx
@@ -34,13 +34,14 @@ function SourceBadge({ source }: { source: string }) {
 function JobLabel({ job }: { job: string }) {
   const labels: Record<string, string> = {
     "bundle-events": "Bundle Events",
+    "bundle-visitors": "Bundle Visitors",
     "update-expired-keys": "Update Expired Keys",
     "prune-cron-runs": "Prune Cron Runs"
   };
   return <>{labels[job] ?? job}</>;
 }
 
-type CronJobKey = "bundle-events" | "update-expired-keys" | "prune-cron-runs";
+type CronJobKey = "bundle-events" | "bundle-visitors" | "update-expired-keys" | "prune-cron-runs";
 
 export default function CronStatusCard() {
   const [runs, setRuns] = useState<CronRun[]>([]);
@@ -80,6 +81,9 @@ export default function CronStatusCard() {
     "bundle-events": runs.find(
       r => r.job === "bundle-events" && (r.source === "vercel_cron" || r.source === "bearer")
     ),
+    "bundle-visitors": runs.find(
+      r => r.job === "bundle-visitors" && (r.source === "vercel_cron" || r.source === "bearer")
+    ),
     "update-expired-keys": runs.find(
       r => r.job === "update-expired-keys" && (r.source === "vercel_cron" || r.source === "bearer")
     ),
@@ -89,6 +93,7 @@ export default function CronStatusCard() {
   };
   const lastByJob: Record<CronJobKey, CronRun | undefined> = {
     "bundle-events": runs.find(r => r.job === "bundle-events"),
+    "bundle-visitors": runs.find(r => r.job === "bundle-visitors"),
     "update-expired-keys": runs.find(r => r.job === "update-expired-keys"),
     "prune-cron-runs": runs.find(r => r.job === "prune-cron-runs")
   };
@@ -139,6 +144,7 @@ export default function CronStatusCard() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <div className="space-y-0 min-w-0 lg:pr-8">
           <JobStatusRow job="bundle-events" schedule="Daily at 21:00 UTC" label="Bundle Events" />
+          <JobStatusRow job="bundle-visitors" schedule="Daily at 21:30 UTC" label="Bundle Visitors" />
           <JobStatusRow job="update-expired-keys" schedule="Daily at 22:00 UTC" label="Update Expired Keys" />
           <JobStatusRow job="prune-cron-runs" schedule="Daily at 03:15 UTC" label="Prune Cron Runs (60d)" />
         </div>

--- a/src/components/admin/ReportDetailsModal.tsx
+++ b/src/components/admin/ReportDetailsModal.tsx
@@ -7,6 +7,7 @@ import ModalSection from "./ModalSection";
 import { ModalCloseButton } from "@/src/components/ui/ModalCloseButton";
 import { FiAlertTriangle, FiCheck, FiX } from "react-icons/fi";
 import { client } from "@/src/sanity/lib/client";
+import { fetchVisitorsByHashes } from "@/src/lib/visitors/visitorLookup";
 import { effectiveReferrerHref, extractReferrerInfo } from "@/src/lib/analytics/analyticsUtils";
 import { visitorTierBadgeClasses } from "@/src/theme/colorSchema";
 import {
@@ -128,16 +129,12 @@ export default function ReportDetailsModal({ isOpen, onClose, report }: ReportDe
       return;
     }
     let cancelled = false;
-    client
-      .fetch<Array<{ visitorHash?: string; visitTier?: string; isSpammer?: boolean }>>(
-        `*[_type=="visitor" && visitorHash in $hashes]{ visitorHash, visitTier, isSpammer }`,
-        { hashes }
-      )
-      .then(rows => {
+    fetchVisitorsByHashes(hashes)
+      .then(map => {
         if (cancelled) return;
         const m: Record<string, { visitTier?: string; isSpammer?: boolean }> = {};
-        for (const r of rows ?? []) {
-          if (r.visitorHash) m[r.visitorHash] = { visitTier: r.visitTier, isSpammer: r.isSpammer };
+        for (const [hash, v] of map) {
+          m[hash] = { visitTier: v.visitTier, isSpammer: v.isSpammer };
         }
         setVisitorByHash(m);
       })

--- a/src/components/home/PopularProgramsSection.tsx
+++ b/src/components/home/PopularProgramsSection.tsx
@@ -3,13 +3,7 @@
 import { FaFire } from "react-icons/fa";
 import { ProgramsGrid } from "@/src/components/programs";
 import { PopularProgramsSectionProps } from "@/src/types/home";
-import { sortByPopularity } from "@/src/lib/program/programUtils";
-
 export default function PopularProgramsSection({ programs }: PopularProgramsSectionProps) {
-  // Sort programs by popularity score (highest first)
-  const sortedPrograms = sortByPopularity(programs);
-
-  // Find programs with highest stats for badges
   const maxViews = Math.max(...programs.map(p => p.viewCount), 0);
   const maxDownloads = Math.max(...programs.map(p => p.downloadCount), 0);
 
@@ -32,7 +26,7 @@ export default function PopularProgramsSection({ programs }: PopularProgramsSect
 
         {/* Programs Grid with CTAs */}
         <ProgramsGrid
-          programs={sortedPrograms}
+          programs={programs}
           maxViews={maxViews}
           maxDownloads={maxDownloads}
           showBrowseAllCTA={true}

--- a/src/lib/analytics/bundleEvents.ts
+++ b/src/lib/analytics/bundleEvents.ts
@@ -1,12 +1,13 @@
 /** @fileoverview Cron/migration: moves old `trackingEvent` docs into `trackingEventBundle`, deletes sources, optional retention window. */
 import { randomUUID } from "node:crypto";
+import {
+  BUNDLE_MAX_ITERATIONS,
+  BUNDLE_SIZE,
+  BUNDLING_RETENTION_DAYS
+} from "@/src/lib/analytics/bundlingConstants";
 import { TAG_BUNDLE_COUNTS } from "@/src/lib/cache/cacheTags";
 import { revalidateTag } from "next/cache";
 import { client } from "@/src/sanity/lib/client";
-
-const RETENTION_DAYS = 7;
-const BUNDLE_SIZE = 1000;
-const MAX_ITERATIONS = 10;
 
 const EVENT_FIELDS =
   "event, programSlug, notFound, path, referrer, country, city, social, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt";
@@ -43,11 +44,11 @@ export interface BundleEventsResult {
   error?: string;
 }
 
-/** Runs the event bundling process. Uses retention cutoff (7 days) by default. Set skipRetention=true for one-time migration. */
+/** Runs the event bundling process. Uses retention cutoff (2 days) by default. Set skipRetention=true for one-time migration. */
 export async function runBundleEvents(skipRetention = false): Promise<BundleEventsResult> {
   const cutoff = skipRetention
     ? new Date(Date.now() + 864e5).toISOString() // future = bundle all
-    : new Date(Date.now() - RETENTION_DAYS * 864e5).toISOString();
+    : new Date(Date.now() - BUNDLING_RETENTION_DAYS * 864e5).toISOString();
   let created = 0;
   let appended = 0;
 
@@ -87,7 +88,7 @@ export async function runBundleEvents(skipRetention = false): Promise<BundleEven
       `*[_type == "trackingEventBundle"] | order(timeRangeEnd desc) [0]{ timeRangeEnd }`
     );
     let after = latestBundle?.timeRangeEnd ?? "";
-    for (let i = 0; i < MAX_ITERATIONS; i++) {
+    for (let i = 0; i < BUNDLE_MAX_ITERATIONS; i++) {
       const batch = await client.fetch<Array<Record<string, unknown> & { _id: string }>>(
         after
           ? `*[_type == "trackingEvent" && createdAt < $cutoff && createdAt > $after] | order(createdAt asc) [0...$limit]{ _id, ${EVENT_FIELDS} }`

--- a/src/lib/analytics/bundlingConstants.ts
+++ b/src/lib/analytics/bundlingConstants.ts
@@ -1,0 +1,6 @@
+/** Shared retention and batch limits for analytics + visitor cron bundling. */
+export const BUNDLING_RETENTION_DAYS = 2;
+export const BUNDLING_RETENTION_MS = BUNDLING_RETENTION_DAYS * 864e5;
+export const BUNDLE_SIZE = 1000;
+/** Max new bundles created per cron invocation (raised to clear backlog faster). */
+export const BUNDLE_MAX_ITERATIONS = 30;

--- a/src/lib/analytics/eventsApi.ts
+++ b/src/lib/analytics/eventsApi.ts
@@ -1,11 +1,15 @@
 /** @fileoverview Fetches merged tracking events for admin ranges, bundle program counts for homepage, visitor tag aggregates. */
+import { BUNDLING_RETENTION_MS } from "@/src/lib/analytics/bundlingConstants";
 import { TAG_BUNDLE_COUNTS } from "@/src/lib/cache/cacheTags";
 import { PUBLIC_ISR_REVALIDATE_SECONDS } from "@/src/lib/cache/constants";
 import { client } from "@/src/sanity/lib/client";
-import { trackingEventsWithRangeQuery, trackingEventBundlesQuery, bundleCountsQuery } from "@/src/lib/sanity/queries";
+import {
+  trackingEventsWithRangeQuery,
+  trackingEventBundlesQuery,
+  bundleCountsQuery,
+  visitorTagAggregatesQuery
+} from "@/src/lib/sanity/queries";
 import { AnalyticsEventData } from "@/src/types";
-
-const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
 
 export interface BundleCountsByProgram {
   page_viewed: number;
@@ -61,11 +65,11 @@ export function mergeSingleProgramStats(
 
 /**
  * Fetches all events (singular + bundled) for a date range.
- * Skips bundle fetch when range is entirely within retention (since >= now - 7d).
+ * Skips bundle fetch when range is entirely within retention window.
  */
 export async function fetchEventsForRange(since: string, until: string): Promise<AnalyticsEventData[]> {
   const now = Date.now();
-  const retentionCutoff = new Date(now - RETENTION_MS).toISOString();
+  const retentionCutoff = new Date(now - BUNDLING_RETENTION_MS).toISOString();
   const needBundles = since < retentionCutoff;
 
   const [singular, bundles] = await Promise.all([
@@ -95,10 +99,11 @@ export async function fetchVisitorTagAggregatesForRange(
   since: string,
   until: string
 ): Promise<VisitorTagAggregateRow[]> {
-  const rows = await client.fetch<Array<{ visitTier?: string; isSpammer?: boolean }>>(
-    `*[_type == "visitor" && lastActivityAt >= $since && lastActivityAt <= $until]{ visitTier, isSpammer }`,
-    { since, until }
-  );
+  const { singular, bundled } = await client.fetch<{
+    singular?: Array<{ visitTier?: string; isSpammer?: boolean }>;
+    bundled?: Array<{ visitTier?: string; isSpammer?: boolean }>;
+  }>(visitorTagAggregatesQuery, { since, until });
+  const rows = [...(singular ?? []), ...(bundled ?? [])];
   const tierOrder = ["new", "returning", "regular", "star"] as const;
   const tierCounts = new Map<string, number>();
   let spammers = 0;

--- a/src/lib/api/cronUtils.ts
+++ b/src/lib/api/cronUtils.ts
@@ -1,7 +1,7 @@
 import { SanityClient } from "@sanity/client";
 
 export type CronSource = "vercel_cron" | "bearer" | "manual";
-export type CronJob = "bundle-events" | "update-expired-keys" | "prune-cron-runs";
+export type CronJob = "bundle-events" | "bundle-visitors" | "update-expired-keys" | "prune-cron-runs";
 
 /** Verifies cron auth (x-vercel-cron or Bearer token). Returns ok + source for logging. */
 export function verifyCronAuth(req: Request): { ok: boolean; source: CronSource } {

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -114,6 +114,17 @@ export const programBySlugQuery = `
 `;
 
 /* ------------ Analytics ------------ */
+/** Resolves tier/spammer from live visitor or archived visitor bundles (for bundled events). */
+export const visitorFieldsFromHashProjection = `
+  "visitTier": coalesce(
+    *[_type=="visitor" && visitorHash == ^.ipHash][0].visitTier,
+    *[_type=="visitorBundle"].visitors[visitorHash == ^.ipHash][0].visitTier
+  ),
+  "visitorIsSpammer": coalesce(
+    *[_type=="visitor" && visitorHash == ^.ipHash][0].isSpammer,
+    *[_type=="visitorBundle"].visitors[visitorHash == ^.ipHash][0].isSpammer
+  )`;
+
 export const trackingEventsQuery = `*[_type=="trackingEvent" && createdAt >= $since]{
       _id, event, programSlug, notFound, social, path, referrer, country, city, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt
     } | order(createdAt desc)`;
@@ -121,8 +132,7 @@ export const trackingEventsQuery = `*[_type=="trackingEvent" && createdAt >= $si
 /* ------------ Analytics with Custom Date Range ------------ */
 export const trackingEventsWithRangeQuery = `*[_type=="trackingEvent" && createdAt >= $since && createdAt <= $until]{
       _id, event, programSlug, notFound, social, path, referrer, country, city, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt,
-      "visitTier": *[_type=="visitor" && visitorHash == ^.ipHash][0].visitTier,
-      "visitorIsSpammer": *[_type=="visitor" && visitorHash == ^.ipHash][0].isSpammer
+      ${visitorFieldsFromHashProjection}
     } | order(createdAt desc)`;
 
 /* ------------ Bundle counts by program (for merging with singular counts) ------------ */
@@ -133,7 +143,15 @@ export const bundleCountsQuery = `*[_type == "trackingEventBundle"]{
 /* ------------ Bundled Events (overlaps range, events filtered in-doc) ------------ */
 export const trackingEventBundlesQuery = `*[_type == "trackingEventBundle" && timeRangeEnd >= $since && timeRangeStart <= $until]{
   _id,
-  "events": events[createdAt >= $since && createdAt <= $until]{ event, programSlug, notFound, path, referrer, country, city, social, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt, "visitTier": *[_type=="visitor" && visitorHash == ^.ipHash][0].visitTier, "visitorIsSpammer": *[_type=="visitor" && visitorHash == ^.ipHash][0].isSpammer }
+  "events": events[createdAt >= $since && createdAt <= $until]{ event, programSlug, notFound, path, referrer, country, city, social, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt, ${visitorFieldsFromHashProjection} }
+}`;
+
+/** Active + bundled visitors with lastActivityAt in range (admin tier aggregates). */
+export const visitorTagAggregatesQuery = `{
+  "singular": *[_type == "visitor" && lastActivityAt >= $since && lastActivityAt <= $until]{ visitTier, isSpammer },
+  "bundled": *[_type == "visitorBundle" && timeRangeEnd >= $since && timeRangeStart <= $until]{
+    "rows": visitors[lastActivityAt >= $since && lastActivityAt <= $until]{ visitTier, isSpammer }
+  }.rows[]
 }`;
 
 /* ------------ Key Reports ------------ */

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -178,7 +178,7 @@ export const duplicateKeyReportQuery = `*[_type=="keyReport" && ipHash == $ipHas
 /* ------------ Popular Programs (related / light cards — no per-program stats) ------------ */
 export const popularProgramsQuery = `*[_type == "program"] | order(_createdAt desc) [0...6]{ ${relatedProgramsCardProjection} }`;
 
-/* ------------ Popular Programs by Page Views (same listing + featured shape as programsWithStatsQuery) ------------ */
+/* @deprecated Use programsWithStatsQuery + mergeProgramStats + sortPrograms("popular") — GROQ order uses stored scores only. */
 export const popularProgramsByViewsQuery = `*[_type == "program"]{ ${programsListingProjection}, ${featuredBlockProjection} } | order(popularityScore desc) [0...6]`;
 
 /* ------------ Statistics ------------ */

--- a/src/lib/visitors/bundleVisitors.ts
+++ b/src/lib/visitors/bundleVisitors.ts
@@ -1,0 +1,125 @@
+/** @fileoverview Cron: moves inactive `visitor` docs into `visitorBundle`, deletes sources. */
+import { randomUUID } from "node:crypto";
+import {
+  BUNDLE_MAX_ITERATIONS,
+  BUNDLE_SIZE,
+  BUNDLING_RETENTION_DAYS
+} from "@/src/lib/analytics/bundlingConstants";
+import { client } from "@/src/sanity/lib/client";
+
+const VISITOR_FIELDS =
+  "visitorHash, visitCount, lastActivityAt, visitTier, isSpammer, reportCount, suggestionCount, contributionScore, spamMarkedAt, country, city, geoUpdatedAt, createdAt, updatedAt";
+
+function toBundledVisitor(doc: Record<string, unknown> & { _id?: string }) {
+  return {
+    _type: "bundledVisitor",
+    _key: randomUUID(),
+    visitorHash: doc.visitorHash,
+    visitCount: doc.visitCount,
+    lastActivityAt: doc.lastActivityAt,
+    visitTier: doc.visitTier,
+    isSpammer: doc.isSpammer,
+    reportCount: doc.reportCount,
+    suggestionCount: doc.suggestionCount,
+    contributionScore: doc.contributionScore,
+    spamMarkedAt: doc.spamMarkedAt,
+    country: doc.country,
+    city: doc.city,
+    geoUpdatedAt: doc.geoUpdatedAt,
+    createdAt: doc.createdAt,
+    updatedAt: doc.updatedAt
+  };
+}
+
+export interface BundleVisitorsResult {
+  ok: boolean;
+  created: number;
+  appended: number;
+  error?: string;
+}
+
+/** Bundles visitors with lastActivityAt older than retention (2 days). Set skipRetention=true for one-time migration. */
+export async function runBundleVisitors(skipRetention = false): Promise<BundleVisitorsResult> {
+  const cutoff = skipRetention
+    ? new Date(Date.now() + 864e5).toISOString()
+    : new Date(Date.now() - BUNDLING_RETENTION_DAYS * 864e5).toISOString();
+  let created = 0;
+  let appended = 0;
+
+  try {
+    while (true) {
+      const incomplete = await client.fetch<{ _id: string; visitorCount: number; timeRangeEnd: string } | null>(
+        `*[_type == "visitorBundle" && visitorCount < $limit] | order(timeRangeEnd desc) [0]{ _id, visitorCount, timeRangeEnd }`,
+        { limit: BUNDLE_SIZE }
+      );
+      if (!incomplete) break;
+
+      const limit = BUNDLE_SIZE - incomplete.visitorCount;
+      const toAdd = await client.fetch<Array<Record<string, unknown> & { _id: string }>>(
+        `*[_type == "visitor" && lastActivityAt < $cutoff && lastActivityAt > $after] | order(lastActivityAt asc) [0...$limit]{ _id, ${VISITOR_FIELDS} }`,
+        { cutoff, after: incomplete.timeRangeEnd, limit }
+      );
+      if (!toAdd.length) break;
+
+      const newVisitors = toAdd.map(d => toBundledVisitor(d));
+      const lastVisitor = toAdd[toAdd.length - 1];
+      const newTimeRangeEnd = (lastVisitor.lastActivityAt as string) ?? incomplete.timeRangeEnd;
+      const newVisitorCount = incomplete.visitorCount + toAdd.length;
+      const idsToDelete = toAdd.map(v => v._id);
+      const tx = client.transaction();
+      const now = new Date().toISOString();
+      tx.patch(incomplete._id, p =>
+        p
+          .append("visitors", newVisitors)
+          .set({ timeRangeEnd: newTimeRangeEnd, visitorCount: newVisitorCount, updatedAt: now })
+      );
+      idsToDelete.forEach(id => tx.delete(id));
+      await tx.commit();
+      appended += toAdd.length;
+    }
+
+    const latestBundle = await client.fetch<{ timeRangeEnd: string } | null>(
+      `*[_type == "visitorBundle"] | order(timeRangeEnd desc) [0]{ timeRangeEnd }`
+    );
+    let after = latestBundle?.timeRangeEnd ?? "";
+    for (let i = 0; i < BUNDLE_MAX_ITERATIONS; i++) {
+      const batch = await client.fetch<Array<Record<string, unknown> & { _id: string }>>(
+        after
+          ? `*[_type == "visitor" && lastActivityAt < $cutoff && lastActivityAt > $after] | order(lastActivityAt asc) [0...$limit]{ _id, ${VISITOR_FIELDS} }`
+          : `*[_type == "visitor" && lastActivityAt < $cutoff] | order(lastActivityAt asc) [0...$limit]{ _id, ${VISITOR_FIELDS} }`,
+        after ? { cutoff, after, limit: BUNDLE_SIZE } : { cutoff, limit: BUNDLE_SIZE }
+      );
+      if (!batch.length) break;
+
+      const visitors = batch.map(d => toBundledVisitor(d));
+      const timeRangeStart = (visitors[0].lastActivityAt as string) ?? cutoff;
+      const timeRangeEnd = (visitors[visitors.length - 1].lastActivityAt as string) ?? cutoff;
+      after = timeRangeEnd;
+      const idsToDelete = batch.map(v => v._id);
+      const tx = client.transaction();
+      const now = new Date().toISOString();
+      tx.create({
+        _type: "visitorBundle",
+        bundledAt: now,
+        updatedAt: now,
+        timeRangeStart,
+        timeRangeEnd,
+        visitorCount: visitors.length,
+        visitors
+      });
+      idsToDelete.forEach(id => tx.delete(id));
+      await tx.commit();
+      created += 1;
+    }
+
+    return { ok: true, created, appended };
+  } catch (err) {
+    console.error("Bundle-visitors error:", err);
+    return {
+      ok: false,
+      created,
+      appended,
+      error: err instanceof Error ? err.message : "Bundling failed"
+    };
+  }
+}

--- a/src/lib/visitors/isVisitorSpammerByHash.ts
+++ b/src/lib/visitors/isVisitorSpammerByHash.ts
@@ -1,11 +1,2 @@
 /** @fileoverview Read `visitor.isSpammer` by hash; used before accepting public key reports. */
-import { client } from "@/src/sanity/lib/client";
-
-export async function isVisitorSpammerByHash(visitorHash: string | undefined): Promise<boolean> {
-  if (!visitorHash) return false;
-  const row = await client.fetch<{ isSpammer?: boolean } | null>(
-    `*[_type == "visitor" && visitorHash == $h][0]{ isSpammer }`,
-    { h: visitorHash }
-  );
-  return row?.isSpammer === true;
-}
+export { isVisitorSpammerByHash } from "@/src/lib/visitors/visitorLookup";

--- a/src/lib/visitors/serverVisitorContext.ts
+++ b/src/lib/visitors/serverVisitorContext.ts
@@ -1,9 +1,9 @@
 /** @fileoverview RSC: load `visitor` by hashed IP for spammer gate and optional visitor hint payload. */
-import { client } from "@/src/sanity/lib/client";
 import { getClientIpFromForwardedHeaders, hashIp } from "@/src/lib/api/requestGeo";
 import { buildVisitorHintData } from "@/src/lib/visitors/buildVisitorHintData";
 import type { VisitTier } from "@/src/lib/visitors/visitTier";
 import type { PublicVisitorContext } from "@/src/lib/visitors/publicVisitorContext";
+import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
 
 export async function getVisitorContextForPublicPage(headersList: Headers): Promise<PublicVisitorContext> {
   const ip = getClientIpFromForwardedHeaders(headersList);
@@ -12,16 +12,7 @@ export async function getVisitorContextForPublicPage(headersList: Headers): Prom
     return { isSpammer: false, visitorHint: null };
   }
 
-  const doc = await client.fetch<{
-    isSpammer?: boolean;
-    visitTier?: VisitTier;
-    visitCount?: number;
-    reportCount?: number;
-    suggestionCount?: number;
-  } | null>(
-    `*[_type == "visitor" && visitorHash == $h][0]{ isSpammer, visitTier, visitCount, reportCount, suggestionCount }`,
-    { h: visitorHash }
-  );
+  const doc = await fetchVisitorByHash(visitorHash);
 
   if (doc?.isSpammer === true) {
     return {
@@ -35,7 +26,7 @@ export async function getVisitorContextForPublicPage(headersList: Headers): Prom
   }
 
   const visitorHint = buildVisitorHintData({
-    visitTier: doc.visitTier,
+    visitTier: doc.visitTier as VisitTier,
     visitCount: doc.visitCount ?? 0,
     reportCount: doc.reportCount ?? 0,
     suggestionCount: doc.suggestionCount ?? 0

--- a/src/lib/visitors/upsertVisitorContribution.ts
+++ b/src/lib/visitors/upsertVisitorContribution.ts
@@ -1,4 +1,5 @@
 import { client } from "@/src/sanity/lib/client";
+import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
 import { resolveVisitTier } from "@/src/lib/visitors/visitTier";
 
 export type VisitorContributionKind = "report" | "suggestion";
@@ -47,16 +48,25 @@ export async function upsertVisitorContribution(
   const nextVisitTier = resolveVisitTier(prevVisitCount, nextContributionScore, isSpammer);
 
   if (!existing?._id) {
+    const archived = await fetchVisitorByHash(visitorHash);
+    const visitCount = archived?.visitCount ?? 0;
+    const restoredReport = archived?.reportCount ?? 0;
+    const restoredSuggestion = archived?.suggestionCount ?? 0;
+    const restoredScore = archived?.contributionScore ?? 0;
+    const isSpammer = archived?.isSpammer === true;
+    const reportCount = kind === "report" ? restoredReport + 1 : restoredReport;
+    const suggestionCount = kind === "suggestion" ? restoredSuggestion + 1 : restoredSuggestion;
+    const contributionScore = restoredScore + 1;
     await client.create({
       _type: "visitor",
       visitorHash,
-      visitCount: 0,
-      lastActivityAt: now,
-      visitTier: nextVisitTier,
-      isSpammer: false,
-      reportCount: nextReportCount,
-      suggestionCount: nextSuggestionCount,
-      contributionScore: nextContributionScore,
+      visitCount,
+      lastActivityAt: archived?.lastActivityAt ?? now,
+      visitTier: resolveVisitTier(visitCount, contributionScore, isSpammer),
+      isSpammer,
+      reportCount,
+      suggestionCount,
+      contributionScore,
       createdAt: now,
       updatedAt: now
     });

--- a/src/lib/visitors/upsertVisitorOnPageView.ts
+++ b/src/lib/visitors/upsertVisitorOnPageView.ts
@@ -1,4 +1,5 @@
 import { client } from "@/src/sanity/lib/client";
+import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
 import { resolveVisitTier } from "@/src/lib/visitors/visitTier";
 
 const SESSION_GAP_MS = 60 * 60 * 1000;
@@ -25,16 +26,21 @@ export async function upsertVisitorOnPageView(
   );
 
   if (!existing) {
+    const archived = await fetchVisitorByHash(visitorHash);
+    const prevCount = archived?.visitCount ?? 0;
+    const contributionScore = archived?.contributionScore ?? 0;
+    const isSpammer = archived?.isSpammer === true;
+    const nextCount = prevCount + 1;
     await client.create({
       _type: "visitor",
       visitorHash,
-      visitCount: 1,
+      visitCount: nextCount,
       lastActivityAt: now,
-      visitTier: resolveVisitTier(1, 0, false),
-      isSpammer: false,
-      reportCount: 0,
-      suggestionCount: 0,
-      contributionScore: 0,
+      visitTier: resolveVisitTier(nextCount, contributionScore, isSpammer),
+      isSpammer,
+      reportCount: archived?.reportCount ?? 0,
+      suggestionCount: archived?.suggestionCount ?? 0,
+      contributionScore,
       ...(location?.country ? { country: location.country } : {}),
       ...(location?.city ? { city: location.city } : {}),
       ...(location?.country || location?.city ? { geoUpdatedAt: now } : {}),

--- a/src/lib/visitors/visitorLookup.ts
+++ b/src/lib/visitors/visitorLookup.ts
@@ -1,0 +1,91 @@
+/** @fileoverview Resolve visitor fields from live `visitor` docs or archived `visitorBundle` rows. */
+import { client } from "@/src/sanity/lib/client";
+
+export type ResolvedVisitor = {
+  source: "live" | "archived";
+  _id?: string;
+  visitorHash: string;
+  visitTier?: string;
+  isSpammer?: boolean;
+  visitCount?: number;
+  reportCount?: number;
+  suggestionCount?: number;
+  contributionScore?: number;
+  country?: string;
+  city?: string;
+  lastActivityAt?: string;
+};
+
+type LiveRow = Omit<ResolvedVisitor, "source" | "visitorHash"> & { visitorHash?: string };
+type ArchivedRow = Omit<ResolvedVisitor, "source" | "visitorHash"> & { visitorHash?: string };
+
+function pickLive(row: LiveRow | null | undefined, hash: string): ResolvedVisitor | null {
+  if (!row?.visitorHash) return null;
+  return { source: "live", ...row, visitorHash: hash };
+}
+
+function pickArchived(rows: ArchivedRow[] | null | undefined, hash: string): ResolvedVisitor | null {
+  const sorted = [...(rows ?? [])].sort((a, b) => {
+    const ta = a.lastActivityAt ? new Date(a.lastActivityAt).getTime() : 0;
+    const tb = b.lastActivityAt ? new Date(b.lastActivityAt).getTime() : 0;
+    return tb - ta;
+  });
+  const best = sorted.find(r => r.visitorHash === hash);
+  if (!best?.visitorHash) return null;
+  return { source: "archived", ...best, visitorHash: hash };
+}
+
+/** Latest live or archived visitor for a hash (live wins). */
+export async function fetchVisitorByHash(visitorHash: string): Promise<ResolvedVisitor | null> {
+  const { live, archived } = await client.fetch<{
+    live?: LiveRow | null;
+    archived?: ArchivedRow[];
+  }>(
+    `{
+      "live": *[_type == "visitor" && visitorHash == $h][0]{
+        _id, visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, contributionScore, country, city, lastActivityAt
+      },
+      "archived": *[_type == "visitorBundle"].visitors[visitorHash == $h]{
+        visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, contributionScore, country, city, lastActivityAt
+      }
+    }`,
+    { h: visitorHash }
+  );
+  return pickLive(live, visitorHash) ?? pickArchived(archived, visitorHash);
+}
+
+/** Batch resolve visitors by hash (live wins per hash). */
+export async function fetchVisitorsByHashes(
+  hashes: string[]
+): Promise<Map<string, ResolvedVisitor>> {
+  const unique = [...new Set(hashes.filter(Boolean))];
+  if (!unique.length) return new Map();
+
+  const { live, archived } = await client.fetch<{
+    live?: LiveRow[];
+    archived?: ArchivedRow[];
+  }>(
+    `{
+      "live": *[_type == "visitor" && visitorHash in $hashes]{
+        _id, visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, contributionScore, country, city, lastActivityAt
+      },
+      "archived": *[_type == "visitorBundle"].visitors[visitorHash in $hashes]{
+        visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, contributionScore, country, city, lastActivityAt
+      }
+    }`,
+    { hashes: unique }
+  );
+
+  const map = new Map<string, ResolvedVisitor>();
+  for (const h of unique) {
+    const row = pickLive((live ?? []).find(r => r.visitorHash === h), h) ?? pickArchived(archived, h);
+    if (row) map.set(h, row);
+  }
+  return map;
+}
+
+export async function isVisitorSpammerByHash(visitorHash: string | undefined): Promise<boolean> {
+  if (!visitorHash) return false;
+  const v = await fetchVisitorByHash(visitorHash);
+  return v?.isSpammer === true;
+}

--- a/src/sanity/schemaTypes/analytics/bundledVisitor.ts
+++ b/src/sanity/schemaTypes/analytics/bundledVisitor.ts
@@ -1,0 +1,46 @@
+import { defineField, defineType } from "sanity";
+
+const VISIT_TIERS = [
+  { title: "New (0-1 sessions)", value: "new" },
+  { title: "Returning (2-5)", value: "returning" },
+  { title: "Regular (6-15)", value: "regular" },
+  { title: "Star (16+ sessions & 5+ contributions)", value: "star" }
+] as const;
+
+/** Snapshot of a `visitor` row embedded in `visitorBundle.visitors`. */
+export const bundledVisitor = defineType({
+  name: "bundledVisitor",
+  title: "Bundled visitor",
+  type: "object",
+  fields: [
+    defineField({ name: "visitorHash", title: "Visitor hash", type: "string" }),
+    defineField({ name: "visitCount", title: "Visit count", type: "number" }),
+    defineField({ name: "lastActivityAt", title: "Last activity", type: "datetime" }),
+    defineField({
+      name: "visitTier",
+      title: "Visit tier",
+      type: "string",
+      options: { list: [...VISIT_TIERS] }
+    }),
+    defineField({ name: "isSpammer", title: "Spammer", type: "boolean" }),
+    defineField({ name: "reportCount", title: "Key reports", type: "number" }),
+    defineField({ name: "suggestionCount", title: "Key suggestions", type: "number" }),
+    defineField({ name: "contributionScore", title: "Contribution score", type: "number" }),
+    defineField({ name: "spamMarkedAt", title: "Marked spam at", type: "datetime" }),
+    defineField({ name: "country", title: "Country", type: "string" }),
+    defineField({ name: "city", title: "City", type: "string" }),
+    defineField({ name: "geoUpdatedAt", title: "Geo updated at", type: "datetime" }),
+    defineField({ name: "createdAt", title: "Created at", type: "datetime" }),
+    defineField({ name: "updatedAt", title: "Updated at", type: "datetime" })
+  ],
+  preview: {
+    select: { hash: "visitorHash", count: "visitCount", tier: "visitTier", spam: "isSpammer" },
+    prepare({ hash, count, tier, spam }: { hash?: string; count?: number; tier?: string; spam?: boolean }) {
+      const short = typeof hash === "string" ? `${hash.slice(0, 10)}…` : "?";
+      return {
+        title: `${short} · ${count ?? 0} visits`,
+        subtitle: [tier, spam ? "SPAMMER" : null].filter(Boolean).join(" · ")
+      };
+    }
+  }
+});

--- a/src/sanity/schemaTypes/analytics/visitorBundle.ts
+++ b/src/sanity/schemaTypes/analytics/visitorBundle.ts
@@ -1,0 +1,46 @@
+import { defineField, defineType } from "sanity";
+
+export const visitorBundle = defineType({
+  name: "visitorBundle",
+  title: "Visitor Bundle",
+  type: "document",
+  fields: [
+    defineField({
+      name: "updatedAt",
+      title: "Updated At",
+      type: "datetime",
+      description: "Last time cron added visitors to this bundle",
+      readOnly: true
+    }),
+    defineField({
+      name: "bundledAt",
+      title: "Bundled At",
+      type: "datetime",
+      readOnly: true
+    }),
+    defineField({
+      name: "timeRangeStart",
+      title: "Time Range Start",
+      type: "datetime",
+      description: "Oldest lastActivityAt in this bundle"
+    }),
+    defineField({
+      name: "timeRangeEnd",
+      title: "Time Range End",
+      type: "datetime",
+      description: "Newest lastActivityAt in this bundle"
+    }),
+    defineField({
+      name: "visitorCount",
+      title: "Visitor Count",
+      type: "number",
+      description: "Number of visitors in this bundle"
+    }),
+    defineField({
+      name: "visitors",
+      title: "Visitors",
+      type: "array",
+      of: [{ type: "bundledVisitor" }]
+    })
+  ]
+});

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -2,7 +2,9 @@ import { type SchemaTypeDefinition } from "sanity";
 
 import { trackingEvent } from "./analytics/trackingEvent";
 import { bundledTrackingEvent } from "./analytics/bundledTrackingEvent";
+import { bundledVisitor } from "./analytics/bundledVisitor";
 import { trackingEventBundle } from "./analytics/trackingEventBundle";
+import { visitorBundle } from "./analytics/visitorBundle";
 import { keyReport } from "./analytics/keyReport";
 import { visitor } from "./analytics/visitor";
 
@@ -25,7 +27,9 @@ export const schema: { types: SchemaTypeDefinition[] } = {
   types: [
     trackingEvent,
     bundledTrackingEvent,
+    bundledVisitor,
     trackingEventBundle,
+    visitorBundle,
     keyReport,
     cronRun,
     siteNotificationFeed,

--- a/src/sanity/schemaTypes/system/cronRun.ts
+++ b/src/sanity/schemaTypes/system/cronRun.ts
@@ -13,6 +13,7 @@ export const cronRun = defineType({
       options: {
         list: [
           { title: "Bundle Events", value: "bundle-events" },
+          { title: "Bundle Visitors", value: "bundle-visitors" },
           { title: "Update Expired Keys", value: "update-expired-keys" },
           { title: "Prune Cron Runs", value: "prune-cron-runs" }
         ]

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
   "crons": [
-    { "path": "/api/v1/cron/update-expired-keys", "schedule": "0 22 * * *" },
+    { "path": "/api/v1/cron/prune-cron-runs", "schedule": "15 3 * * *" },
     { "path": "/api/v1/cron/bundle-events", "schedule": "0 21 * * *" },
-    { "path": "/api/v1/cron/prune-cron-runs", "schedule": "15 3 * * *" }
+    { "path": "/api/v1/cron/bundle-visitors", "schedule": "30 21 * * *" },
+    { "path": "/api/v1/cron/update-expired-keys", "schedule": "0 22 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary

Reduces Sanity document growth by bundling inactive visitors and tightening analytics retention, while fixing homepage most popular to use the same post-merge sort as /programs.

## Changelog

<!-- tags: feat, perf, api -->

### Highlights

- Daily visitor bundling cron archives inactive visitors into bundles
- Analytics retention shortened from 7 to 2 days with higher bundle throughput
- Homepage popular sort matches /programs after mergeProgramStats

### Data & analytics

- New visitorBundle and bundledVisitor Sanity types with runBundleVisitors cron
- Unified fetchVisitorByHash across live and archived records
- Spammer checks include bundled visitor hashes

---

## Environment Variables

None

## Testing

- Trigger bundle-events and bundle-visitors crons; confirm cronRun logs
- Admin events: tier badges on old events spanning bundled data
- Homepage vs /programs?sort=popular: same top programs

## Technical Details

Addresses approaching Sanity 10k document limit. Returning visitors get a new live visitor doc with stats restored from archived snapshot.
