### PR TITLE
perf: decrease ISR writes with 12h public revalidation

### DIFF
--- a/src/app/api/v1/programs/list/route.ts
+++ b/src/app/api/v1/programs/list/route.ts
@@ -12,13 +12,18 @@ export async function GET(req: NextRequest) {
   const sp = req.nextUrl.searchParams;
 
   try {
-    const data = await getProgramsListData(sp.get("search") ?? undefined, sp.get("filter") ?? undefined, sp.get("sort") ?? undefined, sp.get("page") ?? undefined);
+    const data = await getProgramsListData(
+      sp.get("search") ?? undefined,
+      sp.get("filter") ?? undefined,
+      sp.get("sort") ?? undefined,
+      sp.get("page") ?? undefined
+    );
 
     return NextResponse.json(
       { data, meta: {} },
       {
         headers: {
-          "Cache-Control": `public, s-maxage=${PUBLIC_ISR_REVALIDATE_SECONDS}, stale-while-revalidate=120`
+          "Cache-Control": `public, s-maxage=${PUBLIC_ISR_REVALIDATE_SECONDS}, stale-while-revalidate=${PUBLIC_ISR_REVALIDATE_SECONDS}`
         }
       }
     );

--- a/src/app/api/v1/visitor/context/route.ts
+++ b/src/app/api/v1/visitor/context/route.ts
@@ -23,7 +23,7 @@ export async function GET(req: NextRequest) {
     { data: ctx, meta: {} },
     {
       headers: {
-        "Cache-Control": `private, max-age=${PUBLIC_ISR_REVALIDATE_SECONDS}, stale-while-revalidate=60`
+        "Cache-Control": `private, max-age=${PUBLIC_ISR_REVALIDATE_SECONDS}, stale-while-revalidate=${PUBLIC_ISR_REVALIDATE_SECONDS}`
       }
     }
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { LogoData, SocialData } from "@/src/types";
 import { urlFor } from "../sanity/lib/image";
 import { getImageDimensions } from "@sanity/asset-utils";
 import { generateHomePageMetadata } from "@/src/lib/seo/metadata";
+import { PUBLIC_ISR_REVALIDATE_SECONDS } from "../lib/cache/constants";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"]
@@ -23,8 +24,7 @@ const geistMono = Geist_Mono({
   subsets: ["latin"]
 });
 
-/** Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
-export const revalidate = 3600;
+export const revalidate = PUBLIC_ISR_REVALIDATE_SECONDS;
 
 type HeadMetaTag = {
   name?: string;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,7 +13,6 @@ import { LogoData, SocialData } from "@/src/types";
 import { urlFor } from "../sanity/lib/image";
 import { getImageDimensions } from "@sanity/asset-utils";
 import { generateHomePageMetadata } from "@/src/lib/seo/metadata";
-import { PUBLIC_ISR_REVALIDATE_SECONDS } from "../lib/cache/constants";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"]
@@ -24,7 +23,8 @@ const geistMono = Geist_Mono({
   subsets: ["latin"]
 });
 
-export const revalidate = PUBLIC_ISR_REVALIDATE_SECONDS;
+/** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` in `@/src/lib/cache/constants` (Next.js requires a literal). */
+export const revalidate = 43200;
 
 type HeadMetaTag = {
   name?: string;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,9 +17,9 @@ import StatsSection from "@/src/components/home/StatsSection";
 import CTASection from "@/src/components/home/CTASection";
 import { SocialData } from "@/src/types";
 import { TAG_HOMEPAGE_PROGRAMS, TAG_HOMEPAGE_STATS } from "@/src/lib/cache/cacheTags";
+import { PUBLIC_ISR_REVALIDATE_SECONDS } from "../lib/cache/constants";
 
-/** Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
-export const revalidate = 3600;
+export const revalidate = PUBLIC_ISR_REVALIDATE_SECONDS;
 
 const HOMEPAGE_POPULAR_LIMIT = 8;
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,9 +17,8 @@ import StatsSection from "@/src/components/home/StatsSection";
 import CTASection from "@/src/components/home/CTASection";
 import { SocialData } from "@/src/types";
 import { TAG_HOMEPAGE_PROGRAMS, TAG_HOMEPAGE_STATS } from "@/src/lib/cache/cacheTags";
-import { PUBLIC_ISR_REVALIDATE_SECONDS } from "../lib/cache/constants";
-
-export const revalidate = PUBLIC_ISR_REVALIDATE_SECONDS;
+/** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` in `@/src/lib/cache/constants` (Next.js requires a literal). */
+export const revalidate = 43200;
 
 const HOMEPAGE_POPULAR_LIMIT = 8;
 

--- a/src/app/program/[slug]/page.tsx
+++ b/src/app/program/[slug]/page.tsx
@@ -33,9 +33,9 @@ import { loadMessages } from "@/src/lib/i18n/loadMessages";
 import { ProgramVisitorProvider } from "@/src/components/visitors/ProgramVisitorProvider";
 import { client } from "@/src/sanity/lib/client";
 import { TAG_SITEMAP_URLS } from "@/src/lib/cache/cacheTags";
+import { PUBLIC_ISR_REVALIDATE_SECONDS } from "../../../lib/cache/constants";
 
-/** Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
-export const revalidate = 3600;
+export const revalidate = PUBLIC_ISR_REVALIDATE_SECONDS;
 
 interface ProgramPageProps {
   params: Promise<{ slug: string }>;

--- a/src/app/program/[slug]/page.tsx
+++ b/src/app/program/[slug]/page.tsx
@@ -33,9 +33,8 @@ import { loadMessages } from "@/src/lib/i18n/loadMessages";
 import { ProgramVisitorProvider } from "@/src/components/visitors/ProgramVisitorProvider";
 import { client } from "@/src/sanity/lib/client";
 import { TAG_SITEMAP_URLS } from "@/src/lib/cache/cacheTags";
-import { PUBLIC_ISR_REVALIDATE_SECONDS } from "../../../lib/cache/constants";
-
-export const revalidate = PUBLIC_ISR_REVALIDATE_SECONDS;
+/** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` in `@/src/lib/cache/constants` (Next.js requires a literal). */
+export const revalidate = 43200;
 
 interface ProgramPageProps {
   params: Promise<{ slug: string }>;

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -11,9 +11,8 @@ import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDe
 import { getFeaturedProgram } from "@/src/lib/sanity/sanityActions";
 import { getCachedProgramsForJsonLd, getCachedProgramsHeroTotals } from "@/src/lib/programs/getProgramsPageData";
 import type { SocialData } from "@/src/types";
-import { PUBLIC_ISR_REVALIDATE_SECONDS } from "../../lib/cache/constants";
-
-export const revalidate = PUBLIC_ISR_REVALIDATE_SECONDS;
+/** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` in `@/src/lib/cache/constants` (Next.js requires a literal). */
+export const revalidate = 43200;
 
 export async function generateMetadata() {
   return await generateProgramsPageMetadata();

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -9,14 +9,11 @@ import FeaturedProgramSection from "@/src/components/home/FeaturedProgramSection
 import { FacebookGroupButton } from "@/src/components/social";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
 import { getFeaturedProgram } from "@/src/lib/sanity/sanityActions";
-import {
-  getCachedProgramsForJsonLd,
-  getCachedProgramsHeroTotals
-} from "@/src/lib/programs/getProgramsPageData";
+import { getCachedProgramsForJsonLd, getCachedProgramsHeroTotals } from "@/src/lib/programs/getProgramsPageData";
 import type { SocialData } from "@/src/types";
+import { PUBLIC_ISR_REVALIDATE_SECONDS } from "../../lib/cache/constants";
 
-/** Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
-export const revalidate = 3600;
+export const revalidate = PUBLIC_ISR_REVALIDATE_SECONDS;
 
 export async function generateMetadata() {
   return await generateProgramsPageMetadata();

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,10 +5,9 @@ import { client } from "@/src/sanity/lib/client";
 import { allProgramsQuery } from "@/src/lib/sanity/queries";
 import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
 import { Program, CDKey } from "@/src/types";
-import { PUBLIC_ISR_REVALIDATE_SECONDS } from "../lib/cache/constants";
-
 /** ISR fallback; URL set busts use `TAG_SITEMAP_URLS` (admin + selective webhook). */
-export const revalidate = PUBLIC_ISR_REVALIDATE_SECONDS;
+/** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` in `@/src/lib/cache/constants` (Next.js requires a literal). */
+export const revalidate = 43200;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const [store, programs] = await Promise.all([

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,9 +5,10 @@ import { client } from "@/src/sanity/lib/client";
 import { allProgramsQuery } from "@/src/lib/sanity/queries";
 import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
 import { Program, CDKey } from "@/src/types";
+import { PUBLIC_ISR_REVALIDATE_SECONDS } from "../lib/cache/constants";
 
-/** ISR fallback; URL set busts use `TAG_SITEMAP_URLS` (admin + selective webhook). Keep in sync with `PUBLIC_ISR_REVALIDATE_SECONDS`. */
-export const revalidate = 3600;
+/** ISR fallback; URL set busts use `TAG_SITEMAP_URLS` (admin + selective webhook). */
+export const revalidate = PUBLIC_ISR_REVALIDATE_SECONDS;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const [store, programs] = await Promise.all([
@@ -17,14 +18,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = resolveSiteBaseUrl(store?.seo);
   const currentDate = new Date();
 
-  const trustPaths = [
-    "/about",
-    "/how-it-works",
-    "/affiliate-disclosure",
-    "/verification-policy",
-    "/dmca",
-    "/partners"
-  ];
+  const trustPaths = ["/about", "/how-it-works", "/affiliate-disclosure", "/verification-policy", "/dmca", "/partners"];
 
   // Static routes with proper SEO optimization
   const staticRoutes: MetadataRoute.Sitemap = [

--- a/src/lib/cache/constants.ts
+++ b/src/lib/cache/constants.ts
@@ -4,4 +4,5 @@
  * `export const revalidate` in `app/layout`, pages, and `sitemap.ts` must use the same numeric literal (Next.js
  * does not accept imported values for segment config — see those files).
  */
-export const PUBLIC_ISR_REVALIDATE_SECONDS = 12 * 60 * 60;
+const TWELVE_HOURS = 12 * 60 * 60;
+export const PUBLIC_ISR_REVALIDATE_SECONDS = TWELVE_HOURS;

--- a/src/lib/cache/constants.ts
+++ b/src/lib/cache/constants.ts
@@ -3,6 +3,6 @@
  *
  * `export const revalidate` in `app/layout`, pages, and `sitemap.ts` must use the same numeric literal (Next.js
  * does not accept imported values for segment config — see those files).
+ * Currently set to 12 hours.
  */
-const TWELVE_HOURS = 12 * 60 * 60;
-export const PUBLIC_ISR_REVALIDATE_SECONDS = TWELVE_HOURS;
+export const PUBLIC_ISR_REVALIDATE_SECONDS = 43200;

--- a/src/lib/cache/constants.ts
+++ b/src/lib/cache/constants.ts
@@ -1,8 +1,8 @@
 /**
  * Public route ISR / Data Cache fallback (seconds). Webhooks should bust tags before this window matters.
  *
- * `export const revalidate` in `app/layout`, pages, and `sitemap.ts` must use the same numeric literal (Next.js
- * does not accept imported values for segment config — see those files).
+ * `export const revalidate` in `app/layout`, pages, and `sitemap.ts` must be the same numeric literal (e.g.
+ * `43200`) — Next.js rejects imported values for segment config. Keep in sync when changing this constant.
  * Currently set to 12 hours.
  */
 export const PUBLIC_ISR_REVALIDATE_SECONDS = 43200;

--- a/src/lib/cache/constants.ts
+++ b/src/lib/cache/constants.ts
@@ -4,4 +4,4 @@
  * `export const revalidate` in `app/layout`, pages, and `sitemap.ts` must use the same numeric literal (Next.js
  * does not accept imported values for segment config — see those files).
  */
-export const PUBLIC_ISR_REVALIDATE_SECONDS = 3600;
+export const PUBLIC_ISR_REVALIDATE_SECONDS = 12 * 60 * 60;

--- a/src/lib/cache/revalidateProgramContent.ts
+++ b/src/lib/cache/revalidateProgramContent.ts
@@ -1,8 +1,6 @@
 import { revalidatePath, revalidateTag } from "next/cache";
 import {
-  TAG_FEATURED_PROGRAM,
   TAG_HOMEPAGE_PROGRAMS,
-  TAG_HOMEPAGE_STATS,
   TAG_PROGRAM_LISTINGS,
   TAG_PROGRAMS_FULL,
   TAG_SITEMAP_URLS,
@@ -27,8 +25,6 @@ export function revalidateAfterProgramContentWrite(opts: ProgramWriteOpts = {}):
   revalidateTag(TAG_PROGRAMS_FULL, "max");
   revalidateTag(TAG_PROGRAM_LISTINGS, "max");
   revalidateTag(TAG_HOMEPAGE_PROGRAMS, "max");
-  revalidateTag(TAG_HOMEPAGE_STATS, "max");
-  revalidateTag(TAG_FEATURED_PROGRAM, "max");
   if (slug) revalidateTag(programDetailTag(slug), "max");
   if (previousSlug && previousSlug !== slug) revalidateTag(programDetailTag(previousSlug), "max");
   if (invalidateSitemap) {


### PR DESCRIPTION
## Summary

Cuts ISR write volume and aligns public revalidation to 12 hours so homepage stats and featured content stop forcing excessive rebuilds.

## Changelog

<!-- tags: perf, fix -->

### Highlights

- Public ISR revalidate raised to 12 hours across key routes
- Homepage stats and featured blocks no longer trigger forced revalidation churn
- Programs list and visitor context APIs aligned with shared revalidate constant

### Performance

- sitemap, program pages, programs index, and homepage share consistent ISR seconds
- build-safe integer revalidate values across layout and pages

---

## Environment Variables

None

## Testing

- Production build succeeds with aligned revalidate literals
- Homepage and /programs still refresh after Sanity webhooks
- programs/list and visitor/context responses respect CDN cache headers

## Technical Details

Central constant in cache/constants.ts; revalidateProgramContent paths updated.
