### PR TITLE
perf: cut fluid active cpu with program stats rollup and static /programs

### DIFF
--- a/src/app/api/v1/admin/key-report-notifications/route.ts
+++ b/src/app/api/v1/admin/key-report-notifications/route.ts
@@ -1,55 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAdminSession } from "@/src/lib/admin/adminAuth";
-import { client } from "@/src/sanity/lib/client";
-import { keyReportsQuery } from "@/src/lib/sanity/queries";
-import type { KeyReportNotificationItem } from "@/src/types/admin";
+import { getCachedKeyReportNotifications } from "@/src/lib/admin/keyReportNotifications.server";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
-import { getKeyData } from "@/src/lib/keyHashing";
-import type { CDKey, ProgramFlow } from "@/src/types/program";
-import { normalizeProgramFlow } from "@/src/lib/program/activationEntry";
-
-const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
-const MAX_ITEMS = 20;
-
-type KeyReportEventType = "report_key_working" | "report_key_expired" | "report_key_limit_reached";
-
-interface KeyReportEvent {
-  eventType: string;
-  programSlug: string;
-  key?: string;
-  label?: string;
-  _createdAt?: string;
-  createdAt?: string;
-}
-
-interface Group {
-  programSlug: string;
-  storageKey: string;
-  label: string;
-  working: number;
-  expired: number;
-  limit_reached: number;
-  lastReportAt: string;
-  lastEventType?: KeyReportEventType;
-}
-
-interface ProgramWithKeys {
-  slug: string;
-  title: string;
-  programFlow?: string;
-  cdKeys?: CDKey[];
-}
-
-function reportStorageKey(r: KeyReportEvent): string {
-  const k = (r.key ?? "").trim();
-  return k || "unknown";
-}
-
-function reportLabel(r: KeyReportEvent): string {
-  const l = (r.label ?? "").trim();
-  return l || "—";
-}
 
 /** GET /api/v1/admin/key-report-notifications - Keys needing attention (negative reports, 60d) */
 export async function GET(req: NextRequest) {
@@ -60,96 +13,7 @@ export async function GET(req: NextRequest) {
   if (admin instanceof Response) return admin;
 
   try {
-    const since = new Date(Date.now() - SIXTY_DAYS_MS).toISOString();
-
-    const [events, programs] = await Promise.all([
-      client.fetch<KeyReportEvent[]>(keyReportsQuery, { since }),
-      client.fetch<ProgramWithKeys[]>(
-        `*[_type == "program"]{ "slug": slug.current, title, "programFlow": coalesce(programFlow, "cd_key"), cdKeys }`
-      )
-    ]);
-
-    const programTitleBySlug = new Map<string, string>();
-    const resolvedKeys = new Set<string>();
-    for (const p of programs ?? []) {
-      if (p.slug) programTitleBySlug.set(p.slug, p.title ?? p.slug);
-      const flow = normalizeProgramFlow(p.programFlow) as ProgramFlow;
-      for (const k of p.cdKeys ?? []) {
-        const kd = getKeyData({ ...(k as CDKey), programFlow: flow }, flow);
-        if (p.slug && kd?.hash && (k.status === "expired" || k.status === "limit")) {
-          resolvedKeys.add(`${p.slug}:${kd.hash}`);
-        }
-      }
-    }
-
-    const groups = new Map<string, Group>();
-
-    for (const report of events ?? []) {
-      const programSlug = (report.programSlug ?? "").trim() || "unknown";
-      const storageKey = reportStorageKey(report);
-      const label = reportLabel(report);
-      if (storageKey === "unknown") continue;
-      const groupKey = `${programSlug}:${storageKey}`;
-      const eventType = report.eventType as KeyReportEventType;
-
-      const reportAt = report._createdAt ?? report.createdAt ?? "";
-      if (!groups.has(groupKey)) {
-        groups.set(groupKey, {
-          programSlug,
-          storageKey,
-          label,
-          working: 0,
-          expired: 0,
-          limit_reached: 0,
-          lastReportAt: reportAt,
-          lastEventType: eventType
-        });
-      }
-      const g = groups.get(groupKey)!;
-      if (reportAt && reportAt >= g.lastReportAt) {
-        g.lastReportAt = reportAt;
-        g.lastEventType = eventType;
-      }
-      if (eventType === "report_key_working") g.working++;
-      else if (eventType === "report_key_expired") g.expired++;
-      else if (eventType === "report_key_limit_reached") g.limit_reached++;
-    }
-
-    const negativeFiltered: Array<Group & { negativeCount: number; total: number }> = [];
-    for (const g of groups.values()) {
-      const negativeCount = g.expired + g.limit_reached;
-      if (negativeCount < 1) continue;
-      if (g.working > 0 && g.lastEventType === "report_key_working") continue;
-      if (resolvedKeys.has(`${g.programSlug}:${g.storageKey}`)) continue;
-      const total = g.working + g.expired + g.limit_reached;
-      negativeFiltered.push({ ...g, negativeCount, total });
-    }
-
-    negativeFiltered.sort((a, b) => {
-      if (b.negativeCount !== a.negativeCount) return b.negativeCount - a.negativeCount;
-      const ratioA = a.total > 0 ? a.working / a.total : 0;
-      const ratioB = b.total > 0 ? b.working / b.total : 0;
-      return ratioA - ratioB;
-    });
-
-    const items: KeyReportNotificationItem[] = negativeFiltered.slice(0, MAX_ITEMS).map(g => {
-      const total = g.working + g.expired + g.limit_reached;
-      const ratioLabel = total > 0 ? `${g.working}/${total} positive` : "0 positive";
-      return {
-        programSlug: g.programSlug,
-        programTitle: programTitleBySlug.get(g.programSlug) ?? g.programSlug,
-        label: g.label,
-        negativeCount: g.negativeCount,
-        positiveCount: g.working,
-        working: g.working,
-        expired: g.expired,
-        limit_reached: g.limit_reached,
-        ratioLabel,
-        lastReportAt: g.lastReportAt,
-        link: `/admin/key-reports?program=${encodeURIComponent(g.programSlug)}`
-      };
-    });
-
+    const items = await getCachedKeyReportNotifications();
     return NextResponse.json({ data: items, meta: {} });
   } catch (err) {
     console.error("[GET /api/v1/admin/key-report-notifications]", err);

--- a/src/app/api/v1/analytics/track/route.ts
+++ b/src/app/api/v1/analytics/track/route.ts
@@ -11,7 +11,7 @@ import { isAutomatedAnalyticsRequest } from "@/src/lib/api/isAutomatedAnalyticsR
 import { getClientIp, hashIp, getLocationFromIP } from "@/src/lib/api/requestGeo";
 import { upsertVisitorOnPageView } from "@/src/lib/visitors/upsertVisitorOnPageView";
 import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
-import { isProgramSlugPublished } from "@/src/lib/sanity/programSlugExists";
+import { isProgramSlugPublishedCached } from "@/src/lib/sanity/getCachedPublishedProgramSlugs";
 
 const ANALYTICS_EVENTS = new Set([
   "copy_cdkey",
@@ -133,7 +133,7 @@ export async function POST(req: NextRequest) {
       const slugFromPath = pathNorm.startsWith("/program/") ? pathNorm.split("/")[2] : undefined;
       const trustedProgramPath = Boolean(slugFromPath && slugFromPath === programSlug.trim());
       if (!trustedProgramPath) {
-        const ok = await isProgramSlugPublished(programSlug);
+        const ok = await isProgramSlugPublishedCached(programSlug);
         if (!ok) programSlug = undefined;
       }
     }

--- a/src/app/api/v1/cron/bundle-events/route.ts
+++ b/src/app/api/v1/cron/bundle-events/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
 import { client } from "@/src/sanity/lib/client";
 import { runBundleEvents } from "@/src/lib/analytics/bundleEvents";
+import { runSyncProgramStatsRollup } from "@/src/lib/analytics/syncProgramStatsRollup";
+import { TAG_HOMEPAGE_PROGRAMS, TAG_PROGRAM_LISTINGS } from "@/src/lib/cache/cacheTags";
 import { verifyCronAuth, logCronRun } from "@/src/lib/api/cronUtils";
 import { Errors } from "@/src/lib/api/errors";
 
@@ -35,16 +38,25 @@ export async function GET(req: NextRequest) {
       result.created > 0 || result.appended > 0
         ? `${result.created} new, ${result.appended} appended`
         : "No events to bundle";
-    await logCronRun(client, { job: "bundle-events", source, status: "ok", details });
+
+    const rollup = await runSyncProgramStatsRollup();
+    if (rollup.ok && rollup.patched > 0) {
+      revalidateTag(TAG_PROGRAM_LISTINGS, "max");
+      revalidateTag(TAG_HOMEPAGE_PROGRAMS, "max");
+    }
+
+    const rollupNote = rollup.ok ? `, stats synced (${rollup.patched} programs)` : rollup.error ? `, stats sync failed` : "";
+    await logCronRun(client, { job: "bundle-events", source, status: "ok", details: details + rollupNote });
 
     return NextResponse.json({
       data: {
         created: result.created,
         appended: result.appended,
+        statsPatched: rollup.patched,
         message:
           result.created > 0 || result.appended > 0
-            ? `Bundled ${result.created} new bundle(s), appended ${result.appended} events`
-            : "No events to bundle."
+            ? `Bundled ${result.created} new bundle(s), appended ${result.appended} events${rollupNote}`
+            : `No events to bundle${rollupNote}`
       },
       meta: {}
     });

--- a/src/app/api/v1/cron/update-expired-keys/route.ts
+++ b/src/app/api/v1/cron/update-expired-keys/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { client } from "@/src/sanity/lib/client";
 import { updateAllExpiredKeys } from "@/src/lib/sanity/sanityActions";
-import { verifyCronAuth, logCronRun } from "@/src/lib/api/cronUtils";
+import { requireAdminSession } from "@/src/lib/admin/adminAuth";
+import { verifyCronAuth, logCronRun, type CronSource } from "@/src/lib/api/cronUtils";
 import { Errors } from "@/src/lib/api/errors";
-
 /** GET /api/v1/cron/update-expired-keys - Cron: update expired keys (requires cron auth) */
 export async function GET(req: NextRequest) {
   const { ok, source } = verifyCronAuth(req);
@@ -28,11 +28,18 @@ export async function GET(req: NextRequest) {
   }
 }
 
-/** POST /api/v1/cron/update-expired-keys - Manual trigger (no auth; used by admin Key Status) */
+/** POST /api/v1/cron/update-expired-keys - Manual trigger (admin session or cron auth) */
 export async function POST(req: NextRequest) {
-  const source = "manual" as const;
-  try {
-    await updateAllExpiredKeys();
+  let source: CronSource = "manual";
+  const cron = verifyCronAuth(req);
+  if (!cron.ok) {
+    const admin = await requireAdminSession();
+    if (admin instanceof Response) return admin;
+  } else {
+    source = cron.source;
+  }
+
+  try {    await updateAllExpiredKeys();
     await logCronRun(client, { job: "update-expired-keys", source, status: "ok" });
     return NextResponse.json({
       data: { success: true, message: "Expired keys updated successfully" },

--- a/src/app/api/v1/programs/list/route.ts
+++ b/src/app/api/v1/programs/list/route.ts
@@ -1,0 +1,29 @@
+/** GET /api/v1/programs/list — cached program grid data (static /programs shell fetches this client-side). */
+import { NextRequest, NextResponse } from "next/server";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { PUBLIC_ISR_REVALIDATE_SECONDS } from "@/src/lib/cache/constants";
+import { getProgramsListData } from "@/src/lib/programs/getProgramsPageData";
+
+export async function GET(req: NextRequest) {
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const sp = req.nextUrl.searchParams;
+
+  try {
+    const data = await getProgramsListData(sp.get("search") ?? undefined, sp.get("filter") ?? undefined, sp.get("sort") ?? undefined, sp.get("page") ?? undefined);
+
+    return NextResponse.json(
+      { data, meta: {} },
+      {
+        headers: {
+          "Cache-Control": `public, s-maxage=${PUBLIC_ISR_REVALIDATE_SECONDS}, stale-while-revalidate=120`
+        }
+      }
+    );
+  } catch (err) {
+    console.error("[GET /api/v1/programs/list]", err);
+    return Errors.internal();
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ const geistMono = Geist_Mono({
 });
 
 /** Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
-export const revalidate = 300;
+export const revalidate = 3600;
 
 type HeadMetaTag = {
   name?: string;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,7 @@
 import { client } from "@/src/sanity/lib/client";
 import { programsWithStatsQuery, siteStatsQuery } from "@lib/sanity/queries";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
-import { getBundleCountsByProgram, mergeProgramStats } from "@/src/lib/analytics/eventsApi";
-import { sortPrograms } from "@/src/lib/program/programUtils";
+import { mergeProgramStats } from "@/src/lib/analytics/eventsApi";
 import type { ProgramWithStats } from "@/src/types/home";
 import { generateHomePageMetadata } from "@/src/lib/seo/metadata";
 import { generateHomePageJsonLd } from "@/src/lib/seo/jsonLd";
@@ -20,7 +19,7 @@ import { SocialData } from "@/src/types";
 import { TAG_HOMEPAGE_PROGRAMS, TAG_HOMEPAGE_STATS } from "@/src/lib/cache/cacheTags";
 
 /** Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
-export const revalidate = 300;
+export const revalidate = 3600;
 
 const HOMEPAGE_POPULAR_LIMIT = 8;
 
@@ -33,18 +32,16 @@ export default async function HomePage() {
   weekAgo.setDate(weekAgo.getDate() - 7);
   const weekAgoISO = weekAgo.toISOString();
 
-  const [rawPopularPrograms, bundleCounts, stats, store, featuredProgram] = await Promise.all([
+  const [rawPopularPrograms, stats, store, featuredProgram] = await Promise.all([
     client.fetch(programsWithStatsQuery, {}, { next: { tags: [TAG_HOMEPAGE_PROGRAMS] } }),
-    getBundleCountsByProgram(),
     client.fetch(siteStatsQuery, { weekAgo: weekAgoISO }, { next: { tags: [TAG_HOMEPAGE_STATS] } }),
     getCachedStoreDetailsDocument(),
     getFeaturedProgram()
   ]);
 
-  const popularPrograms = sortPrograms(
-    mergeProgramStats((rawPopularPrograms ?? []) as ProgramWithStats[], bundleCounts),
-    "popular"
-  ).slice(0, HOMEPAGE_POPULAR_LIMIT) as ProgramWithStats[];
+  const popularPrograms = mergeProgramStats((rawPopularPrograms ?? []) as ProgramWithStats[])
+    .sort((a, b) => b.popularityScore - a.popularityScore)
+    .slice(0, HOMEPAGE_POPULAR_LIMIT) as ProgramWithStats[];
 
   const normalizedPopularPrograms = popularPrograms.map(program => ({
     ...program,

--- a/src/app/program/[slug]/page.tsx
+++ b/src/app/program/[slug]/page.tsx
@@ -35,7 +35,7 @@ import { client } from "@/src/sanity/lib/client";
 import { TAG_SITEMAP_URLS } from "@/src/lib/cache/cacheTags";
 
 /** Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
-export const revalidate = 300;
+export const revalidate = 3600;
 
 interface ProgramPageProps {
   params: Promise<{ slug: string }>;
@@ -43,7 +43,7 @@ interface ProgramPageProps {
 
 export async function generateStaticParams() {
   const slugs = await client.fetch<Array<{ slug?: { current?: string } }>>(
-    `*[_type == "program"] | order(coalesce(popularityScore, 0) desc) [0...50]{ slug }`,
+    `*[_type == "program"] | order(coalesce(stats.popularityScore, popularityScore, 0) desc) [0...50]{ slug }`,
     {},
     { next: { tags: [TAG_SITEMAP_URLS] } }
   );

--- a/src/app/programs/ProgramsPageClient.tsx
+++ b/src/app/programs/ProgramsPageClient.tsx
@@ -1,40 +1,86 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { ProgramsFilter, ProgramsGrid } from "@/src/components/programs";
 import Pagination from "@/src/components/ui/Pagination";
-import { ProgramsPageClientProps, FilterType, SortType } from "@/src/types/programs";
+import type { ProgramsListData } from "@/src/lib/programs/getProgramsPageData";
+import { FilterType, SortType } from "@/src/types/programs";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { scrollToSectionWithHeaderOffset } from "@/src/lib/dom/scrollToSection";
+import { normalizeFilterType, normalizeSortType } from "@/src/lib/program/programUtils";
+import type { ProgramWithStats } from "@/src/types/home";
 
 const SEARCH_DEBOUNCE_MS = 400;
+const EMPTY_PROGRAMS: ProgramWithStats[] = [];
 
-export default function ProgramsPageClient({
-  programs,
-  searchTerm,
-  filter,
-  sortBy,
-  currentPage,
-  totalPrograms,
-  programsPerPage
-}: ProgramsPageClientProps) {
+function readListParams(searchParams: URLSearchParams) {
+  return {
+    searchTerm: (searchParams.get("search") || "").trim(),
+    filter: normalizeFilterType(searchParams.get("filter") ?? undefined),
+    sortBy: normalizeSortType(searchParams.get("sort") ?? undefined),
+    page: Math.max(1, Number.parseInt(searchParams.get("page") || "1", 10) || 1)
+  };
+}
+
+export default function ProgramsPageClient() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const searchParamsRef = useRef(searchParams);
   searchParamsRef.current = searchParams;
+
   const [isPending, startTransition] = useTransition();
+  const [isLoading, setIsLoading] = useState(true);
+  const [listData, setListData] = useState<ProgramsListData | null>(null);
+  const [fetchError, setFetchError] = useState(false);
+
   const wasPending = useRef(false);
   const scrollAfterPaginationRef = useRef(false);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const localSearchRef = useRef(searchTerm);
+  const fetchGenRef = useRef(0);
+
+  const params = readListParams(searchParams);
+  const { searchTerm, filter, sortBy, page } = params;
   const [localSearch, setLocalSearch] = useState(searchTerm);
+  const localSearchRef = useRef(searchTerm);
 
   useEffect(() => {
     setLocalSearch(searchTerm);
+    localSearchRef.current = searchTerm;
   }, [searchTerm]);
 
-  localSearchRef.current = localSearch;
+  const programs = listData?.programs ?? EMPTY_PROGRAMS;
+  const totalPrograms = listData?.totalCount ?? 0;
+  const programsPerPage = listData?.programsPerPage ?? 16;
+  const currentPage = listData?.page ?? page;
+
+  const loadList = useCallback(async (sp: URLSearchParams) => {
+    const gen = ++fetchGenRef.current;
+    setIsLoading(true);
+    setFetchError(false);
+    try {
+      const res = await fetch(`/api/v1/programs/list?${sp.toString()}`);
+      const json = (await res.json()) as { data?: ProgramsListData };
+      if (gen !== fetchGenRef.current) return;
+      if (!res.ok || !json.data) {
+        setFetchError(true);
+        setListData(null);
+        return;
+      }
+      setListData(json.data);
+    } catch {
+      if (gen === fetchGenRef.current) {
+        setFetchError(true);
+        setListData(null);
+      }
+    } finally {
+      if (gen === fetchGenRef.current) setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadList(searchParams);
+  }, [searchParams, loadList]);
 
   const clearSearchDebounce = () => {
     if (searchDebounceRef.current != null) {
@@ -60,10 +106,11 @@ export default function ProgramsPageClient({
   const totalPages = Math.max(1, Math.ceil(totalPrograms / programsPerPage));
   const startIndex = totalPrograms === 0 ? 0 : (currentPage - 1) * programsPerPage + 1;
   const endIndex = Math.min(currentPage * programsPerPage, totalPrograms);
+  const showLoading = isLoading && !listData;
 
   const resolveSearchForUrl = (updates: Partial<{ search: string }>): string => {
     if (updates.search !== undefined) return updates.search.trim();
-    return localSearch.trim();
+    return localSearchRef.current.trim();
   };
 
   const updateQuery = (updates: Partial<{ search: string; filter: FilterType; sort: SortType; page: number }>) => {
@@ -117,14 +164,15 @@ export default function ProgramsPageClient({
   };
 
   const handleSearchInputChange = (value: string) => {
+    localSearchRef.current = value;
     setLocalSearch(value);
     scheduleSearchUrlSync();
   };
 
-  const handlePageChange = (page: number) => {
+  const handlePageChange = (nextPage: number) => {
     clearSearchDebounce();
     scrollAfterPaginationRef.current = true;
-    updateQuery({ page });
+    updateQuery({ page: nextPage });
   };
 
   return (
@@ -140,7 +188,11 @@ export default function ProgramsPageClient({
       />
 
       <div className="mb-4 sm:mb-6">
-        {totalPrograms === 0 ? (
+        {fetchError ? (
+          <p className="text-sm text-red-300 sm:text-base">Could not load programs. Try refreshing.</p>
+        ) : showLoading ? (
+          <p className="text-sm text-neutral-100 sm:text-base">Loading programs…</p>
+        ) : totalPrograms === 0 ? (
           <p className="text-sm text-neutral-100 sm:text-base">No results</p>
         ) : (
           <p className="text-sm text-neutral-100 sm:text-base">
@@ -149,9 +201,15 @@ export default function ProgramsPageClient({
         )}
       </div>
 
-      <ProgramsGrid programs={programs} maxViews={maxViews} maxDownloads={maxDownloads} />
+      {!fetchError && (
+        <ProgramsGrid
+          programs={showLoading ? EMPTY_PROGRAMS : programs}
+          maxViews={maxViews}
+          maxDownloads={maxDownloads}
+        />
+      )}
 
-      {totalPrograms > 0 && (
+      {totalPrograms > 0 && !fetchError && (
         <Pagination
           currentPage={currentPage}
           totalPages={totalPages}
@@ -161,7 +219,7 @@ export default function ProgramsPageClient({
           variant="detailed"
           tone="light"
           showInfo={false}
-          className={`mt-8 sm:mt-10 lg:mt-12 ${isPending ? "opacity-70" : ""}`}
+          className={`mt-8 sm:mt-10 lg:mt-12 ${isPending || isLoading ? "opacity-70" : ""}`}
         />
       )}
     </div>

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { generateProgramsPageMetadata } from "@/src/lib/seo/metadata";
 import { generateProgramsPageJsonLd } from "@/src/lib/seo/jsonLd";
 import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
@@ -6,46 +7,40 @@ import ProgramsPageClient from "@/src/app/programs/ProgramsPageClient";
 import { ProgramsHero, ContributeSection, WhyUseSection } from "@/src/components/programs";
 import FeaturedProgramSection from "@/src/components/home/FeaturedProgramSection";
 import { FacebookGroupButton } from "@/src/components/social";
-import { getProgramsPageData } from "@/src/lib/programs/getProgramsPageData";
+import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
+import { getFeaturedProgram } from "@/src/lib/sanity/sanityActions";
+import {
+  getCachedProgramsForJsonLd,
+  getCachedProgramsHeroTotals
+} from "@/src/lib/programs/getProgramsPageData";
 import type { SocialData } from "@/src/types";
-import type { FilterType, SortType } from "@/src/types/programs";
 
 /** Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
-export const revalidate = 300;
+export const revalidate = 3600;
 
 export async function generateMetadata() {
   return await generateProgramsPageMetadata();
 }
 
-export default async function ProgramsPage({
-  searchParams
-}: {
-  searchParams: Promise<{ search?: string; filter?: FilterType; sort?: SortType; page?: string }>;
-}) {
-  const params = await searchParams;
-  const {
-    programs,
-    totalCount,
-    totalKeys,
-    searchTerm,
-    filter,
-    sortBy,
-    page,
-    programsPerPage,
-    storeRow,
-    featuredProgram
-  } = await getProgramsPageData(params.search, params.filter, params.sort, params.page);
+/** Static shell — list/filter/sort/pagination via cached `/api/v1/programs/list`. */
+export default async function ProgramsPage() {
+  const [storeRow, featuredProgram, heroTotals, jsonLdPrograms] = await Promise.all([
+    getCachedStoreDetailsDocument(),
+    getFeaturedProgram(),
+    getCachedProgramsHeroTotals(),
+    getCachedProgramsForJsonLd()
+  ]);
 
   const socialData: SocialData = {
     socialLinks: storeRow?.socialLinks ?? []
   };
 
-  const jsonLd = generateProgramsPageJsonLd(programs, totalCount, resolveSiteBaseUrl(storeRow?.seo));
+  const jsonLd = generateProgramsPageJsonLd(jsonLdPrograms, heroTotals.totalCount, resolveSiteBaseUrl(storeRow?.seo));
 
   return (
     <>
       <JsonLd data={jsonLd} />
-      <ProgramsHero totalCount={totalCount} totalKeys={totalKeys} />
+      <ProgramsHero totalCount={heroTotals.totalCount} totalKeys={heroTotals.totalKeys} />
 
       <section className="border-b border-[#2a475e] bg-[#16202d] py-8">
         <div className="max-w-360 mx-auto px-4 sm:px-6 lg:px-8 flex justify-center">
@@ -53,15 +48,14 @@ export default async function ProgramsPage({
         </div>
       </section>
 
-      <ProgramsPageClient
-        programs={programs}
-        searchTerm={searchTerm}
-        filter={filter}
-        sortBy={sortBy}
-        currentPage={page}
-        totalPrograms={totalCount}
-        programsPerPage={programsPerPage}
-      />
+      <Suspense
+        fallback={
+          <div id="programs-grid" className="mx-auto max-w-360 px-4 py-8 sm:px-6 lg:px-8">
+            <p className="text-sm text-neutral-100">Loading programs…</p>
+          </div>
+        }>
+        <ProgramsPageClient />
+      </Suspense>
 
       <ContributeSection />
       <FeaturedProgramSection program={featuredProgram} />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -7,7 +7,7 @@ import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
 import { Program, CDKey } from "@/src/types";
 
 /** ISR fallback; URL set busts use `TAG_SITEMAP_URLS` (admin + selective webhook). Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
-export const revalidate = 300;
+export const revalidate = 3600;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const [store, programs] = await Promise.all([

--- a/src/components/admin/layout/KeyReportAlerts.tsx
+++ b/src/components/admin/layout/KeyReportAlerts.tsx
@@ -21,8 +21,17 @@ export function useKeyReportAlerts() {
 
   useEffect(() => {
     load();
-    const t = setInterval(load, 60_000);
-    return () => clearInterval(t);
+    const onVisible = () => {
+      if (document.visibilityState === "visible") load();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    const t = setInterval(() => {
+      if (document.visibilityState === "visible") load();
+    }, 300_000);
+    return () => {
+      clearInterval(t);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
   }, []);
 
   return { alerts };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -14,6 +14,8 @@ import type { HeaderProps } from "@/src/types/layout";
 import type { Notification } from "@/src/types/notifications";
 import { useStoreDetails } from "@components/providers/StoreDetailsProvider";
 import { usePathname } from "next/navigation";
+const NOTIFICATIONS_SESSION_KEY = "keyaway:notifications:v1";
+
 export default function Header({ logoData, notifications: notificationsProp, socialData }: HeaderProps) {
   const storeData = useStoreDetails();
   const pathname = usePathname();
@@ -25,11 +27,31 @@ export default function Header({ logoData, notifications: notificationsProp, soc
       return;
     }
     let cancelled = false;
+
+    try {
+      const cached = sessionStorage.getItem(NOTIFICATIONS_SESSION_KEY);
+      if (cached) {
+        const parsed = JSON.parse(cached) as Notification[];
+        if (Array.isArray(parsed)) {
+          setNotifications(parsed);
+          return;
+        }
+      }
+    } catch {
+      // ignore
+    }
+
     void fetch("/api/v1/notifications/recent")
       .then(r => r.json())
       .then((body: { data?: { notifications?: Notification[] } }) => {
         const list = body?.data?.notifications ?? [];
-        if (!cancelled) setNotifications(list);
+        if (cancelled) return;
+        setNotifications(list);
+        try {
+          sessionStorage.setItem(NOTIFICATIONS_SESSION_KEY, JSON.stringify(list));
+        } catch {
+          // ignore
+        }
       })
       .catch(() => {});
     return () => {

--- a/src/components/program/KeyStatusUpdater.tsx
+++ b/src/components/program/KeyStatusUpdater.tsx
@@ -10,7 +10,8 @@ export default function KeyStatusUpdater() {
     setIsUpdating(true);
     try {
       const response = await fetch("/api/v1/cron/update-expired-keys", {
-        method: "POST"
+        method: "POST",
+        credentials: "include"
       });
 
       const result = await response.json();

--- a/src/components/program/cdkeys/CDKeyTable.tsx
+++ b/src/components/program/cdkeys/CDKeyTable.tsx
@@ -187,7 +187,8 @@ export default function CDKeyTable({
                     sortColumn={sortColumn}
                     sortDirection={sortDirection}
                     onSort={handleSort}
-                    className="bg-[#212B45] text-white"
+                    tone="light"
+                    className="bg-[#212B45]"
                   />
                   <tbody className="divide-y divide-[#2a475e]">
                     {visibleKeys.map((cdKey: CDKey, i: number) => {

--- a/src/components/ui/SortableTableHead.tsx
+++ b/src/components/ui/SortableTableHead.tsx
@@ -2,6 +2,9 @@ import { FaChevronDown } from "react-icons/fa";
 
 export type SortDirection = "asc" | "desc";
 
+/** `light` = pale headers on dark sections; `dark` = dark headers on white/light sections. */
+export type SortableTableHeadTone = "light" | "dark";
+
 export interface SortableColumn {
   key: string;
   label: string;
@@ -15,25 +18,51 @@ export interface SortableTableHeadProps {
   sortDirection?: SortDirection;
   onSort?: (column: string) => void;
   className?: string;
+  tone?: SortableTableHeadTone;
 }
+
+const sortableHeadToneStyles: Record<
+  SortableTableHeadTone,
+  { inactive: string; hover: string; active: string; static: string }
+> = {
+  light: {
+    inactive: "text-[#8f98a0]",
+    hover: "hover:text-[#c6d4df]",
+    active: "text-white",
+    static: "text-[#8f98a0]"
+  },
+  dark: {
+    inactive: "text-gray-600",
+    hover: "hover:text-gray-500",
+    active: "text-black",
+    static: "text-gray-600"
+  }
+};
 
 function renderHeaderCell(
   column: SortableColumn,
+  tone: SortableTableHeadTone,
   sortColumn?: string,
   sortDirection?: SortDirection,
   onSort?: (column: string) => void
 ) {
+  const styles = sortableHeadToneStyles[tone];
+
   if (column.sortable && onSort) {
     const isActive = sortColumn === column.key;
     const aria = isActive ? (sortDirection === "asc" ? "ascending" : "descending") : "none";
+    const textClass = isActive ? styles.active : `${styles.inactive} ${styles.hover}`;
 
     return (
       <th
         key={column.key}
         scope="col"
         aria-sort={aria}
-        className={`p-4 text-sm font-semibold ${isActive ? "text-black" : "text-gray-600 hover:text-gray-500"} tracking-wider select-none ${column.className || ""}`}>
-        <button onClick={() => onSort(column.key)} className="flex items-center group cursor-pointer w-full">
+        className={`p-4 text-sm font-semibold tracking-wider select-none ${textClass} ${column.className || ""}`}>
+        <button
+          type="button"
+          onClick={() => onSort(column.key)}
+          className={`flex items-center group cursor-pointer w-full ${textClass}`}>
           <span>{column.label}</span>
           <span className="ml-1">
             <FaChevronDown
@@ -48,7 +77,9 @@ function renderHeaderCell(
   }
 
   return (
-    <th key={column.key} className={`p-4 text-sm font-semibold tracking-wider text-gray-600 ${column.className || ""}`}>
+    <th
+      key={column.key}
+      className={`p-4 text-sm font-semibold tracking-wider ${styles.static} ${column.className || ""}`}>
       {column.label}
     </th>
   );
@@ -59,11 +90,12 @@ export default function SortableTableHead({
   sortColumn,
   sortDirection,
   onSort,
-  className = ""
+  className = "",
+  tone = "dark"
 }: SortableTableHeadProps) {
   return (
-    <thead className={`${className}`}>
-      <tr>{columns.map(column => renderHeaderCell(column, sortColumn, sortDirection, onSort))}</tr>
+    <thead className={className}>
+      <tr>{columns.map(column => renderHeaderCell(column, tone, sortColumn, sortDirection, onSort))}</tr>
     </thead>
   );
 }

--- a/src/lib/admin/keyReportNotifications.server.ts
+++ b/src/lib/admin/keyReportNotifications.server.ts
@@ -1,0 +1,151 @@
+import { unstable_cache } from "next/cache";
+import { client } from "@/src/sanity/lib/client";
+import { keyReportsQuery } from "@/src/lib/sanity/queries";
+import type { KeyReportNotificationItem } from "@/src/types/admin";
+import { getKeyData } from "@/src/lib/keyHashing";
+import type { CDKey, ProgramFlow } from "@/src/types/program";
+import { normalizeProgramFlow } from "@/src/lib/program/activationEntry";
+
+const SIXTY_DAYS_MS = 60 * 24 * 60 * 60 * 1000;
+const MAX_ITEMS = 20;
+const CACHE_SECONDS = 120;
+
+type KeyReportEventType = "report_key_working" | "report_key_expired" | "report_key_limit_reached";
+
+interface KeyReportEvent {
+  eventType: string;
+  programSlug: string;
+  key?: string;
+  label?: string;
+  _createdAt?: string;
+  createdAt?: string;
+}
+
+interface Group {
+  programSlug: string;
+  storageKey: string;
+  label: string;
+  working: number;
+  expired: number;
+  limit_reached: number;
+  lastReportAt: string;
+  lastEventType?: KeyReportEventType;
+}
+
+function reportStorageKey(r: KeyReportEvent): string {
+  const k = (r.key ?? "").trim();
+  return k || "unknown";
+}
+
+function reportLabel(r: KeyReportEvent): string {
+  const l = (r.label ?? "").trim();
+  return l || "—";
+}
+
+async function buildKeyReportNotifications(): Promise<KeyReportNotificationItem[]> {
+  const since = new Date(Date.now() - SIXTY_DAYS_MS).toISOString();
+
+  const [events, programs] = await Promise.all([
+    client.fetch<KeyReportEvent[]>(keyReportsQuery, { since }),
+    client.fetch<
+      Array<{
+        slug?: string;
+        title?: string;
+        programFlow?: string;
+        cdKeys?: Array<Pick<CDKey, "key" | "status">>;
+      }>
+    >(
+      `*[_type == "program"]{
+        "slug": slug.current,
+        title,
+        "programFlow": coalesce(programFlow, "cd_key"),
+        "cdKeys": cdKeys[status in ["expired", "limit"]]{ key, status }
+      }`
+    )
+  ]);
+
+  const programTitleBySlug = new Map<string, string>();
+  const resolvedKeys = new Set<string>();
+  for (const p of programs ?? []) {
+    if (p.slug) programTitleBySlug.set(p.slug, p.title ?? p.slug);
+    const flow = normalizeProgramFlow(p.programFlow) as ProgramFlow;
+    for (const k of p.cdKeys ?? []) {
+      const kd = getKeyData({ ...(k as CDKey), programFlow: flow }, flow);
+      if (p.slug && kd?.hash) resolvedKeys.add(`${p.slug}:${kd.hash}`);
+    }
+  }
+
+  const groups = new Map<string, Group>();
+
+  for (const report of events ?? []) {
+    const programSlug = (report.programSlug ?? "").trim() || "unknown";
+    const storageKey = reportStorageKey(report);
+    const label = reportLabel(report);
+    if (storageKey === "unknown") continue;
+    const groupKey = `${programSlug}:${storageKey}`;
+    const eventType = report.eventType as KeyReportEventType;
+
+    const reportAt = report._createdAt ?? report.createdAt ?? "";
+    if (!groups.has(groupKey)) {
+      groups.set(groupKey, {
+        programSlug,
+        storageKey,
+        label,
+        working: 0,
+        expired: 0,
+        limit_reached: 0,
+        lastReportAt: reportAt,
+        lastEventType: eventType
+      });
+    }
+    const g = groups.get(groupKey)!;
+    if (reportAt && reportAt >= g.lastReportAt) {
+      g.lastReportAt = reportAt;
+      g.lastEventType = eventType;
+    }
+    if (eventType === "report_key_working") g.working++;
+    else if (eventType === "report_key_expired") g.expired++;
+    else if (eventType === "report_key_limit_reached") g.limit_reached++;
+  }
+
+  const negativeFiltered: Array<Group & { negativeCount: number; total: number }> = [];
+  for (const g of groups.values()) {
+    const negativeCount = g.expired + g.limit_reached;
+    if (negativeCount < 1) continue;
+    if (g.working > 0 && g.lastEventType === "report_key_working") continue;
+    if (resolvedKeys.has(`${g.programSlug}:${g.storageKey}`)) continue;
+    const total = g.working + g.expired + g.limit_reached;
+    negativeFiltered.push({ ...g, negativeCount, total });
+  }
+
+  negativeFiltered.sort((a, b) => {
+    if (b.negativeCount !== a.negativeCount) return b.negativeCount - a.negativeCount;
+    const ratioA = a.total > 0 ? a.working / a.total : 0;
+    const ratioB = b.total > 0 ? b.working / b.total : 0;
+    return ratioA - ratioB;
+  });
+
+  return negativeFiltered.slice(0, MAX_ITEMS).map(g => {
+    const total = g.working + g.expired + g.limit_reached;
+    const ratioLabel = total > 0 ? `${g.working}/${total} positive` : "0 positive";
+    return {
+      programSlug: g.programSlug,
+      programTitle: programTitleBySlug.get(g.programSlug) ?? g.programSlug,
+      label: g.label,
+      negativeCount: g.negativeCount,
+      positiveCount: g.working,
+      working: g.working,
+      expired: g.expired,
+      limit_reached: g.limit_reached,
+      ratioLabel,
+      lastReportAt: g.lastReportAt,
+      link: `/admin/key-reports?program=${encodeURIComponent(g.programSlug)}`
+    };
+  });
+}
+
+export const getCachedKeyReportNotifications = unstable_cache(
+  buildKeyReportNotifications,
+  ["admin-key-report-notifications"],
+  { revalidate: CACHE_SECONDS }
+);

--- a/src/lib/analytics/eventsApi.ts
+++ b/src/lib/analytics/eventsApi.ts
@@ -1,10 +1,9 @@
-/** @fileoverview Fetches merged tracking events for admin ranges, bundle program counts for homepage, visitor tag aggregates. */
+/** @fileoverview Fetches merged tracking events for admin ranges; program stats live on program docs (cron rollup). */
 import { enrichEventsWithVisitorMeta } from "@/src/lib/analytics/enrichEventsWithVisitorMeta";
 import { mergeTrackingEventsForRange } from "@/src/lib/analytics/mergeTrackingEventsForRange";
-import { TAG_BUNDLE_COUNTS } from "@/src/lib/cache/cacheTags";
-import { PUBLIC_ISR_REVALIDATE_SECONDS } from "@/src/lib/cache/constants";
+import { calculatePopularityScore } from "@/src/lib/program/programUtils";
 import { client } from "@/src/sanity/lib/client";
-import { bundleCountsQuery, visitorTagAggregatesQuery } from "@/src/lib/sanity/queries";
+import { visitorTagAggregatesQuery } from "@/src/lib/sanity/queries";
 import { AnalyticsEventData } from "@/src/types";
 
 export interface BundleCountsByProgram {
@@ -12,50 +11,27 @@ export interface BundleCountsByProgram {
   download_click: number;
 }
 
-/** Fetches bundle event counts aggregated by programSlug. Cached via Next.js. */
+/** @deprecated Stats are stored on program documents via cron rollup. Returns empty map. */
 export async function getBundleCountsByProgram(): Promise<Map<string, BundleCountsByProgram>> {
-  const bundles = await client.fetch<{ events: Array<{ programSlug?: string; event?: string; notFound?: boolean }> }[]>(
-    bundleCountsQuery,
-    {},
-    { next: { revalidate: PUBLIC_ISR_REVALIDATE_SECONDS, tags: [TAG_BUNDLE_COUNTS] } }
-  );
-  const map = new Map<string, BundleCountsByProgram>();
-  for (const b of bundles || []) {
-    for (const e of b.events || []) {
-      const slug = e.programSlug;
-      if (!slug || !e.event) continue;
-      const curr = map.get(slug) ?? { page_viewed: 0, download_click: 0 };
-      if (e.event === "page_viewed" && !e.notFound) curr.page_viewed++;
-      else if (e.event === "download_click") curr.download_click++;
-      map.set(slug, curr);
-    }
-  }
-  return map;
+  return new Map();
 }
 
-/** Merges singular counts with bundle counts for programs. Preserves all other fields. */
+/** Ensures view/download/popularity fields are numeric (already merged on program by cron). */
 export function mergeProgramStats<
   T extends { slug?: { current?: string }; viewCount?: number; downloadCount?: number; popularityScore?: number }
->(programs: T[], bundleCounts: Map<string, BundleCountsByProgram>): T[] {
+>(programs: T[]): T[] {
   return programs.map(p => {
-    const slug = p.slug?.current;
-    const bc = slug ? bundleCounts.get(slug) : undefined;
-    const v = (p.viewCount ?? 0) + (bc?.page_viewed ?? 0);
-    const d = (p.downloadCount ?? 0) + (bc?.download_click ?? 0);
-    const score = v + d * 3;
-    return { ...p, viewCount: v, downloadCount: d, popularityScore: score } as T;
+    const viewCount = p.viewCount ?? 0;
+    const downloadCount = p.downloadCount ?? 0;
+    const popularityScore = p.popularityScore ?? calculatePopularityScore(viewCount, downloadCount);
+    return { ...p, viewCount, downloadCount, popularityScore } as T;
   });
 }
 
-/** Merges stats for a single program. */
-export function mergeSingleProgramStats(
-  program: { viewCount?: number; downloadCount?: number },
-  slug: string | undefined,
-  bundleCounts: Map<string, BundleCountsByProgram>
-) {
-  const bc = slug ? bundleCounts.get(slug) : undefined;
-  const viewCount = (program.viewCount ?? 0) + (bc?.page_viewed ?? 0);
-  const downloadCount = (program.downloadCount ?? 0) + (bc?.download_click ?? 0);
+/** Merges stats for a single program (fields already on document). */
+export function mergeSingleProgramStats(program: { viewCount?: number; downloadCount?: number }) {
+  const viewCount = program.viewCount ?? 0;
+  const downloadCount = program.downloadCount ?? 0;
   return { viewCount, downloadCount };
 }
 

--- a/src/lib/analytics/syncProgramStatsRollup.ts
+++ b/src/lib/analytics/syncProgramStatsRollup.ts
@@ -1,0 +1,109 @@
+/** @fileoverview Cron: aggregate trackingEvent + bundle counts onto program docs (removes 2MB bundle fetch from public pages). */
+import { calculatePopularityScore } from "@/src/lib/program/programUtils";
+import {
+  TAG_FEATURED_PROGRAM,
+  TAG_HOMEPAGE_PROGRAMS,
+  TAG_PROGRAM_LISTINGS
+} from "@/src/lib/cache/cacheTags";
+import { client } from "@/src/sanity/lib/client";
+import { revalidateTag } from "next/cache";
+
+const BUNDLE_BATCH = 40;
+
+type StatsRow = { page_viewed: number; download_click: number };
+
+function applyEvent(
+  map: Map<string, StatsRow>,
+  programSlug: string | undefined,
+  event: string | undefined,
+  notFound?: boolean
+) {
+  const slug = programSlug?.trim();
+  if (!slug || !event) return;
+  const row = map.get(slug) ?? { page_viewed: 0, download_click: 0 };
+  if (event === "page_viewed" && !notFound) row.page_viewed++;
+  else if (event === "download_click") row.download_click++;
+  map.set(slug, row);
+}
+
+async function aggregateEventStats(): Promise<Map<string, StatsRow>> {
+  const map = new Map<string, StatsRow>();
+
+  let offset = 0;
+  while (true) {
+    const batch = await client.fetch<Array<{ events?: Array<{ programSlug?: string; event?: string; notFound?: boolean }> }>>(
+      `*[_type == "trackingEventBundle"] | order(_id asc) [$start...$end]{
+        "events": events[]{ programSlug, event, notFound }
+      }`,
+      { start: offset, end: offset + BUNDLE_BATCH - 1 }
+    );
+    if (!batch?.length) break;
+    for (const bundle of batch) {
+      for (const e of bundle.events ?? []) {
+        applyEvent(map, e.programSlug, e.event, e.notFound);
+      }
+    }
+    if (batch.length < BUNDLE_BATCH) break;
+    offset += BUNDLE_BATCH;
+  }
+
+  const singular = await client.fetch<Array<{ programSlug?: string; event?: string; notFound?: boolean }>>(
+    `*[_type == "trackingEvent" && event in ["page_viewed", "download_click"]]{
+      programSlug, event, notFound
+    }`
+  );
+  for (const e of singular ?? []) {
+    applyEvent(map, e.programSlug, e.event, e.notFound);
+  }
+
+  return map;
+}
+
+export interface SyncProgramStatsRollupResult {
+  ok: boolean;
+  patched: number;
+  error?: string;
+}
+
+/** Writes merged view/download/popularity scores onto each program document. */
+export async function runSyncProgramStatsRollup(): Promise<SyncProgramStatsRollupResult> {
+  try {
+    const statsBySlug = await aggregateEventStats();
+    const programs = await client.fetch<Array<{ _id: string; slug?: { current?: string } }>>(
+      `*[_type == "program"]{ _id, slug }`
+    );
+
+    let patched = 0;
+    const tx = client.transaction();
+
+    for (const program of programs ?? []) {
+      const slug = program.slug?.current;
+      const row = slug ? statsBySlug.get(slug) : undefined;
+      const viewCount = row?.page_viewed ?? 0;
+      const downloadCount = row?.download_click ?? 0;
+      const popularityScore = calculatePopularityScore(viewCount, downloadCount);
+      tx.patch(program._id, p =>
+        p
+          .set({ stats: { viewCount, downloadCount, popularityScore } })
+          .unset(["viewCount", "downloadCount", "popularityScore"])
+      );
+      patched++;
+    }
+
+    if (patched > 0) {
+      await tx.commit();
+      revalidateTag(TAG_PROGRAM_LISTINGS, "max");
+      revalidateTag(TAG_HOMEPAGE_PROGRAMS, "max");
+      revalidateTag(TAG_FEATURED_PROGRAM, "max");
+    }
+
+    return { ok: true, patched };
+  } catch (err) {
+    console.error("[syncProgramStatsRollup]", err);
+    return {
+      ok: false,
+      patched: 0,
+      error: err instanceof Error ? err.message : "Rollup sync failed"
+    };
+  }
+}

--- a/src/lib/cache/constants.ts
+++ b/src/lib/cache/constants.ts
@@ -4,4 +4,4 @@
  * `export const revalidate` in `app/layout`, pages, and `sitemap.ts` must use the same numeric literal (Next.js
  * does not accept imported values for segment config — see those files).
  */
-export const PUBLIC_ISR_REVALIDATE_SECONDS = 300;
+export const PUBLIC_ISR_REVALIDATE_SECONDS = 3600;

--- a/src/lib/program/programUtils.ts
+++ b/src/lib/program/programUtils.ts
@@ -54,17 +54,22 @@ export function sortByOldest(programs: ProgramWithStats[]): ProgramWithStats[] {
   return [...programs].sort((a, b) => new Date(a._createdAt).getTime() - new Date(b._createdAt).getTime());
 }
 
-/** Sorts that must run after projection + bundle merge (stats are not stored on program documents). */
-export function isStatsBasedProgramsSort(sortType: SortType): boolean {
-  return sortType === "popular" || sortType === "views" || sortType === "downloads";
+/** Sorts that were merged in JS before stats lived on program documents — now sort in GROQ. */
+export function isStatsBasedProgramsSort(_sortType: SortType): boolean {
+  return false;
 }
 
 /**
- * GROQ `| order(...)` after `{ programsListingProjection }` (projected fields).
- * Do not use for popular/views/downloads — use isStatsBasedProgramsSort + sortPrograms() instead.
+ * GROQ `| order(...)` after `{ programsListingProjection }`.
  */
 export function groqProgramsOrderClause(sortType: SortType): string {
   switch (sortType) {
+    case "popular":
+      return "| order(popularityScore desc)";
+    case "views":
+      return "| order(viewCount desc)";
+    case "downloads":
+      return "| order(downloadCount desc)";
     case "latest":
       return "| order(_createdAt desc)";
     case "oldest":

--- a/src/lib/programs/getProgramsPageData.ts
+++ b/src/lib/programs/getProgramsPageData.ts
@@ -1,25 +1,17 @@
 import { unstable_cache } from "next/cache";
 import { client } from "@/src/sanity/lib/client";
 import { programsListingProjection } from "@/src/lib/sanity/queries";
-import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
-import { getFeaturedProgram } from "@/src/lib/sanity/sanityActions";
-import { getBundleCountsByProgram, mergeProgramStats } from "@/src/lib/analytics/eventsApi";
+import { mergeProgramStats } from "@/src/lib/analytics/eventsApi";
 import type { ProgramWithStats } from "@/src/types/home";
 import type { FilterType, SortType } from "@/src/types/programs";
 import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
-import {
-  groqProgramsOrderClause,
-  isStatsBasedProgramsSort,
-  normalizeFilterType,
-  normalizeSortType,
-  sortPrograms
-} from "@/src/lib/program/programUtils";
+import { groqProgramsOrderClause, normalizeFilterType, normalizeSortType } from "@/src/lib/program/programUtils";
 import { TAG_PROGRAM_LISTINGS } from "@/src/lib/cache/cacheTags";
 import { PUBLIC_ISR_REVALIDATE_SECONDS } from "@/src/lib/cache/constants";
 
-const PROGRAMS_PER_PAGE = 16;
+export const PROGRAMS_PER_PAGE = 16;
 
-export type ProgramsPageData = {
+export type ProgramsListData = {
   programs: ProgramWithStats[];
   totalCount: number;
   totalKeys: number;
@@ -28,16 +20,37 @@ export type ProgramsPageData = {
   sortBy: SortType;
   page: number;
   programsPerPage: number;
-  storeRow: Awaited<ReturnType<typeof getCachedStoreDetailsDocument>>;
-  featuredProgram: Awaited<ReturnType<typeof getFeaturedProgram>>;
 };
 
-async function fetchProgramsPageData(
+export type ProgramsHeroTotals = {
+  totalCount: number;
+  totalKeys: number;
+};
+
+async function fetchProgramsHeroTotals(): Promise<ProgramsHeroTotals> {
+  const [totalCount, keyCountRows] = await Promise.all([
+    client.fetch<number>(`count(*[_type == "program"])`, {}, { next: { tags: [TAG_PROGRAM_LISTINGS] } }),
+    client.fetch<Array<{ keyCount?: number }>>(
+      `*[_type == "program"]{"keyCount": count(cdKeys[])}`,
+      {},
+      { next: { tags: [TAG_PROGRAM_LISTINGS] } }
+    )
+  ]);
+  const totalKeys = (keyCountRows ?? []).reduce((sum, row) => sum + (row.keyCount ?? 0), 0);
+  return { totalCount: totalCount ?? 0, totalKeys };
+}
+
+export const getCachedProgramsHeroTotals = unstable_cache(fetchProgramsHeroTotals, ["programs-hero-totals"], {
+  revalidate: PUBLIC_ISR_REVALIDATE_SECONDS,
+  tags: [TAG_PROGRAM_LISTINGS]
+});
+
+async function fetchProgramsListData(
   searchTerm: string,
   filter: FilterType,
   sortBy: SortType,
   page: number
-): Promise<ProgramsPageData> {
+): Promise<ProgramsListData> {
   const startIdx = (page - 1) * PROGRAMS_PER_PAGE;
   const endIdx = startIdx + PROGRAMS_PER_PAGE - 1;
   const filterQuery =
@@ -48,24 +61,16 @@ async function fetchProgramsPageData(
   const programsFilter = `*[_type == "program" && ${filterQuery}${searchFilter}]`;
   const countQuery = `count(${programsFilter})`;
   const keyCountQuery = `${programsFilter}{"keyCount": count(cdKeys[])}`;
-  const statsSort = isStatsBasedProgramsSort(sortBy);
-  const listQuery = statsSort
-    ? `${programsFilter} {${programsListingProjection}}`
-    : `${programsFilter} {${programsListingProjection}} ${groqProgramsOrderClause(sortBy)} [${startIdx}...${endIdx}]`;
+  const listQuery = `${programsFilter} {${programsListingProjection}} ${groqProgramsOrderClause(sortBy)} [${startIdx}...${endIdx}]`;
   const queryParams = searchTerm ? { search: `*${searchTerm.toLowerCase()}*` } : {};
 
-  const [totalCount, keyCountRows, rawPrograms, bundleCounts, storeRow, featuredProgram] = await Promise.all([
+  const [totalCount, keyCountRows, rawPrograms] = await Promise.all([
     client.fetch<number>(countQuery, queryParams, { next: { tags: [TAG_PROGRAM_LISTINGS] } }),
     client.fetch<Array<{ keyCount?: number }>>(keyCountQuery, queryParams, { next: { tags: [TAG_PROGRAM_LISTINGS] } }),
-    client.fetch<ProgramWithStats[]>(listQuery, queryParams, { next: { tags: [TAG_PROGRAM_LISTINGS] } }),
-    getBundleCountsByProgram(),
-    getCachedStoreDetailsDocument(),
-    getFeaturedProgram()
+    client.fetch<ProgramWithStats[]>(listQuery, queryParams, { next: { tags: [TAG_PROGRAM_LISTINGS] } })
   ]);
 
-  const mergedAll = mergeProgramStats((rawPrograms ?? []) as ProgramWithStats[], bundleCounts);
-  const pageSlice = statsSort ? sortPrograms(mergedAll, sortBy).slice(startIdx, endIdx + 1) : mergedAll;
-  const programs = pageSlice.map(program => ({
+  const programs = mergeProgramStats((rawPrograms ?? []) as ProgramWithStats[]).map(program => ({
     ...program,
     descriptionPlain: portableTextToPlainText(program.description)
   })) as ProgramWithStats[];
@@ -74,32 +79,46 @@ async function fetchProgramsPageData(
 
   return {
     programs,
-    totalCount,
+    totalCount: totalCount ?? 0,
     totalKeys,
     searchTerm,
     filter,
     sortBy,
     page,
-    programsPerPage: PROGRAMS_PER_PAGE,
-    storeRow,
-    featuredProgram
+    programsPerPage: PROGRAMS_PER_PAGE
   };
 }
 
-export async function getProgramsPageData(
+export async function getProgramsListData(
   rawSearch: string | undefined,
   rawFilter: string | undefined,
   rawSort: string | undefined,
   rawPage: string | undefined
-): Promise<ProgramsPageData> {
+): Promise<ProgramsListData> {
   const searchTerm = (rawSearch || "").trim();
   const filter = normalizeFilterType(rawFilter);
   const sortBy = normalizeSortType(rawSort);
   const page = Math.max(1, Number.parseInt(rawPage || "1", 10) || 1);
 
   return unstable_cache(
-    () => fetchProgramsPageData(searchTerm, filter, sortBy, page),
-    ["programs-page", searchTerm, filter, sortBy, String(page)],
+    () => fetchProgramsListData(searchTerm, filter, sortBy, page),
+    ["programs-list-v2", searchTerm, filter, sortBy, String(page)],
+    { revalidate: PUBLIC_ISR_REVALIDATE_SECONDS, tags: [TAG_PROGRAM_LISTINGS] }
+  )();
+}
+
+/** Top programs for JSON-LD on static /programs shell. */
+export async function getCachedProgramsForJsonLd(limit = 20): Promise<ProgramWithStats[]> {
+  return unstable_cache(
+    async () => {
+      const rows = await client.fetch<ProgramWithStats[]>(
+        `*[_type == "program"] {${programsListingProjection}} | order(popularityScore desc) [0...$limit]`,
+        { limit: limit - 1 },
+        { next: { tags: [TAG_PROGRAM_LISTINGS] } }
+      );
+      return mergeProgramStats(rows ?? []);
+    },
+    ["programs-jsonld-v2", String(limit)],
     { revalidate: PUBLIC_ISR_REVALIDATE_SECONDS, tags: [TAG_PROGRAM_LISTINGS] }
   )();
 }

--- a/src/lib/sanity/getCachedPublishedProgramSlugs.ts
+++ b/src/lib/sanity/getCachedPublishedProgramSlugs.ts
@@ -1,0 +1,29 @@
+/** @fileoverview Cached set of published program slugs (track API validation without per-hit Sanity fetch). */
+import { unstable_cache } from "next/cache";
+import { TAG_PROGRAM_LISTINGS } from "@/src/lib/cache/cacheTags";
+import { PUBLIC_ISR_REVALIDATE_SECONDS } from "@/src/lib/cache/constants";
+import { client } from "@/src/sanity/lib/client";
+
+async function fetchPublishedSlugSet(): Promise<Set<string>> {
+  const slugs = await client.fetch<string[]>(
+    `*[_type == "program" && defined(slug.current)].slug.current`,
+    {},
+    { next: { tags: [TAG_PROGRAM_LISTINGS] } }
+  );
+  return new Set((slugs ?? []).filter(Boolean));
+}
+
+export async function getCachedPublishedProgramSlugs(): Promise<Set<string>> {
+  return unstable_cache(fetchPublishedSlugSet, ["published-program-slugs"], {
+    revalidate: PUBLIC_ISR_REVALIDATE_SECONDS,
+    tags: [TAG_PROGRAM_LISTINGS]
+  })();
+}
+
+/** True if slug exists on a published program (uses cached slug inventory). */
+export async function isProgramSlugPublishedCached(slug: string | undefined): Promise<boolean> {
+  const s = slug?.trim();
+  if (!s) return false;
+  const set = await getCachedPublishedProgramSlugs();
+  return set.has(s);
+}

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -40,6 +40,17 @@ featured{
   showcaseGif
 }`;
 
+/** Flattened analytics fields — reads nested `stats` with legacy top-level fallback. */
+export const programStatsProjection = `
+  "viewCount": coalesce(stats.viewCount, viewCount, 0),
+  "downloadCount": coalesce(stats.downloadCount, downloadCount, 0),
+  "popularityScore": coalesce(
+    stats.popularityScore,
+    popularityScore,
+    coalesce(stats.viewCount, viewCount, 0) + coalesce(stats.downloadCount, downloadCount, 0) * 3
+  )
+`;
+
 /* ------------ Programs listing projection (shared: stats + list fields) ------------ */
 export const programsListingProjection = `
   title,
@@ -50,9 +61,7 @@ export const programsListingProjection = `
   _createdAt,
   "keyCount": count(cdKeys[]),
   "hasKeys": count(cdKeys[]) > 0,
-  "viewCount": coalesce(viewCount, 0),
-  "downloadCount": coalesce(downloadCount, 0),
-  "popularityScore": coalesce(popularityScore, 0)
+  ${programStatsProjection}
 `;
 
 /** Related / card rows: no tracking aggregates, no cdKeys[]. */
@@ -181,7 +190,8 @@ export const programBySlugQuery = `
       createdAt
     }
   },
-  cdKeys[]
+  cdKeys[],
+  ${programStatsProjection}
 }
 `;
 
@@ -312,8 +322,7 @@ export const featuredProgramQuery = `*[_type == "program" && slug.current == $sl
   cdKeys[],
   "totalKeys": count(cdKeys[]),
   "workingKeys": count(cdKeys[status == "active" || status == "new"]),
-  "viewCount": coalesce(viewCount, 0),
-  "downloadCount": coalesce(downloadCount, 0)
+  ${programStatsProjection}
 }`;
 
 /* ------------ Programs for Auto-Selection (highest working keys) ------------ */
@@ -329,7 +338,5 @@ export const programsForAutoSelectionQuery = `*[_type == "program"]{
   cdKeys[],
   "totalKeys": count(cdKeys[]),
   "workingKeys": count(cdKeys[status == "active" || status == "new"]),
-  "viewCount": coalesce(viewCount, 0),
-  "downloadCount": coalesce(downloadCount, 0),
-  "popularityScore": coalesce(popularityScore, (coalesce(viewCount, 0) + coalesce(downloadCount, 0) * 3))
+  ${programStatsProjection}
 } | order(workingKeys desc, popularityScore desc)`;

--- a/src/lib/sanity/sanityActions.ts
+++ b/src/lib/sanity/sanityActions.ts
@@ -4,7 +4,7 @@ import { programDetailTag, TAG_FEATURED_PROGRAM } from "@/src/lib/cache/cacheTag
 import { client } from "@/src/sanity/lib/client";
 import { CDKey, Program } from "@/src/types";
 import { programBySlugQuery, featuredProgramSettingsQuery, programsForAutoSelectionQuery } from "./queries";
-import { getBundleCountsByProgram, mergeProgramStats, mergeSingleProgramStats } from "@/src/lib/analytics/eventsApi";
+import { mergeProgramStats, mergeSingleProgramStats } from "@/src/lib/analytics/eventsApi";
 import { applyKeyStatusForDisplay } from "@/src/lib/program/applyKeyStatusForDisplay";
 
 /**
@@ -101,21 +101,15 @@ export async function getProgramBySlug(slug: string) {
 /**
  * Helper: Get program stats (keys, views, downloads) including bundled events
  */
-async function getProgramStats(
-  program: Program,
-  bundleCounts?: Map<string, { page_viewed: number; download_click: number }>
-) {
+async function getProgramStats(program: Program) {
   const sortedCdKeys = program.cdKeys || [];
   const totalKeys = sortedCdKeys.length;
   const workingKeys = sortedCdKeys.filter((cd: CDKey) => cd.status === "active" || cd.status === "new").length;
 
-  const counts = bundleCounts ?? (await getBundleCountsByProgram());
-
-  const { viewCount, downloadCount } = mergeSingleProgramStats(
-    { viewCount: program.viewCount ?? 0, downloadCount: program.downloadCount ?? 0 },
-    program.slug?.current,
-    counts
-  );
+  const { viewCount, downloadCount } = mergeSingleProgramStats({
+    viewCount: program.viewCount ?? 0,
+    downloadCount: program.downloadCount ?? 0
+  });
 
   return { ...program, totalKeys, workingKeys, viewCount, downloadCount };
 }
@@ -169,14 +163,9 @@ export async function getFeaturedProgram(): Promise<
     const settings = await client.fetch(featuredProgramSettingsQuery, {}, { next: { tags: [TAG_FEATURED_PROGRAM] } });
 
     if (!settings) {
-      // No settings: auto-select first program with working keys
-      const [rawPrograms, bundleCounts] = await Promise.all([
-        client.fetch(programsForAutoSelectionQuery, {}, { next: { tags: [TAG_FEATURED_PROGRAM] } }),
-        getBundleCountsByProgram()
-      ]);
+      const rawPrograms = await client.fetch(programsForAutoSelectionQuery, {}, { next: { tags: [TAG_FEATURED_PROGRAM] } });
       const programs = mergeProgramStats(
-        (rawPrograms ?? []) as Array<{ slug: { current: string }; viewCount?: number; downloadCount?: number }>,
-        bundleCounts
+        (rawPrograms ?? []) as Array<{ slug: { current: string }; viewCount?: number; downloadCount?: number }>
       );
       for (const p of programs) {
         const workingKeys = ((p as Program).cdKeys || []).filter(
@@ -205,13 +194,9 @@ export async function getFeaturedProgram(): Promise<
 
     // Auto-select when rotation needed
     if (needsRot) {
-      const [rawPrograms, bundleCounts] = await Promise.all([
-        client.fetch(programsForAutoSelectionQuery, {}, { next: { tags: [TAG_FEATURED_PROGRAM] } }),
-        getBundleCountsByProgram()
-      ]);
+      const rawPrograms = await client.fetch(programsForAutoSelectionQuery, {}, { next: { tags: [TAG_FEATURED_PROGRAM] } });
       const programs = mergeProgramStats(
-        (rawPrograms ?? []) as Array<{ slug: { current: string }; viewCount?: number; downloadCount?: number }>,
-        bundleCounts
+        (rawPrograms ?? []) as Array<{ slug: { current: string }; viewCount?: number; downloadCount?: number }>
       );
       const programsWithStats = await Promise.all(
         programs.map(
@@ -253,7 +238,7 @@ export async function getFeaturedProgram(): Promise<
           .catch(err => console.error("Failed to update rotation:", err));
       }
 
-      return await getProgramStats(selected.program, bundleCounts);
+      return await getProgramStats(selected.program);
     }
 
     return null;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,30 +1,9 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
-// Simple in-memory cache to prevent too frequent updates
-const lastUpdateTime = new Map<string, number>();
-const UPDATE_INTERVAL = 5 * 60 * 1000; // 5 minutes
-
 // Auth redirect in proxy caused 302 loop with Auth.js v5 beta. Protection handled by ProtectedAdminLayout.
-export function proxy(request: NextRequest) {
-  const response = NextResponse.next();
-
-  // Only handle program pages for key updates
-  if (request.nextUrl.pathname.startsWith("/program/")) {
-    const slug = request.nextUrl.pathname.split("/program/")[1];
-
-    if (slug) {
-      const now = Date.now();
-      const lastUpdate = lastUpdateTime.get(slug) || 0;
-
-      if (now - lastUpdate > UPDATE_INTERVAL) {
-        lastUpdateTime.set(slug, now);
-        response.headers.set("x-update-keys", "true");
-      }
-    }
-  }
-
-  return response;
+export function proxy(_request: NextRequest) {
+  return NextResponse.next();
 }
 
 export const config = {

--- a/src/sanity/schemaTypes/program/program.ts
+++ b/src/sanity/schemaTypes/program/program.ts
@@ -231,6 +231,38 @@ export const program = defineType({
       }
     }),
     defineField({
+      name: "stats",
+      title: "Analytics stats",
+      type: "object",
+      readOnly: true,
+      options: { collapsible: true, collapsed: true },
+      description: "Synced from analytics by the bundle-events cron. Do not edit manually.",
+      fields: [
+        defineField({
+          name: "viewCount",
+          title: "Page views",
+          type: "number",
+          readOnly: true,
+          initialValue: 0
+        }),
+        defineField({
+          name: "downloadCount",
+          title: "Download clicks",
+          type: "number",
+          readOnly: true,
+          initialValue: 0
+        }),
+        defineField({
+          name: "popularityScore",
+          title: "Popularity score",
+          type: "number",
+          readOnly: true,
+          description: "viewCount + downloadCount × 3",
+          initialValue: 0
+        })
+      ]
+    }),
+    defineField({
       name: "cdKeys",
       title: "Activation entries",
       description: "Keys, accounts, or giveaway links depending on Activation flow above.",


### PR DESCRIPTION
## Summary

Reduces Vercel Fluid Active CPU by storing analytics counts on program documents, serving /programs as a static shell with a cached list API, and tightening admin polling.

## Changelog

<!-- tags: perf, api, enhance -->

### Highlights

- Program view/download stats roll up onto Sanity program docs
- /programs static shell with cached GET /api/v1/programs/list
- Admin key-report notifications cached with lighter GROQ and tab-scoped polling

### Performance

- Homepage, featured program, and programs listing read stored stats — no multi-MB bundle fetch per render
- Public ISR fallback revalidate raised to 3600s; webhook tag bust unchanged
- Analytics track uses cached slug inventory instead of per-hit Sanity lookups

### Admin & security

- Manual update-expired-keys cron requires admin session or cron auth
- Removed unused x-update-keys proxy hook
- SortableTableHead tone=light for dark program key table headers

---

## Environment Variables

None

## Testing

- Run bundle-events cron; confirm non-zero stats on homepage, featured block, and /programs page 1
- /programs filter, sort, pagination, and search via API
- Admin key-report alerts load; manual Update Keys works when logged in
- page_viewed tracking still records navigations

## Technical Details

Sanity program.stats nested object; rollup cron clears legacy top-level stat fields. Run rollup once after deploy if stats are zero.
