### PR TITLE
perf(admin): paginated events, analytics summary, and 120s cache

### DIFF
--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -4,8 +4,12 @@
 import { useState, useEffect, useCallback } from "react";
 import { allProgramsQuery } from "@/src/lib/sanity/queries";
 import { client } from "@/src/sanity/lib/client";
-import { fetchEventsForRangeFromAdminApi, fetchVisitorTagAggregatesForRange } from "@/src/lib/analytics/eventsApi";
-import type { VisitorTagAggregateRow } from "@/src/lib/analytics/eventsApi";
+import {
+  fetchAnalyticsSummary,
+  fetchVisitorTagAggregatesForRange,
+  type AnalyticsSummaryData,
+  type VisitorTagAggregateRow
+} from "@/src/lib/analytics/eventsApi";
 import { visitorTierSwatchBgClass } from "@/src/theme/colorSchema";
 import ProtectedAdminLayout from "@/src/components/admin/ProtectedAdminLayout";
 import AnalyticsCard from "@/src/components/admin/AnalyticsCard";
@@ -13,58 +17,60 @@ import DataTable from "@/src/components/admin/DataTable";
 import EventChart from "@/src/components/admin/EventChart";
 import TimeFilter from "@/src/components/admin/TimeFilter";
 import RecentActivity from "@/src/components/admin/RecentActivity";
-import { Program, AnalyticsEventData } from "@/src/types";
-import {
-  getDateRange,
-  aggregateEvents,
-  transformEventData,
-  transformProgramData,
-  transformSocialData,
-  transformPathActivityTable,
-  transformCountryData,
-  transformReferrerDataWithParams
-} from "@/src/lib/analytics/analyticsUtils";
+import { Program } from "@/src/types";
+import { getDateRange } from "@/src/lib/analytics/analyticsUtils";
 
 export default function AnalyticsPage() {
-  const [events, setEvents] = useState<AnalyticsEventData[]>([]);
+  const [summary, setSummary] = useState<AnalyticsSummaryData | null>(null);
   const [programs, setPrograms] = useState<Program[]>([]);
   const [visitorTagRows, setVisitorTagRows] = useState<VisitorTagAggregateRow[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selectedPeriod, setSelectedPeriod] = useState("30d");
+  const [refreshing, setRefreshing] = useState(false);
+  const [selectedPeriod, setSelectedPeriod] = useState("24h");
   const [customDateRange, setCustomDateRange] = useState({
     start: "",
     end: ""
   });
 
-  const fetchEvents = useCallback(async () => {
-    setLoading(true);
-    try {
-      if (selectedPeriod === "custom" && (!customDateRange.start || !customDateRange.end)) {
-        setEvents([]);
-        setPrograms([]);
-        setVisitorTagRows([]);
+  const fetchData = useCallback(
+    async (options?: { refresh?: boolean }) => {
+      const isRefresh = options?.refresh === true;
+      if (isRefresh) setRefreshing(true);
+      else setLoading(true);
+
+      try {
+        if (selectedPeriod === "custom" && (!customDateRange.start || !customDateRange.end)) {
+          setSummary(null);
+          setPrograms([]);
+          setVisitorTagRows([]);
+          return;
+        }
+        const { since, until } = getDateRange(selectedPeriod, customDateRange);
+        const [summaryData, programsData, visitorRows] = await Promise.all([
+          fetchAnalyticsSummary(since, until, { refresh: isRefresh }),
+          client.fetch(allProgramsQuery),
+          fetchVisitorTagAggregatesForRange(since, until)
+        ]);
+        setSummary(summaryData);
+        setPrograms(programsData);
+        setVisitorTagRows(visitorRows);
+      } catch (error) {
+        console.error("Error fetching analytics:", error);
+      } finally {
         setLoading(false);
-        return;
+        setRefreshing(false);
       }
-      const { since, until } = getDateRange(selectedPeriod, customDateRange);
-      const [eventsData, programsData, visitorRows] = await Promise.all([
-        fetchEventsForRangeFromAdminApi(since, until),
-        client.fetch(allProgramsQuery),
-        fetchVisitorTagAggregatesForRange(since, until)
-      ]);
-      setEvents(eventsData);
-      setPrograms(programsData);
-      setVisitorTagRows(visitorRows);
-    } catch (error) {
-      console.error("Error fetching events:", error);
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedPeriod, customDateRange]);
+    },
+    [selectedPeriod, customDateRange]
+  );
 
   useEffect(() => {
-    fetchEvents();
-  }, [fetchEvents]);
+    fetchData();
+  }, [fetchData]);
+
+  const handleRefresh = () => {
+    fetchData({ refresh: true });
+  };
 
   const handlePeriodChange = (period: string) => {
     setSelectedPeriod(period);
@@ -74,12 +80,10 @@ export default function AnalyticsPage() {
     setCustomDateRange({ start, end });
   };
 
-  const { totals, byProgram, bySocial, byPath, byCountry } = aggregateEvents(events);
-  const totalEvents = events.length;
   const totalPrograms = programs.filter(p => p.slug?.current).length;
-  const uniqueVisitors = new Set(events.map(e => e.ipHash).filter(Boolean)).size;
+  const totals = summary?.totals ?? {};
 
-  if (loading) {
+  if (loading && !refreshing) {
     return (
       <ProtectedAdminLayout title="Analytics" subtitle="Real-time insights into user behavior and engagement">
         <div className="flex items-center justify-center h-64">
@@ -92,12 +96,13 @@ export default function AnalyticsPage() {
     );
   }
 
-  const eventData = transformEventData(totals);
-  const programData = transformProgramData(byProgram);
-  const socialData = transformSocialData(bySocial);
-  const pathData = transformPathActivityTable(events, byPath);
-  const countryData = transformCountryData(byCountry);
-  const referrerData = transformReferrerDataWithParams(events);
+  const eventData = summary?.eventChart ?? [];
+  const programData = summary?.programTable ?? [];
+  const socialData = summary?.socialTable ?? [];
+  const pathData = summary?.pathTable ?? [];
+  const countryData = summary?.countryTable ?? [];
+  const referrerData = summary?.referrerTable ?? [];
+  const recentEvents = summary?.recentEvents ?? [];
 
   return (
     <ProtectedAdminLayout title="Analytics" subtitle="Real-time insights into user behavior and engagement">
@@ -107,11 +112,20 @@ export default function AnalyticsPage() {
           onPeriodChange={handlePeriodChange}
           customDateRange={customDateRange}
           onCustomDateChange={handleCustomDateChange}
+          onRefresh={handleRefresh}
+          refreshing={refreshing}
+          refreshDisabled={loading}
         />
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-6 gap-4 mb-8">
-        <AnalyticsCard title="Total Events" value={totalEvents} subtitle="Last 30 days" icon="📊" color="blue" />
+        <AnalyticsCard
+          title="Total Events"
+          value={summary?.totalEvents ?? 0}
+          subtitle="Selected period"
+          icon="📊"
+          color="blue"
+        />
         <AnalyticsCard
           title="Total Programs"
           value={totalPrograms}
@@ -121,28 +135,28 @@ export default function AnalyticsPage() {
         />
         <AnalyticsCard
           title="Social Clicks"
-          value={totals.get("social_click") || 0}
+          value={totals.social_click ?? 0}
           subtitle="Social media engagement"
           icon="📱"
           color="purple"
         />
         <AnalyticsCard
           title="Page Views"
-          value={totals.get("page_viewed") || 0}
+          value={totals.page_viewed ?? 0}
           subtitle="Total page views"
           icon="👁️"
           color="orange"
         />
         <AnalyticsCard
           title="Unique Visitors"
-          value={uniqueVisitors}
+          value={summary?.uniqueVisitors ?? 0}
           subtitle="Distinct visitors"
           icon="👨‍👩‍👧"
           color="purple"
         />
         <AnalyticsCard
           title="Unique Countries"
-          value={byCountry.size}
+          value={summary?.uniqueCountries ?? 0}
           subtitle="Geographic reach"
           icon="🌍"
           color="blue"
@@ -173,13 +187,12 @@ export default function AnalyticsPage() {
             label: r.label,
             swatchClass: visitorTierSwatchBgClass(r.key)
           }))}
-          maxItems={10}
           showPercentage={true}
         />
         <DataTable title="Social Media Engagement" data={socialData} maxItems={10} showPercentage={true} />
       </div>
 
-      <RecentActivity events={events} maxItems={10} />
+      <RecentActivity events={recentEvents} maxItems={10} />
     </ProtectedAdminLayout>
   );
 }

--- a/src/app/admin/analytics/page.tsx
+++ b/src/app/admin/analytics/page.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { allProgramsQuery } from "@/src/lib/sanity/queries";
 import { client } from "@/src/sanity/lib/client";
-import { fetchEventsForRange, fetchVisitorTagAggregatesForRange } from "@/src/lib/analytics/eventsApi";
+import { fetchEventsForRangeFromAdminApi, fetchVisitorTagAggregatesForRange } from "@/src/lib/analytics/eventsApi";
 import type { VisitorTagAggregateRow } from "@/src/lib/analytics/eventsApi";
 import { visitorTierSwatchBgClass } from "@/src/theme/colorSchema";
 import ProtectedAdminLayout from "@/src/components/admin/ProtectedAdminLayout";
@@ -48,7 +48,7 @@ export default function AnalyticsPage() {
       }
       const { since, until } = getDateRange(selectedPeriod, customDateRange);
       const [eventsData, programsData, visitorRows] = await Promise.all([
-        fetchEventsForRange(since, until),
+        fetchEventsForRangeFromAdminApi(since, until),
         client.fetch(allProgramsQuery),
         fetchVisitorTagAggregatesForRange(since, until)
       ]);

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -9,7 +9,7 @@ import { SortableColumn, SortDirection } from "@/src/components/ui/SortableTable
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { AnalyticsEventData } from "@/src/types";
 import { getDateRange } from "@/src/lib/analytics/analyticsUtils";
-import { fetchEventsForRange } from "@/src/lib/analytics/eventsApi";
+import { fetchEventsForRangeFromAdminApi } from "@/src/lib/analytics/eventsApi";
 
 export default function EventsPage() {
   const [events, setEvents] = useState<AnalyticsEventData[]>([]);
@@ -45,7 +45,7 @@ export default function EventsPage() {
         return;
       }
       const { since, until } = getDateRange(selectedPeriod, customDateRange);
-      const eventsData = await fetchEventsForRange(since, until);
+      const eventsData = await fetchEventsForRangeFromAdminApi(since, until);
       setEvents(eventsData);
     } catch (error) {
       console.error("Error fetching events:", error);

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -6,19 +6,31 @@ import TimeFilter from "@/src/components/admin/TimeFilter";
 import EventsFilter from "@/src/components/admin/events/EventsFilter";
 import EventsTable from "@/src/components/admin/events/EventsTable";
 import { SortableColumn, SortDirection } from "@/src/components/ui/SortableTableHead";
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { AnalyticsEventData } from "@/src/types";
 import { getDateRange } from "@/src/lib/analytics/analyticsUtils";
-import { fetchEventsForRangeFromAdminApi } from "@/src/lib/analytics/eventsApi";
+import { fetchAdminEventsPage } from "@/src/lib/analytics/eventsApi";
+
+const SORT_API_MAP: Record<string, string> = {
+  timestamp: "createdAt",
+  event: "event",
+  program: "programSlug",
+  social: "social",
+  path: "path"
+};
 
 export default function EventsPage() {
   const [events, setEvents] = useState<AnalyticsEventData[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selectedEvent, setSelectedEvent] = useState<string>("all");
-  const [selectedPeriod, setSelectedPeriod] = useState("30d");
+  const [refreshing, setRefreshing] = useState(false);
+  const [selectedEvent, setSelectedEvent] = useState("all");
+  const [selectedPeriod, setSelectedPeriod] = useState("24h");
   const [currentPage, setCurrentPage] = useState(1);
-  const [sortColumn, setSortColumn] = useState<string>("timestamp");
+  const [sortColumn, setSortColumn] = useState("timestamp");
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [countsByEvent, setCountsByEvent] = useState<Record<string, number>>({});
+  const [totalItems, setTotalItems] = useState(0);
+  const [totalPages, setTotalPages] = useState(1);
   const [customDateRange, setCustomDateRange] = useState({
     start: "",
     end: ""
@@ -36,27 +48,53 @@ export default function EventsPage() {
   ];
   const eventsPerPage = 25;
 
-  const fetchEvents = useCallback(async () => {
-    setLoading(true);
-    try {
-      if (selectedPeriod === "custom" && (!customDateRange.start || !customDateRange.end)) {
-        setEvents([]);
+  const fetchEvents = useCallback(
+    async (options?: { refresh?: boolean }) => {
+      const isRefresh = options?.refresh === true;
+      if (isRefresh) setRefreshing(true);
+      else setLoading(true);
+
+      try {
+        if (selectedPeriod === "custom" && (!customDateRange.start || !customDateRange.end)) {
+          setEvents([]);
+          setCountsByEvent({});
+          setTotalItems(0);
+          setTotalPages(1);
+          return;
+        }
+        const { since, until } = getDateRange(selectedPeriod, customDateRange);
+        const sort = SORT_API_MAP[sortColumn] ?? "createdAt";
+        const result = await fetchAdminEventsPage({
+          since,
+          until,
+          event: selectedEvent,
+          page: currentPage,
+          limit: eventsPerPage,
+          sort,
+          order: sortDirection,
+          refresh: isRefresh
+        });
+        setEvents(result.data);
+        setCountsByEvent(result.meta.countsByEvent);
+        setTotalItems(result.meta.total);
+        setTotalPages(result.meta.totalPages);
+      } catch (error) {
+        console.error("Error fetching events:", error);
+      } finally {
         setLoading(false);
-        return;
+        setRefreshing(false);
       }
-      const { since, until } = getDateRange(selectedPeriod, customDateRange);
-      const eventsData = await fetchEventsForRangeFromAdminApi(since, until);
-      setEvents(eventsData);
-    } catch (error) {
-      console.error("Error fetching events:", error);
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedPeriod, customDateRange]);
+    },
+    [selectedPeriod, customDateRange, selectedEvent, currentPage, sortColumn, sortDirection]
+  );
 
   useEffect(() => {
     fetchEvents();
   }, [fetchEvents]);
+
+  const handleRefresh = () => {
+    fetchEvents({ refresh: true });
+  };
 
   const handlePeriodChange = (period: string) => {
     setSelectedPeriod(period);
@@ -83,64 +121,9 @@ export default function EventsPage() {
     }
   };
 
-  const filteredEvents = selectedEvent === "all" ? events : events.filter(event => event.event === selectedEvent);
+  const eventTypes = Object.keys(countsByEvent).sort();
 
-  const sortedEvents = useMemo(() => {
-    return [...filteredEvents].sort((a, b) => {
-      let cmp = 0;
-      switch (sortColumn) {
-        case "visitorTags": {
-          const tag = (e: (typeof filteredEvents)[number]) =>
-            !e.ipHash ? "" : e.visitorIsSpammer ? "spammer" : e.visitTier || "new";
-          cmp = tag(a).localeCompare(tag(b));
-          break;
-        }
-        case "event":
-          cmp = a.event.localeCompare(b.event);
-          break;
-        case "program":
-          const aProgram = a.programSlug || "";
-          const bProgram = b.programSlug || "";
-          cmp = aProgram.localeCompare(bProgram);
-          break;
-        case "social": {
-          cmp = (a.social || "").localeCompare(b.social || "");
-          break;
-        }
-        case "path":
-          const aPath = a.path || "";
-          const bPath = b.path || "";
-          cmp = aPath.localeCompare(bPath);
-          break;
-        case "location":
-          const aLocation = `${a.country || ""} ${a.city || ""}`.trim();
-          const bLocation = `${b.country || ""} ${b.city || ""}`.trim();
-          cmp = aLocation.localeCompare(bLocation);
-          break;
-        case "referrer":
-          const aReferrer = a.referrer || "";
-          const bReferrer = b.referrer || "";
-          cmp = aReferrer.localeCompare(bReferrer);
-          break;
-        case "timestamp":
-          cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
-          break;
-        default:
-          return 0;
-      }
-      return sortDirection === "asc" ? cmp : -cmp;
-    });
-  }, [filteredEvents, sortColumn, sortDirection]);
-
-  const totalPages = Math.max(1, Math.ceil(sortedEvents.length / eventsPerPage));
-  const clampedPage = Math.min(currentPage, totalPages);
-  const pageStartIndex = (clampedPage - 1) * eventsPerPage;
-  const pageEndIndex = Math.min(pageStartIndex + eventsPerPage, sortedEvents.length);
-  const paginatedEvents = sortedEvents.slice(pageStartIndex, pageEndIndex);
-
-  const eventTypes = Array.from(new Set(events.map(e => e.event)));
-
-  if (loading) {
+  if (loading && !refreshing) {
     return (
       <ProtectedAdminLayout title="Events" subtitle="Track and analyze site analytics">
         <div className="flex items-center justify-center h-64">
@@ -162,17 +145,20 @@ export default function EventsPage() {
             onPeriodChange={handlePeriodChange}
             customDateRange={customDateRange}
             onCustomDateChange={handleCustomDateChange}
+            onRefresh={handleRefresh}
+            refreshing={refreshing}
+            refreshDisabled={loading}
           />
         </div>
 
         <EventsFilter
           selectedEvent={selectedEvent}
           eventTypes={[]}
-          events={events}
+          countsByEvent={{}}
+          totalCount={0}
           onEventChange={handleEventFilterChange}
         />
 
-        {/* Custom Range Message */}
         <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-6">
           <div className="flex items-center">
             <div className="shrink-0">
@@ -204,24 +190,28 @@ export default function EventsPage() {
           onPeriodChange={handlePeriodChange}
           customDateRange={customDateRange}
           onCustomDateChange={handleCustomDateChange}
+          onRefresh={handleRefresh}
+          refreshing={refreshing}
+          refreshDisabled={loading}
         />
       </div>
 
       <EventsFilter
         selectedEvent={selectedEvent}
         eventTypes={eventTypes}
-        events={events}
+        countsByEvent={countsByEvent}
+        totalCount={Object.values(countsByEvent).reduce((a, b) => a + b, 0)}
         onEventChange={handleEventFilterChange}
       />
 
       <EventsTable
-        events={paginatedEvents}
-        totalItems={sortedEvents.length}
+        events={events}
+        totalItems={totalItems}
         columns={tableColumns}
         sortColumn={sortColumn}
         sortDirection={sortDirection}
         onSort={handleSort}
-        currentPage={clampedPage}
+        currentPage={currentPage}
         totalPages={totalPages}
         itemsPerPage={eventsPerPage}
         onPageChange={setCurrentPage}

--- a/src/app/api/v1/admin/analytics/events/route.ts
+++ b/src/app/api/v1/admin/analytics/events/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminSession } from "@/src/lib/admin/adminAuth";
+import { fetchEventsForRange } from "@/src/lib/analytics/eventsApi";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+
+/** GET /api/v1/admin/analytics/events?since=&until= — server-side range fetch (no browser Sanity client). */
+export async function GET(req: NextRequest) {
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const admin = await requireAdminSession();
+  if (admin instanceof Response) return admin;
+
+  const sinceRaw = req.nextUrl.searchParams.get("since");
+  const untilRaw = req.nextUrl.searchParams.get("until");
+  if (!sinceRaw || !untilRaw) return Errors.validation("since and until are required ISO dates");
+
+  const sinceDate = new Date(sinceRaw);
+  const untilDate = new Date(untilRaw);
+  if (isNaN(sinceDate.getTime()) || isNaN(untilDate.getTime())) {
+    return Errors.validation("since and until must be valid ISO dates");
+  }
+
+  try {
+    const rows = await fetchEventsForRange(sinceDate.toISOString(), untilDate.toISOString());
+    return NextResponse.json({ data: rows, meta: { count: rows.length } });
+  } catch (err) {
+    console.error("[GET /api/v1/admin/analytics/events]", err);
+    return Errors.internal();
+  }
+}

--- a/src/app/api/v1/admin/analytics/events/route.ts
+++ b/src/app/api/v1/admin/analytics/events/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdminSession } from "@/src/lib/admin/adminAuth";
-import { fetchEventsForRange } from "@/src/lib/analytics/eventsApi";
+import { mergeTrackingEventsForRange } from "@/src/lib/analytics/mergeTrackingEventsForRange";
+import { enrichEventsWithVisitorMeta } from "@/src/lib/analytics/enrichEventsWithVisitorMeta";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 
@@ -23,7 +24,8 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const rows = await fetchEventsForRange(sinceDate.toISOString(), untilDate.toISOString());
+    const merged = await mergeTrackingEventsForRange(sinceDate.toISOString(), untilDate.toISOString());
+    const rows = await enrichEventsWithVisitorMeta(merged as unknown as Array<Record<string, unknown>>);
     return NextResponse.json({ data: rows, meta: { count: rows.length } });
   } catch (err) {
     console.error("[GET /api/v1/admin/analytics/events]", err);

--- a/src/app/api/v1/admin/analytics/summary/route.ts
+++ b/src/app/api/v1/admin/analytics/summary/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminSession } from "@/src/lib/admin/adminAuth";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import {
+  getMergedEventsForAdmin,
+  getCachedAnalyticsSummary,
+  setCachedAnalyticsSummary,
+  type AnalyticsSummaryCachePayload
+} from "@/src/lib/api/adminEventsListCache";
+import { enrichEventsWithVisitorMeta } from "@/src/lib/analytics/enrichEventsWithVisitorMeta";
+import {
+  aggregateEvents,
+  transformEventData,
+  transformProgramData,
+  transformSocialData,
+  transformPathActivityTable,
+  transformCountryData,
+  transformReferrerDataWithParams
+} from "@/src/lib/analytics/analyticsUtils";
+import { AnalyticsEventData } from "@/src/types";
+
+const RECENT_LIMIT = 10;
+
+/** GET /api/v1/admin/analytics/summary?since=&until= — server aggregates + recent activity slice. */
+export async function GET(req: NextRequest) {
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const admin = await requireAdminSession();
+  if (admin instanceof Response) return admin;
+
+  const sinceRaw = req.nextUrl.searchParams.get("since");
+  const untilRaw = req.nextUrl.searchParams.get("until");
+  if (!sinceRaw || !untilRaw) return Errors.validation("since and until are required ISO dates");
+
+  const sinceDate = new Date(sinceRaw);
+  const untilDate = new Date(untilRaw);
+  if (isNaN(sinceDate.getTime()) || isNaN(untilDate.getTime())) {
+    return Errors.validation("since and until must be valid ISO dates");
+  }
+
+  const since = sinceDate.toISOString();
+  const until = untilDate.toISOString();
+  const refresh = req.nextUrl.searchParams.get("refresh") === "true";
+
+  try {
+    const summaryCached = getCachedAnalyticsSummary(since, until, { bypass: refresh });
+    if (summaryCached) {
+      return NextResponse.json({
+        data: summaryCached.data,
+        meta: { cacheHit: true, cachedAt: summaryCached.cachedAt }
+      });
+    }
+
+    const { events: merged, cacheHit: mergeCacheHit, cachedAt: mergeCachedAt } =
+      await getMergedEventsForAdmin(since, until, { bypass: refresh });
+
+    const { totals, byProgram, bySocial, byPath, byCountry } = aggregateEvents(merged);
+    const uniqueVisitors = new Set(merged.map(e => e.ipHash).filter(Boolean)).size;
+
+    const recentSlice = merged.slice(0, RECENT_LIMIT);
+    const recentEnriched = (await enrichEventsWithVisitorMeta(
+      recentSlice as unknown as Array<Record<string, unknown>>
+    )) as unknown as AnalyticsEventData[];
+
+    const data: AnalyticsSummaryCachePayload = {
+      totalEvents: merged.length,
+      uniqueVisitors,
+      uniqueCountries: byCountry.size,
+      totals: Object.fromEntries(totals),
+      eventChart: transformEventData(totals),
+      programTable: transformProgramData(byProgram),
+      socialTable: transformSocialData(bySocial),
+      pathTable: transformPathActivityTable(merged, byPath),
+      countryTable: transformCountryData(byCountry),
+      referrerTable: transformReferrerDataWithParams(merged),
+      recentEvents: recentEnriched
+    };
+
+    const cachedAt = setCachedAnalyticsSummary(since, until, data);
+
+    return NextResponse.json({
+      data,
+      meta: { cacheHit: mergeCacheHit, cachedAt: refresh ? mergeCachedAt : cachedAt }
+    });
+  } catch (err) {
+    console.error("[GET /api/v1/admin/analytics/summary]", err);
+    return Errors.internal();
+  }
+}

--- a/src/app/api/v1/admin/events/route.ts
+++ b/src/app/api/v1/admin/events/route.ts
@@ -4,12 +4,17 @@ import { client } from "@/src/sanity/lib/client";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 import { enrichEventsWithVisitorMeta } from "@/src/lib/analytics/enrichEventsWithVisitorMeta";
+import {
+  getMergedEventsForAdmin,
+  invalidateMergedEventsCache
+} from "@/src/lib/api/adminEventsListCache";
+import { AnalyticsEventData } from "@/src/types";
 
 type BundledEvent = Record<string, unknown> & { _key?: string };
 
 const SORT_FIELDS = ["createdAt", "event", "programSlug", "path", "social"] as const;
 const MAX_PAGE_SIZE = 100;
-const DEFAULT_PAGE_SIZE = 20;
+const DEFAULT_PAGE_SIZE = 25;
 
 function eventHasStringValue(event: Record<string, unknown>, search: string): boolean {
   for (const v of Object.values(event)) {
@@ -28,19 +33,57 @@ function matchesFilter(
   return true;
 }
 
-/** Parse and validate GET query params */
+function countsByEventFrom(events: AnalyticsEventData[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const e of events) {
+    out[e.event] = (out[e.event] ?? 0) + 1;
+  }
+  return out;
+}
+
+function sortEvents(
+  events: AnalyticsEventData[],
+  sort: (typeof SORT_FIELDS)[number],
+  order: "asc" | "desc"
+): AnalyticsEventData[] {
+  const sorted = [...events];
+  sorted.sort((a, b) => {
+    const va = a[sort as keyof AnalyticsEventData];
+    const vb = b[sort as keyof AnalyticsEventData];
+    if (va == null && vb == null) return 0;
+    if (va == null) return order === "asc" ? 1 : -1;
+    if (vb == null) return order === "asc" ? -1 : 1;
+    const cmp = String(va).localeCompare(String(vb), undefined, { numeric: true });
+    return order === "asc" ? cmp : -cmp;
+  });
+  return sorted;
+}
+
+function parseRangeParams(searchParams: URLSearchParams): { since: string; until: string } | null {
+  const sinceRaw = searchParams.get("since");
+  const untilRaw = searchParams.get("until");
+  if (!sinceRaw || !untilRaw) return null;
+  const sinceDate = new Date(sinceRaw);
+  const untilDate = new Date(untilRaw);
+  if (isNaN(sinceDate.getTime()) || isNaN(untilDate.getTime())) return null;
+  return { since: sinceDate.toISOString(), until: untilDate.toISOString() };
+}
+
 function parseGetParams(searchParams: URLSearchParams): {
-  search?: string;
-  programSlug?: string;
-  path?: string;
+  since: string;
+  until: string;
+  event?: string;
   page: number;
   limit: number;
-  sort: string;
+  sort: (typeof SORT_FIELDS)[number];
   order: "asc" | "desc";
+  refresh: boolean;
 } | null {
-  const search = searchParams.get("search") ?? undefined;
-  const programSlug = searchParams.get("programSlug") ?? undefined;
-  const path = searchParams.get("path") ?? undefined;
+  const range = parseRangeParams(searchParams);
+  if (!range) return null;
+
+  const event = searchParams.get("event") ?? undefined;
+  if (event !== undefined && (typeof event !== "string" || event.length > 100)) return null;
 
   const pageRaw = searchParams.get("page") ?? "1";
   const page = Math.max(1, parseInt(pageRaw, 10));
@@ -50,30 +93,25 @@ function parseGetParams(searchParams: URLSearchParams): {
   const limit = Math.min(MAX_PAGE_SIZE, Math.max(1, parseInt(limitRaw, 10)));
   if (isNaN(limit)) return null;
 
-  const sort = searchParams.get("sort") ?? "createdAt";
-  if (!SORT_FIELDS.includes(sort as (typeof SORT_FIELDS)[number])) return null;
+  let sort = (searchParams.get("sort") ?? "createdAt") as (typeof SORT_FIELDS)[number];
+  if (sort === ("timestamp" as typeof sort)) sort = "createdAt";
+  if (!SORT_FIELDS.includes(sort)) return null;
 
   const order = (searchParams.get("order") ?? "desc").toLowerCase();
   if (order !== "asc" && order !== "desc") return null;
 
-  // Input validation
-  if (search !== undefined && (typeof search !== "string" || search.length > 200)) return null;
-  if (programSlug !== undefined && (typeof programSlug !== "string" || programSlug.length > 100)) return null;
-  if (path !== undefined && (typeof path !== "string" || path.length > 500)) return null;
+  const refresh = searchParams.get("refresh") === "true";
 
-  return { search, programSlug, path, page, limit, sort, order };
+  return { ...range, event, page, limit, sort, order, refresh };
 }
 
 /**
  * GET /api/v1/admin/events
- * List/search events with pagination, filtering, sorting.
- * Admin-only. Rate limited.
+ * Paginated events for a date range. Merged list cached ~120s; refresh=true bypasses cache.
  */
 export async function GET(req: NextRequest) {
   const { ok: rateOk, remaining } = rateLimitMiddleware(req);
-  if (!rateOk) {
-    return Errors.tooManyRequests();
-  }
+  if (!rateOk) return Errors.tooManyRequests();
 
   const admin = await requireAdminSession();
   if (admin instanceof Response) return admin;
@@ -81,6 +119,7 @@ export async function GET(req: NextRequest) {
   const params = parseGetParams(req.nextUrl.searchParams);
   if (!params) {
     return Errors.validation("Invalid query parameters", [
+      { field: "since", message: "since and until are required ISO dates" },
       { field: "page", message: "page must be >= 1" },
       { field: "limit", message: `limit must be 1-${MAX_PAGE_SIZE}` },
       { field: "sort", message: `sort must be one of: ${SORT_FIELDS.join(", ")}` },
@@ -89,81 +128,36 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    const { search, programSlug, path, page, limit, sort, order } = params;
+    const { since, until, event, page, limit, sort, order, refresh } = params;
 
-    // Build GROQ filter for singular events
-    const term = search ?? "";
-    const singularFilter =
-      term !== ""
-        ? `&& (
-          path == $term || programSlug == $term || social == $term || referrer == $term ||
-          country == $term || city == $term || key == $term || activationUrl == $term ||
-          programFlow == $term || userAgent == $term || utm_source == $term ||
-          utm_medium == $term || utm_campaign == $term
-        )`
-        : "";
-    const programFilter = programSlug ? `&& programSlug == $programSlug` : "";
-    const pathFilter = path ? `&& path == $path` : "";
-
-    const singular = await client.fetch<Array<Record<string, unknown> & { _id: string; _type: string }>>(
-      `*[_type == "trackingEvent" ${singularFilter} ${programFilter} ${pathFilter}]{
-        _id, _type, event, programSlug, notFound, social, path, referrer, country, city,
-        key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt
-      } | order(${sort} ${order})`,
-      { term, programSlug: programSlug ?? "", path: path ?? "" }
-    );
-
-    const allBundles = await client.fetch<Array<{ _id: string; events: BundledEvent[] }>>(
-      `*[_type == "trackingEventBundle"]{ _id, "events": events[]{ event, programSlug, notFound, social, path, referrer, country, city, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt, _key } }`
-    );
-
-    const matchingFromBundles: Array<{ bundleId: string; event: BundledEvent }> = [];
-    for (const b of allBundles ?? []) {
-      for (const e of b.events ?? []) {
-        const ev = e as Record<string, unknown>;
-        if (matchesFilter(ev, { search: term || undefined, programSlug, path })) {
-          matchingFromBundles.push({ bundleId: b._id, event: e });
-        }
-      }
-    }
-
-    // Normalize: singular have _id, bundled have _key + bundleId
-    let allEvents = [
-      ...(singular ?? []).map(s => ({ ...s, source: "singular" as const })),
-      ...matchingFromBundles.map(({ bundleId, event }) => ({
-        ...event,
-        _id: `${bundleId}#${(event as BundledEvent)._key ?? "0"}`,
-        bundleId,
-        source: "bundle" as const
-      }))
-    ];
-
-    allEvents = await enrichEventsWithVisitorMeta(allEvents);
-
-    // Sort merged (simple in-memory; singular already sorted)
-    allEvents.sort((a, b) => {
-      const va = (a as Record<string, unknown>)[sort];
-      const vb = (b as Record<string, unknown>)[sort];
-      if (va == null && vb == null) return 0;
-      if (va == null) return order === "asc" ? 1 : -1;
-      if (vb == null) return order === "asc" ? -1 : 1;
-      const cmp = String(va).localeCompare(String(vb), undefined, { numeric: true });
-      return order === "asc" ? cmp : -cmp;
+    const { events: merged, cacheHit, cachedAt } = await getMergedEventsForAdmin(since, until, {
+      bypass: refresh
     });
 
-    const total = allEvents.length;
-    const totalPages = Math.ceil(total / limit);
+    const countsByEvent = countsByEventFrom(merged);
+    const filtered = event && event !== "all" ? merged.filter(e => e.event === event) : merged;
+
+    const sorted = sortEvents(filtered, sort, order);
+    const total = sorted.length;
+    const totalPages = Math.max(1, Math.ceil(total / limit));
     const offset = (page - 1) * limit;
-    const data = allEvents.slice(offset, offset + limit);
+    const pageSlice = sorted.slice(offset, offset + limit);
+
+    const enriched = (await enrichEventsWithVisitorMeta(
+      pageSlice as unknown as Array<Record<string, unknown>>
+    )) as unknown as AnalyticsEventData[];
 
     const res = NextResponse.json({
-      data,
+      data: enriched,
       meta: {
         page,
         limit,
         total,
         totalPages,
-        hasMore: page < totalPages
+        hasMore: page < totalPages,
+        countsByEvent,
+        cacheHit,
+        cachedAt
       }
     });
     res.headers.set("X-RateLimit-Remaining", String(remaining));
@@ -176,7 +170,7 @@ export async function GET(req: NextRequest) {
 
 /** Parse and validate PATCH body */
 function parsePatchBody(body: unknown): {
-  filter: { programSlug?: string; path?: string; search?: string };
+  filter: { programSlug?: string; path?: string; search?: string; since?: string; until?: string };
   patch: { programSlug?: string; path?: string };
 } | null {
   if (body == null || typeof body !== "object") return null;
@@ -185,11 +179,19 @@ function parsePatchBody(body: unknown): {
   const patch = o.patch as Record<string, unknown> | undefined;
   if (!filter || typeof filter !== "object" || !patch || typeof patch !== "object") return null;
 
-  const outFilter: { programSlug?: string; path?: string; search?: string } = {};
+  const outFilter: {
+    programSlug?: string;
+    path?: string;
+    search?: string;
+    since?: string;
+    until?: string;
+  } = {};
   if (typeof filter.programSlug === "string" && filter.programSlug.length <= 100)
     outFilter.programSlug = filter.programSlug;
   if (typeof filter.path === "string" && filter.path.length <= 500) outFilter.path = filter.path;
   if (typeof filter.search === "string" && filter.search.length <= 200) outFilter.search = filter.search;
+  if (typeof filter.since === "string") outFilter.since = filter.since;
+  if (typeof filter.until === "string") outFilter.until = filter.until;
 
   const outPatch: { programSlug?: string; path?: string } = {};
   if (typeof patch.programSlug === "string" && patch.programSlug.length <= 100)
@@ -197,14 +199,13 @@ function parsePatchBody(body: unknown): {
   if (typeof patch.path === "string" && patch.path.length <= 500) outPatch.path = patch.path;
 
   if (Object.keys(outPatch).length === 0) return null;
-  if (Object.keys(outFilter).length === 0) return null; // Require filter to avoid accidental bulk update
+  if (Object.keys(outFilter).length === 0) return null;
   return { filter: outFilter, patch: outPatch };
 }
 
 /**
  * PATCH /api/v1/admin/events
  * Bulk update events matching filter. Admin-only.
- * Body: { filter: { programSlug?, path?, search? }, patch: { programSlug?, path?, ... } }
  */
 export async function PATCH(req: NextRequest) {
   const { ok: rateOk } = rateLimitMiddleware(req);
@@ -232,7 +233,6 @@ export async function PATCH(req: NextRequest) {
   try {
     let updated = 0;
 
-    // Singular events: GROQ patch
     const groqFilterParts: string[] = ["_type == 'trackingEvent'"];
     const params: Record<string, string> = {};
     if (filter.programSlug) {
@@ -245,9 +245,17 @@ export async function PATCH(req: NextRequest) {
     }
     if (filter.search) {
       groqFilterParts.push(
-        `(path == $term || programSlug == $term || social == $term || referrer == $term || country == $term || city == $term || key == $term || activationUrl == $term || programFlow == $term || userAgent == $term || utm_source == $term || utm_medium == $term || utm_campaign == $term)`
+        `(path == $term || programSlug == $term || social == $term || referrer == $term || country == $term || city == $term)`
       );
       params.term = filter.search;
+    }
+    if (filter.since) {
+      groqFilterParts.push("createdAt >= $since");
+      params.since = new Date(filter.since).toISOString();
+    }
+    if (filter.until) {
+      groqFilterParts.push("createdAt <= $until");
+      params.until = new Date(filter.until).toISOString();
     }
 
     const singularIds = await client.fetch<string[]>(`*[${groqFilterParts.join(" && ")}]._id`, params);
@@ -263,9 +271,18 @@ export async function PATCH(req: NextRequest) {
       updated++;
     }
 
-    // Bundled events
+    const bundleFilter =
+      filter.since && filter.until
+        ? `*[_type == "trackingEventBundle" && timeRangeEnd >= $since && timeRangeStart <= $until]{ _id, "events": events[] }`
+        : `*[_type == "trackingEventBundle"]{ _id, "events": events[] }`;
+    const bundleParams =
+      filter.since && filter.until
+        ? { since: new Date(filter.since).toISOString(), until: new Date(filter.until).toISOString() }
+        : {};
+
     const allBundles = await client.fetch<Array<{ _id: string; events: BundledEvent[] }>>(
-      `*[_type == "trackingEventBundle"]{ _id, "events": events[] }`
+      bundleFilter,
+      bundleParams
     );
 
     for (const b of allBundles ?? []) {
@@ -282,6 +299,15 @@ export async function PATCH(req: NextRequest) {
       if (afterEvents.some((e, i) => e !== (b.events ?? [])[i])) {
         await client.patch(b._id).set({ events: afterEvents, eventCount: afterEvents.length }).commit();
       }
+    }
+
+    if (filter.since && filter.until) {
+      invalidateMergedEventsCache(
+        new Date(filter.since).toISOString(),
+        new Date(filter.until).toISOString()
+      );
+    } else {
+      invalidateMergedEventsCache();
     }
 
     return NextResponse.json({

--- a/src/app/api/v1/admin/events/route.ts
+++ b/src/app/api/v1/admin/events/route.ts
@@ -3,7 +3,7 @@ import { requireAdminSession } from "@/src/lib/admin/adminAuth";
 import { client } from "@/src/sanity/lib/client";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
-import { visitorFieldsFromHashProjection } from "@/src/lib/sanity/queries";
+import { enrichEventsWithVisitorMeta } from "@/src/lib/analytics/enrichEventsWithVisitorMeta";
 
 type BundledEvent = Record<string, unknown> & { _key?: string };
 
@@ -108,14 +108,13 @@ export async function GET(req: NextRequest) {
     const singular = await client.fetch<Array<Record<string, unknown> & { _id: string; _type: string }>>(
       `*[_type == "trackingEvent" ${singularFilter} ${programFilter} ${pathFilter}]{
         _id, _type, event, programSlug, notFound, social, path, referrer, country, city,
-        key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt,
-        ${visitorFieldsFromHashProjection}
+        key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt
       } | order(${sort} ${order})`,
       { term, programSlug: programSlug ?? "", path: path ?? "" }
     );
 
     const allBundles = await client.fetch<Array<{ _id: string; events: BundledEvent[] }>>(
-      `*[_type == "trackingEventBundle"]{ _id, "events": events[]{ event, programSlug, notFound, social, path, referrer, country, city, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt, _key, ${visitorFieldsFromHashProjection} } }`
+      `*[_type == "trackingEventBundle"]{ _id, "events": events[]{ event, programSlug, notFound, social, path, referrer, country, city, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt, _key } }`
     );
 
     const matchingFromBundles: Array<{ bundleId: string; event: BundledEvent }> = [];
@@ -129,7 +128,7 @@ export async function GET(req: NextRequest) {
     }
 
     // Normalize: singular have _id, bundled have _key + bundleId
-    const allEvents = [
+    let allEvents = [
       ...(singular ?? []).map(s => ({ ...s, source: "singular" as const })),
       ...matchingFromBundles.map(({ bundleId, event }) => ({
         ...event,
@@ -138,6 +137,8 @@ export async function GET(req: NextRequest) {
         source: "bundle" as const
       }))
     ];
+
+    allEvents = await enrichEventsWithVisitorMeta(allEvents);
 
     // Sort merged (simple in-memory; singular already sorted)
     allEvents.sort((a, b) => {

--- a/src/app/api/v1/admin/programs/[id]/route.ts
+++ b/src/app/api/v1/admin/programs/[id]/route.ts
@@ -58,6 +58,16 @@ function parseBody(body: unknown): Record<string, unknown> {
       out.featuredCopy = null;
     }
   }
+  if (b.latestOfficialVersion !== undefined) {
+    if (b.latestOfficialVersion === null) {
+      out.latestOfficialVersion = null;
+    } else if (typeof b.latestOfficialVersion === "string") {
+      const t = b.latestOfficialVersion.trim();
+      out.latestOfficialVersion = t.length ? t : null;
+    } else {
+      out.latestOfficialVersion = null;
+    }
+  }
   if (b.downloadLink !== undefined) {
     const v = typeof b.downloadLink === "string" ? b.downloadLink.trim() : "";
     if (v && !URL_REGEX.test(v)) throw new Error("downloadLink must be a valid URL");
@@ -127,7 +137,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     const keys = Object.keys(updates);
     if (keys.length === 0) {
       return Errors.validation(
-        "No valid fields to update (allowed: title, slug, description, programFlow, featuredCopy, downloadLink, imageAssetId, showcaseGifAssetId)"
+        "No valid fields to update (allowed: title, slug, description, programFlow, latestOfficialVersion, featuredCopy, downloadLink, imageAssetId, showcaseGifAssetId)"
       );
     }
 
@@ -150,6 +160,9 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       patch.set({ description: plainTextToPortableText(updates.description as string) });
     }
     if (updates.programFlow !== undefined) patch.set({ programFlow: updates.programFlow as ProgramFlow });
+    if (updates.latestOfficialVersion !== undefined) {
+      patch.set({ latestOfficialVersion: (updates.latestOfficialVersion as string | null) ?? null });
+    }
     if (updates.downloadLink !== undefined) patch.set({ downloadLink: (updates.downloadLink as string) ?? null });
     if (updates.imageAssetId !== undefined) {
       patch.set({ image: buildImageReference(updates.imageAssetId as string | null) });

--- a/src/app/api/v1/admin/programs/route.ts
+++ b/src/app/api/v1/admin/programs/route.ts
@@ -62,6 +62,10 @@ export async function POST(req: NextRequest) {
 
     const featuredCopy = typeof b.featuredCopy === "string" ? b.featuredCopy.trim() : "";
 
+    const latestOfficialVersionRaw =
+      typeof b.latestOfficialVersion === "string" ? b.latestOfficialVersion.trim() : "";
+    const latestOfficialVersion = latestOfficialVersionRaw || undefined;
+
     const downloadLinkRaw = typeof b.downloadLink === "string" ? b.downloadLink.trim() : "";
     if (downloadLinkRaw && !URL_REGEX.test(downloadLinkRaw)) {
       return Errors.validation("downloadLink must be a valid URL", [{ field: "downloadLink", message: "Invalid URL" }]);
@@ -106,6 +110,7 @@ export async function POST(req: NextRequest) {
       description: plainTextToPortableText(description),
       programFlow,
       ...(Object.keys(featured).length > 0 ? { featured } : {}),
+      ...(latestOfficialVersion && { latestOfficialVersion }),
       ...(downloadLink && { downloadLink }),
       ...(buildImageReference(imageAssetId) && { image: buildImageReference(imageAssetId) }),
       cdKeys: []

--- a/src/components/admin/TimeFilter.tsx
+++ b/src/components/admin/TimeFilter.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { FaChevronDown } from "react-icons/fa";
+import { FaArrowsRotate } from "react-icons/fa6";
 import { adminChrome } from "@/src/theme/colorSchema";
 
 interface TimeFilterProps {
@@ -12,6 +13,9 @@ interface TimeFilterProps {
     end: string;
   };
   onCustomDateChange?: (start: string, end: string) => void;
+  onRefresh?: () => void;
+  refreshing?: boolean;
+  refreshDisabled?: boolean;
 }
 
 const timePeriods = [
@@ -27,7 +31,10 @@ export default function TimeFilter({
   selectedPeriod,
   onPeriodChange,
   customDateRange,
-  onCustomDateChange
+  onCustomDateChange,
+  onRefresh,
+  refreshing = false,
+  refreshDisabled = false
 }: TimeFilterProps) {
   const [showCustomRange, setShowCustomRange] = useState(false);
 
@@ -57,7 +64,30 @@ export default function TimeFilter({
 
   return (
     <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6">
-      <h3 className="text-lg font-semibold text-gray-900 mb-4">Time Period</h3>
+      <div className="flex items-center justify-between gap-4 mb-4">
+        <h3 className="text-lg font-semibold text-gray-900">Time Period</h3>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => handlePeriodChange("all")}
+            className={`text-sm font-medium underline-offset-2 hover:underline cursor-pointer ${
+              selectedPeriod === "all" ? "text-blue-600 underline" : "text-gray-600 hover:text-gray-900"
+            }`}>
+            All time
+          </button>
+          {onRefresh && (
+            <button
+              type="button"
+              onClick={onRefresh}
+              disabled={refreshDisabled || refreshing}
+              title="Refresh data (bypass cache)"
+              aria-label="Refresh data"
+              className={`inline-flex items-center justify-center w-8 h-8 rounded-lg border border-gray-200 bg-white transition-colors cursor-pointer disabled:opacity-50 ${adminChrome.filterPillIdle} hover:border-blue-300`}>
+              <FaArrowsRotate className={`w-4 h-4 text-gray-700 ${refreshing ? "animate-spin" : ""}`} />
+            </button>
+          )}
+        </div>
+      </div>
 
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2">
         {timePeriods.map(period => (

--- a/src/components/admin/events/EventsFilter.tsx
+++ b/src/components/admin/events/EventsFilter.tsx
@@ -5,11 +5,25 @@ import { adminChrome } from "@/src/theme/colorSchema";
 interface EventsFilterProps {
   selectedEvent: string;
   eventTypes: string[];
-  events: AnalyticsEventData[];
+  events?: AnalyticsEventData[];
+  countsByEvent?: Record<string, number>;
+  totalCount?: number;
   onEventChange: (eventType: string) => void;
 }
 
-export default function EventsFilter({ selectedEvent, eventTypes, events, onEventChange }: EventsFilterProps) {
+export default function EventsFilter({
+  selectedEvent,
+  eventTypes,
+  events = [],
+  countsByEvent,
+  totalCount,
+  onEventChange
+}: EventsFilterProps) {
+  const allCount = totalCount ?? (countsByEvent ? Object.values(countsByEvent).reduce((a, b) => a + b, 0) : events.length);
+
+  const countFor = (eventType: string) =>
+    countsByEvent?.[eventType] ?? events.filter(e => e.event === eventType).length;
+
   return (
     <div className="mb-6">
       <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6">
@@ -20,7 +34,7 @@ export default function EventsFilter({ selectedEvent, eventTypes, events, onEven
             className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
               selectedEvent === "all" ? adminChrome.filterPillActive : adminChrome.filterPillIdle
             }`}>
-            All Events ({events.length})
+            All Events ({allCount})
           </button>
           {eventTypes.map(eventType => (
             <button
@@ -29,7 +43,7 @@ export default function EventsFilter({ selectedEvent, eventTypes, events, onEven
               className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
                 selectedEvent === eventType ? adminChrome.filterPillActive : adminChrome.filterPillIdle
               }`}>
-              {eventType.replace(/_/g, " ").toUpperCase()} ({events.filter(e => e.event === eventType).length})
+              {eventType.replace(/_/g, " ").toUpperCase()} ({countFor(eventType)})
             </button>
           ))}
         </div>

--- a/src/components/admin/programs/ProgramEditModal.tsx
+++ b/src/components/admin/programs/ProgramEditModal.tsx
@@ -32,6 +32,7 @@ export default function ProgramEditModal({ program, isOpen, onClose, onSaved, on
   const [description, setDescription] = useState("");
   const [programFlow, setProgramFlow] = useState<ProgramFlow>("cd_key");
   const [featuredCopy, setFeaturedCopy] = useState("");
+  const [latestOfficialVersion, setLatestOfficialVersion] = useState("");
   const [downloadLink, setDownloadLink] = useState("");
   const [imageAssetId, setImageAssetId] = useState<string | null>(null);
   const [showcaseGifAssetId, setShowcaseGifAssetId] = useState<string | null>(null);
@@ -58,6 +59,7 @@ export default function ProgramEditModal({ program, isOpen, onClose, onSaved, on
           ? program.featured.description.trim()
           : portableTextToPlainText(program.featured?.description)
       );
+      setLatestOfficialVersion(program.latestOfficialVersion ?? "");
       setDownloadLink(program.downloadLink ?? "");
       setImageAssetId(program.image?.asset?._ref ?? null);
       setShowcaseGifAssetId(program.featured?.showcaseGif?.asset?._ref ?? null);
@@ -70,6 +72,7 @@ export default function ProgramEditModal({ program, isOpen, onClose, onSaved, on
       setDescription("");
       setProgramFlow("cd_key");
       setFeaturedCopy("");
+      setLatestOfficialVersion("");
       setDownloadLink("");
       setImageAssetId(null);
       setShowcaseGifAssetId(null);
@@ -136,6 +139,11 @@ export default function ProgramEditModal({ program, isOpen, onClose, onSaved, on
           ? { featuredCopy: featuredCopy.trim() }
           : featuredCopy.trim()
             ? { featuredCopy: featuredCopy.trim() }
+            : {}),
+        ...(program?._id
+          ? { latestOfficialVersion: latestOfficialVersion.trim() || null }
+          : latestOfficialVersion.trim()
+            ? { latestOfficialVersion: latestOfficialVersion.trim() }
             : {}),
         downloadLink: downloadLink.trim() || undefined,
         ...(program?._id ? { imageAssetId: imageAssetId ?? null } : imageAssetId ? { imageAssetId } : {}),
@@ -289,6 +297,20 @@ export default function ProgramEditModal({ program, isOpen, onClose, onSaved, on
                 {slugValidation.error}
               </p>
             )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Program version
+              <span className="text-xs text-gray-500 ml-1">(latest official, e.g. 18.5)</span>
+            </label>
+            <input
+              type="text"
+              value={latestOfficialVersion}
+              onChange={e => setLatestOfficialVersion(e.target.value)}
+              placeholder="18.5"
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-gray-900"
+              disabled={saveLoading}
+            />
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Description *</label>

--- a/src/lib/analytics/adminEventListFields.ts
+++ b/src/lib/analytics/adminEventListFields.ts
@@ -1,0 +1,4 @@
+/** Slim fields for admin event list / analytics merge (no key, utm, userAgent). */
+export const ADMIN_EVENT_LIST_GROQ_FIELDS = `
+  _id, event, programSlug, notFound, social, path, referrer, country, city, ipHash, createdAt
+`;

--- a/src/lib/analytics/analyticsUtils.ts
+++ b/src/lib/analytics/analyticsUtils.ts
@@ -37,6 +37,9 @@ export function getDateRange(
     case "90d":
       since = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000).toISOString();
       break;
+    case "all":
+      since = "1970-01-01T00:00:00.000Z";
+      break;
     case "custom":
       if (customDateRange?.start && customDateRange?.end) {
         since = new Date(customDateRange.start).toISOString();
@@ -63,6 +66,8 @@ export function getDateFromPeriod(period: string, customDateRange?: { start: str
       return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
     case "90d":
       return new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000).toISOString();
+    case "all":
+      return "1970-01-01T00:00:00.000Z";
     case "custom":
       if (customDateRange?.start && customDateRange?.end) {
         return new Date(customDateRange.start).toISOString();

--- a/src/lib/analytics/enrichEventsWithVisitorMeta.ts
+++ b/src/lib/analytics/enrichEventsWithVisitorMeta.ts
@@ -1,0 +1,58 @@
+import { client } from "@/src/sanity/lib/client";
+
+const HASH_CHUNK = 500;
+
+type VisitorRow = { visitorHash: string; visitTier?: string; isSpammer?: boolean };
+
+async function fetchVisitorMetaByHashes(hashes: string[]): Promise<Map<string, VisitorRow>> {
+  const map = new Map<string, VisitorRow>();
+  if (!hashes.length) return map;
+
+  for (let i = 0; i < hashes.length; i += HASH_CHUNK) {
+    const chunk = hashes.slice(i, i + HASH_CHUNK);
+    const live = await client.fetch<VisitorRow[]>(
+      `*[_type == "visitor" && visitorHash in $hashes]{ visitorHash, visitTier, isSpammer }`,
+      { hashes: chunk }
+    );
+    for (const row of live ?? []) {
+      if (row.visitorHash) map.set(row.visitorHash, row);
+    }
+
+    const archived = await client.fetch<VisitorRow[]>(
+      `*[_type == "visitorBundle"]{
+        "rows": visitors[visitorHash in $hashes]{ visitorHash, visitTier, isSpammer }
+      }.rows[]`,
+      { hashes: chunk }
+    );
+    for (const row of archived ?? []) {
+      if (row.visitorHash && !map.has(row.visitorHash)) map.set(row.visitorHash, row);
+    }
+  }
+
+  return map;
+}
+
+/** One batched lookup per chunk instead of per-event GROQ subqueries. */
+export async function enrichEventsWithVisitorMeta<T extends Record<string, unknown>>(events: T[]): Promise<T[]> {
+  const hashes = [
+    ...new Set(
+      events
+        .map(e => (typeof e.ipHash === "string" ? e.ipHash.trim() : ""))
+        .filter((h): h is string => Boolean(h))
+    )
+  ];
+  if (!hashes.length) return events;
+
+  const byHash = await fetchVisitorMetaByHashes(hashes);
+  return events.map(e => {
+    const h = typeof e.ipHash === "string" ? e.ipHash.trim() : "";
+    if (!h) return e;
+    const v = byHash.get(h);
+    if (!v) return e;
+    return {
+      ...e,
+      visitTier: v.visitTier,
+      visitorIsSpammer: v.isSpammer === true
+    };
+  });
+}

--- a/src/lib/analytics/eventsApi.ts
+++ b/src/lib/analytics/eventsApi.ts
@@ -1,15 +1,10 @@
 /** @fileoverview Fetches merged tracking events for admin ranges, bundle program counts for homepage, visitor tag aggregates. */
 import { enrichEventsWithVisitorMeta } from "@/src/lib/analytics/enrichEventsWithVisitorMeta";
-import { BUNDLING_RETENTION_MS } from "@/src/lib/analytics/bundlingConstants";
+import { mergeTrackingEventsForRange } from "@/src/lib/analytics/mergeTrackingEventsForRange";
 import { TAG_BUNDLE_COUNTS } from "@/src/lib/cache/cacheTags";
 import { PUBLIC_ISR_REVALIDATE_SECONDS } from "@/src/lib/cache/constants";
 import { client } from "@/src/sanity/lib/client";
-import {
-  trackingEventsWithRangeQuery,
-  trackingEventBundlesQuery,
-  bundleCountsQuery,
-  visitorTagAggregatesQuery
-} from "@/src/lib/sanity/queries";
+import { bundleCountsQuery, visitorTagAggregatesQuery } from "@/src/lib/sanity/queries";
 import { AnalyticsEventData } from "@/src/types";
 
 export interface BundleCountsByProgram {
@@ -65,31 +60,70 @@ export function mergeSingleProgramStats(
 }
 
 /**
- * Fetches all events (singular + bundled) for a date range.
- * Skips bundle fetch when range is entirely within retention window.
+ * Fetches all events (singular + bundled) for a date range with visitor meta.
+ * Prefer paginated admin API for large ranges.
  */
 export async function fetchEventsForRange(since: string, until: string): Promise<AnalyticsEventData[]> {
-  const now = Date.now();
-  const retentionCutoff = new Date(now - BUNDLING_RETENTION_MS).toISOString();
-  const needBundles = since < retentionCutoff;
-
-  const [singular, bundles] = await Promise.all([
-    client.fetch(trackingEventsWithRangeQuery, { since, until }),
-    needBundles ? client.fetch(trackingEventBundlesQuery, { since, until }) : Promise.resolve([])
-  ]);
-
-  const bundleEvents: AnalyticsEventData[] = (bundles as { _id: string; events: AnalyticsEventData[] }[]).flatMap(b =>
-    (b.events || []).map((e, i) => ({
-      ...e,
-      _id: `${b._id}:${i}`
-    }))
-  );
-
-  const merged = [...(singular as AnalyticsEventData[]), ...bundleEvents].sort(
-    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  );
+  const merged = await mergeTrackingEventsForRange(since, until);
   const enriched = await enrichEventsWithVisitorMeta(merged as unknown as Array<Record<string, unknown>>);
   return enriched as unknown as AnalyticsEventData[];
+}
+
+export interface AdminEventsPageMeta {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasMore: boolean;
+  countsByEvent: Record<string, number>;
+  cacheHit?: boolean;
+  cachedAt?: string | null;
+}
+
+export interface AdminEventsPageResult {
+  data: AnalyticsEventData[];
+  meta: AdminEventsPageMeta;
+}
+
+export type FetchAdminEventsPageParams = {
+  since: string;
+  until: string;
+  event?: string;
+  page?: number;
+  limit?: number;
+  sort?: string;
+  order?: "asc" | "desc";
+  refresh?: boolean;
+};
+
+/** Paginated admin events list (server merge, cache, enrich page slice only). */
+export async function fetchAdminEventsPage(
+  params: FetchAdminEventsPageParams
+): Promise<AdminEventsPageResult> {
+  const sp = new URLSearchParams();
+  sp.set("since", params.since);
+  sp.set("until", params.until);
+  if (params.event && params.event !== "all") sp.set("event", params.event);
+  if (params.page != null) sp.set("page", String(params.page));
+  if (params.limit != null) sp.set("limit", String(params.limit));
+  if (params.sort) sp.set("sort", params.sort);
+  if (params.order) sp.set("order", params.order);
+  if (params.refresh) sp.set("refresh", "true");
+
+  const res = await fetch(`/api/v1/admin/events?${sp.toString()}`);
+  const json = (await res.json()) as { data?: AnalyticsEventData[]; meta?: AdminEventsPageMeta };
+  if (!res.ok) throw new Error("Failed to fetch events");
+  return {
+    data: json.data ?? [],
+    meta: json.meta ?? {
+      page: 1,
+      limit: 25,
+      total: 0,
+      totalPages: 1,
+      hasMore: false,
+      countsByEvent: {}
+    }
+  };
 }
 
 /** Admin UI: load range via server route (token + batched visitor lookup). */
@@ -103,6 +137,48 @@ export async function fetchEventsForRangeFromAdminApi(
   const json = (await res.json()) as { data?: AnalyticsEventData[] };
   if (!res.ok) throw new Error("Failed to fetch events");
   return json.data ?? [];
+}
+
+export interface AnalyticsSummaryData {
+  totalEvents: number;
+  uniqueVisitors: number;
+  uniqueCountries: number;
+  totals: Record<string, number>;
+  eventChart: Array<{ name: string; value: number; color: string }>;
+  programTable: Array<{ key: string; value: number; label: string }>;
+  socialTable: Array<{ key: string; value: number; label: string }>;
+  pathTable: Array<{ key: string; value: number; label: string }>;
+  countryTable: Array<{ key: string; value: number; label: string }>;
+  referrerTable: Array<{ key: string; value: number; label: string; referrerParam?: string }>;
+  recentEvents: AnalyticsEventData[];
+}
+
+/** Server-side analytics aggregates for dashboard (no full event array to client). */
+export async function fetchAnalyticsSummary(
+  since: string,
+  until: string,
+  options?: { refresh?: boolean }
+): Promise<AnalyticsSummaryData> {
+  const sp = new URLSearchParams({ since, until });
+  if (options?.refresh) sp.set("refresh", "true");
+  const res = await fetch(`/api/v1/admin/analytics/summary?${sp.toString()}`);
+  const json = (await res.json()) as { data?: AnalyticsSummaryData };
+  if (!res.ok) throw new Error("Failed to fetch analytics summary");
+  return (
+    json.data ?? {
+      totalEvents: 0,
+      uniqueVisitors: 0,
+      uniqueCountries: 0,
+      totals: {},
+      eventChart: [],
+      programTable: [],
+      socialTable: [],
+      pathTable: [],
+      countryTable: [],
+      referrerTable: [],
+      recentEvents: []
+    }
+  );
 }
 
 export interface VisitorTagAggregateRow {

--- a/src/lib/analytics/eventsApi.ts
+++ b/src/lib/analytics/eventsApi.ts
@@ -1,4 +1,5 @@
 /** @fileoverview Fetches merged tracking events for admin ranges, bundle program counts for homepage, visitor tag aggregates. */
+import { enrichEventsWithVisitorMeta } from "@/src/lib/analytics/enrichEventsWithVisitorMeta";
 import { BUNDLING_RETENTION_MS } from "@/src/lib/analytics/bundlingConstants";
 import { TAG_BUNDLE_COUNTS } from "@/src/lib/cache/cacheTags";
 import { PUBLIC_ISR_REVALIDATE_SECONDS } from "@/src/lib/cache/constants";
@@ -84,8 +85,24 @@ export async function fetchEventsForRange(since: string, until: string): Promise
     }))
   );
 
-  const merged = [...(singular as AnalyticsEventData[]), ...bundleEvents];
-  return merged.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  const merged = [...(singular as AnalyticsEventData[]), ...bundleEvents].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+  const enriched = await enrichEventsWithVisitorMeta(merged as unknown as Array<Record<string, unknown>>);
+  return enriched as unknown as AnalyticsEventData[];
+}
+
+/** Admin UI: load range via server route (token + batched visitor lookup). */
+export async function fetchEventsForRangeFromAdminApi(
+  since: string,
+  until: string
+): Promise<AnalyticsEventData[]> {
+  const res = await fetch(
+    `/api/v1/admin/analytics/events?since=${encodeURIComponent(since)}&until=${encodeURIComponent(until)}`
+  );
+  const json = (await res.json()) as { data?: AnalyticsEventData[] };
+  if (!res.ok) throw new Error("Failed to fetch events");
+  return json.data ?? [];
 }
 
 export interface VisitorTagAggregateRow {

--- a/src/lib/analytics/mergeTrackingEventsForRange.ts
+++ b/src/lib/analytics/mergeTrackingEventsForRange.ts
@@ -1,0 +1,42 @@
+import { BUNDLING_RETENTION_MS } from "@/src/lib/analytics/bundlingConstants";
+import { client } from "@/src/sanity/lib/client";
+import {
+  trackingEventsWithRangeSlimQuery,
+  trackingEventBundlesSlimQuery
+} from "@/src/lib/sanity/queries";
+import { AnalyticsEventData } from "@/src/types";
+
+type BundleRow = { _id: string; events: AnalyticsEventData[] };
+
+/**
+ * Merges slim singular + date-scoped bundled events for a range.
+ * Does not enrich visitor meta — callers enrich only displayed slices.
+ */
+export async function mergeTrackingEventsForRange(
+  since: string,
+  until: string
+): Promise<AnalyticsEventData[]> {
+  const now = Date.now();
+  const retentionCutoff = new Date(now - BUNDLING_RETENTION_MS).toISOString();
+  const needBundles = since < retentionCutoff;
+
+  const [singular, bundles] = await Promise.all([
+    client.fetch<AnalyticsEventData[]>(trackingEventsWithRangeSlimQuery, { since, until }),
+    needBundles
+      ? client.fetch<BundleRow[]>(trackingEventBundlesSlimQuery, { since, until })
+      : Promise.resolve([] as BundleRow[])
+  ]);
+
+  const bundleEvents: AnalyticsEventData[] = (bundles ?? []).flatMap(b =>
+    (b.events ?? []).map((e, i) => ({
+      ...e,
+      _id: `${b._id}:${(e as { _key?: string })._key ?? i}`
+    }))
+  );
+
+  const merged = [...(singular ?? []), ...bundleEvents].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
+  return merged;
+}

--- a/src/lib/api/adminEventsListCache.ts
+++ b/src/lib/api/adminEventsListCache.ts
@@ -1,0 +1,140 @@
+import { mergeTrackingEventsForRange } from "@/src/lib/analytics/mergeTrackingEventsForRange";
+import { AnalyticsEventData } from "@/src/types";
+
+export const ADMIN_EVENTS_LIST_CACHE_TTL_MS = 120_000;
+
+type CacheEntry = {
+  events: AnalyticsEventData[];
+  expiresAt: number;
+  cachedAt: string;
+};
+
+const store = new Map<string, CacheEntry>();
+const PRUNE_AT = 50;
+
+function cacheKey(since: string, until: string): string {
+  return `${since}|${until}`;
+}
+
+function pruneExpired(now = Date.now()): void {
+  if (store.size <= PRUNE_AT) return;
+  for (const [k, v] of store) {
+    if (v.expiresAt <= now) store.delete(k);
+  }
+}
+
+export type MergedEventsCacheResult = {
+  events: AnalyticsEventData[];
+  cacheHit: boolean;
+  cachedAt: string | null;
+};
+
+/**
+ * Returns merged slim events for since/until, cached ~120s per range key.
+ * bypass=true skips read and refreshes the entry (admin refresh button).
+ */
+export async function getMergedEventsForAdmin(
+  since: string,
+  until: string,
+  options?: { bypass?: boolean }
+): Promise<MergedEventsCacheResult> {
+  const key = cacheKey(since, until);
+  const now = Date.now();
+
+  if (!options?.bypass) {
+    const hit = store.get(key);
+    if (hit && hit.expiresAt > now) {
+      return { events: hit.events, cacheHit: true, cachedAt: hit.cachedAt };
+    }
+  }
+
+  const events = await mergeTrackingEventsForRange(since, until);
+  const cachedAt = new Date().toISOString();
+  store.set(key, {
+    events,
+    expiresAt: now + ADMIN_EVENTS_LIST_CACHE_TTL_MS,
+    cachedAt
+  });
+  pruneExpired(now);
+
+  return { events, cacheHit: false, cachedAt };
+}
+
+export type AnalyticsSummaryCachePayload = {
+  totalEvents: number;
+  uniqueVisitors: number;
+  uniqueCountries: number;
+  totals: Record<string, number>;
+  eventChart: Array<{ name: string; value: number; color: string }>;
+  programTable: Array<{ key: string; value: number; label: string }>;
+  socialTable: Array<{ key: string; value: number; label: string }>;
+  pathTable: Array<{ key: string; value: number; label: string }>;
+  countryTable: Array<{ key: string; value: number; label: string }>;
+  referrerTable: Array<{ key: string; value: number; label: string; referrerParam?: string }>;
+  recentEvents: AnalyticsEventData[];
+};
+
+type SummaryCacheEntry = {
+  data: AnalyticsSummaryCachePayload;
+  expiresAt: number;
+  cachedAt: string;
+};
+
+const summaryStore = new Map<string, SummaryCacheEntry>();
+
+export type AnalyticsSummaryCacheResult = {
+  data: AnalyticsSummaryCachePayload;
+  cacheHit: boolean;
+  cachedAt: string | null;
+};
+
+/** Cached analytics dashboard payload (~120s), keyed by since|until. */
+export function getCachedAnalyticsSummary(
+  since: string,
+  until: string,
+  options?: { bypass?: boolean }
+): AnalyticsSummaryCacheResult | null {
+  if (options?.bypass) return null;
+  const key = cacheKey(since, until);
+  const hit = summaryStore.get(key);
+  const now = Date.now();
+  if (hit && hit.expiresAt > now) {
+    return { data: hit.data, cacheHit: true, cachedAt: hit.cachedAt };
+  }
+  return null;
+}
+
+export function setCachedAnalyticsSummary(
+  since: string,
+  until: string,
+  data: AnalyticsSummaryCachePayload
+): string {
+  const now = Date.now();
+  const cachedAt = new Date().toISOString();
+  summaryStore.set(cacheKey(since, until), {
+    data,
+    expiresAt: now + ADMIN_EVENTS_LIST_CACHE_TTL_MS,
+    cachedAt
+  });
+  pruneSummaryExpired(now);
+  return cachedAt;
+}
+
+function pruneSummaryExpired(now: number): void {
+  if (summaryStore.size <= PRUNE_AT) return;
+  for (const [k, v] of summaryStore) {
+    if (v.expiresAt <= now) summaryStore.delete(k);
+  }
+}
+
+/** Invalidate a range after bulk PATCH (optional). */
+export function invalidateMergedEventsCache(since?: string, until?: string): void {
+  if (since && until) {
+    const key = cacheKey(since, until);
+    store.delete(key);
+    summaryStore.delete(key);
+    return;
+  }
+  store.clear();
+  summaryStore.clear();
+}

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -134,6 +134,11 @@ export const trackingEventsWithRangeQuery = `*[_type=="trackingEvent" && created
       _id, event, programSlug, notFound, social, path, referrer, country, city, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt
     } | order(createdAt desc)`;
 
+/** Admin list / summary: slim projection (import fields in merge helper). */
+export const trackingEventsWithRangeSlimQuery = `*[_type=="trackingEvent" && createdAt >= $since && createdAt <= $until]{
+      _id, event, programSlug, notFound, social, path, referrer, country, city, ipHash, createdAt
+    } | order(createdAt desc)`;
+
 /* ------------ Bundle counts by program (for merging with singular counts) ------------ */
 export const bundleCountsQuery = `*[_type == "trackingEventBundle"]{
   "events": events[]{ programSlug, event, notFound }
@@ -143,6 +148,11 @@ export const bundleCountsQuery = `*[_type == "trackingEventBundle"]{
 export const trackingEventBundlesQuery = `*[_type == "trackingEventBundle" && timeRangeEnd >= $since && timeRangeStart <= $until]{
   _id,
   "events": events[createdAt >= $since && createdAt <= $until]{ event, programSlug, notFound, path, referrer, country, city, social, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt }
+}`;
+
+export const trackingEventBundlesSlimQuery = `*[_type == "trackingEventBundle" && timeRangeEnd >= $since && timeRangeStart <= $until]{
+  _id,
+  "events": events[createdAt >= $since && createdAt <= $until]{ event, programSlug, notFound, social, path, referrer, country, city, ipHash, createdAt, _key }
 }`;
 
 /** Active + bundled visitors with lastActivityAt in range (admin tier aggregates). */

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -131,8 +131,7 @@ export const trackingEventsQuery = `*[_type=="trackingEvent" && createdAt >= $si
 
 /* ------------ Analytics with Custom Date Range ------------ */
 export const trackingEventsWithRangeQuery = `*[_type=="trackingEvent" && createdAt >= $since && createdAt <= $until]{
-      _id, event, programSlug, notFound, social, path, referrer, country, city, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt,
-      ${visitorFieldsFromHashProjection}
+      _id, event, programSlug, notFound, social, path, referrer, country, city, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt
     } | order(createdAt desc)`;
 
 /* ------------ Bundle counts by program (for merging with singular counts) ------------ */
@@ -143,7 +142,7 @@ export const bundleCountsQuery = `*[_type == "trackingEventBundle"]{
 /* ------------ Bundled Events (overlaps range, events filtered in-doc) ------------ */
 export const trackingEventBundlesQuery = `*[_type == "trackingEventBundle" && timeRangeEnd >= $since && timeRangeStart <= $until]{
   _id,
-  "events": events[createdAt >= $since && createdAt <= $until]{ event, programSlug, notFound, path, referrer, country, city, social, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt, ${visitorFieldsFromHashProjection} }
+  "events": events[createdAt >= $since && createdAt <= $until]{ event, programSlug, notFound, path, referrer, country, city, social, key, activationUrl, programFlow, userAgent, ipHash, utm_source, utm_medium, utm_campaign, createdAt }
 }`;
 
 /** Active + bundled visitors with lastActivityAt in range (admin tier aggregates). */


### PR DESCRIPTION
## Summary

Fixes slow admin events and analytics after bundle retention by paginating server-side loads, slimming GROQ, caching merged data (~120s), and adding program version editing in the admin modal.

## Changelog

<!-- tags: perf, feat, api -->

### Highlights

- Paginated admin events API with 120s merge cache and refresh bypass
- Analytics summary dashboard without shipping full event arrays to the browser
- Program version (latestOfficialVersion) editable in admin program modal

### Admin performance

- Slim singular/bundle queries and shared mergeTrackingEventsForRange
- Batched enrichEventsWithVisitorMeta without per-event GROQ subqueries
- GET /api/v1/admin/events: since/until, pagination, countsByEvent
- GET /api/v1/admin/analytics/summary with server aggregates + 10 enriched recent rows
- TimeFilter All time link and optional header refresh button

---

## Environment Variables

None

## Testing

- /admin/events (24h): loads quickly; pagination and refresh bypass work
- /admin/analytics: charts load without huge payloads
- All time / 90d: no Sanity timeout
- Admin programs: set/clear program version on add and edit

## Technical Details

In-memory cache is per serverless instance. Legacy GET /api/v1/admin/analytics/events retained for compatibility.
