### PR TITLE
feat: vendor hubs, social sharing, updates feed, and SEO structured data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@portabletext/toolkit": "^5.0.2",
         "@portabletext/types": "^4.0.2",
         "@sanity/client": "^7.22.0",
+        "@sanity/color-input": "^6.0.12",
         "@sanity/image-url": "^2.1.1",
         "@sanity/vision": "^5.26.0",
         "@vercel/analytics": "^2.0.1",
@@ -6182,6 +6183,129 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@sanity/color-input": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@sanity/color-input/-/color-input-6.0.12.tgz",
+      "integrity": "sha512-QSPEHkBphNtXp718IfcEUhYIQx2tozDiTxmSkKS1eitM9ilpkA/gQHb/ChKwX3i8TiGBVY4E2fmeLRHiAQoMVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sanity/icons": "^5.0.0",
+        "@sanity/ui": "^3.3.0",
+        "lodash-es": "^4.18.1",
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^19.2",
+        "sanity": "^5 || ^6.0.0-0",
+        "styled-components": "^6.1"
+      }
+    },
+    "node_modules/@sanity/color-input/node_modules/@sanity/icons": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-5.0.0.tgz",
+      "integrity": "sha512-fINQLovVnCANwQbQ63iO2mUVh2ZX3T4h3hiSEaIStvladI5tmrGAuT+XbUuk3jTmBwOHDGD0EL9lpsghGAS+Sg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12"
+      },
+      "peerDependencies": {
+        "react": "^19"
+      }
+    },
+    "node_modules/@sanity/color-input/node_modules/@sanity/ui": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@sanity/ui/-/ui-3.3.5.tgz",
+      "integrity": "sha512-xXsaquGfi93EHTuOgctH/ryu7J8fe9lajtsq6We1Opmnjr0bron7DOyAaMAUm1jSxemrVDnVJ6s/6TuagDZVEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.8",
+        "@juggle/resize-observer": "^3.4.0",
+        "@sanity/color": "^3.0.6",
+        "@sanity/icons": "^3.8.0",
+        "csstype": "^3.2.3",
+        "motion": "^12.42.2",
+        "react-compiler-runtime": "1.0.0",
+        "react-refractor": "^4.0.0",
+        "use-effect-event": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=20.19 <22 || >=22.12"
+      },
+      "peerDependencies": {
+        "react": "^18 || >=19.0.0-0",
+        "react-dom": "^18 || >=19.0.0-0",
+        "react-is": "^18 || >=19.0.0-0",
+        "styled-components": "^5.2 || ^6"
+      }
+    },
+    "node_modules/@sanity/color-input/node_modules/@sanity/ui/node_modules/@sanity/icons": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-3.8.0.tgz",
+      "integrity": "sha512-LXa8eoE6U2e46L/9Pk6VU1aOWNxEqEG1osTb2YWItPIAa8MyXkICRwdNRWwW3kr5gmf+Sh2ZmfKol/Q+oGKSqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.3 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@sanity/color-input/node_modules/@sanity/ui/node_modules/motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
+      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.42.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sanity/color-input/node_modules/@sanity/ui/node_modules/motion/node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sanity/comlink": {
@@ -14582,18 +14706,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
-      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.36.0"
+        "motion-utils": "^12.39.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
-      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -17627,6 +17751,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "backfill:vendors": "node --env-file=.env.local scripts/backfillVendors.mjs"
   },
   "dependencies": {
     "@portabletext/react": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@portabletext/toolkit": "^5.0.2",
     "@portabletext/types": "^4.0.2",
     "@sanity/client": "^7.22.0",
+    "@sanity/color-input": "^6.0.12",
     "@sanity/image-url": "^2.1.1",
     "@sanity/vision": "^5.26.0",
     "@vercel/analytics": "^2.0.1",

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -10,7 +10,7 @@
 ## What visitors can do
 
 - Browse a **home** page with featured and popular programs.
-- Open **program detail pages** (`/program/{slug}`) with: program description, download link to the official vendor when configured, a **table of CD keys** with status (e.g. active, expired, limit reached), **activation guidance**, related programs, and **Giscus** (GitHub Discussions–based) comments.
+- Open **program detail pages** (`/program/{slug}`) with: program description, download link to the official vendor when configured, a **table of CD keys** with status (e.g. active, expired, limit reached), **activation guidance**, **social share buttons** (Facebook, X, Telegram, Pinterest, Tumblr, LinkedIn), related programs, and a **comments** section.
 - **Report key status** (working / expired / limit reached) to help keep listings accurate; reports are tied to a hashed visitor identifier, not named accounts.
 - Use **contact / suggest** flows to send messages or suggest new keys or programs (rate-limited APIs).
 
@@ -54,6 +54,9 @@ Base path: `https://www.keyaway.app/api/v1/`
 
 - https://www.keyaway.app/ — Home
 - https://www.keyaway.app/programs — All programs
+- https://www.keyaway.app/vendors — Software vendors index
+- https://www.keyaway.app/vendors/{slug} — Vendor hub (programs by vendor)
+- https://www.keyaway.app/updates — Recent program and key activity feed
 - https://www.keyaway.app/program/{slug} — Program detail (replace `{slug}` with the program slug)
 - https://www.keyaway.app/about — About KeyAway
 - https://www.keyaway.app/how-it-works — How listings and community reports work

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -5,6 +5,7 @@
  */
 
 import { visionTool } from "@sanity/vision";
+import { colorInput } from "@sanity/color-input";
 import { defineConfig } from "sanity";
 import { structureTool } from "sanity/structure";
 
@@ -24,6 +25,7 @@ export default defineConfig({
   schema,
   plugins: [
     structureTool({ structure }),
+    colorInput(),
     // Vision is for querying with GROQ from inside the Studio
     // https://www.sanity.io/docs/the-vision-plugin
     visionTool({ defaultApiVersion: apiVersion })

--- a/scripts/backfillVendors.mjs
+++ b/scripts/backfillVendors.mjs
@@ -1,0 +1,123 @@
+/**
+ * One-time backfill: create `vendor` docs and link each `program.vendor`.
+ *
+ * Run (Node 20.6+, loads .env.local for you):
+ *   npm run backfill:vendors            # dry run (prints planned changes)
+ *   npm run backfill:vendors -- --write # actually create vendors + link programs
+ *
+ * Idempotent:
+ *   - Vendors are upserted by a deterministic id `vendor.<slug>` (createIfNotExists).
+ *   - Existing `program.vendor` references are never overwritten.
+ *
+ * Requires env: NEXT_PUBLIC_SANITY_STUDIO_PROJECT_ID, NEXT_PUBLIC_SANITY_STUDIO_DATASET,
+ * SANITY_API_TOKEN (write token), optional NEXT_PUBLIC_SANITY_STUDIO_API_VERSION.
+ */
+import { createClient } from "@sanity/client";
+
+const WRITE = process.argv.includes("--write");
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_STUDIO_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_STUDIO_DATASET;
+const apiVersion = process.env.NEXT_PUBLIC_SANITY_STUDIO_API_VERSION || "2025-09-07";
+const token = process.env.SANITY_API_TOKEN;
+
+if (!projectId || !dataset) {
+  console.error("Missing NEXT_PUBLIC_SANITY_STUDIO_PROJECT_ID / NEXT_PUBLIC_SANITY_STUDIO_DATASET.");
+  process.exit(1);
+}
+if (WRITE && !token) {
+  console.error("SANITY_API_TOKEN is required for --write.");
+  process.exit(1);
+}
+
+const client = createClient({ projectId, dataset, apiVersion, token, useCdn: false });
+
+/** Explicit brand map (title lower-cased is tested for these substrings, first match wins). */
+const BRAND_RULES = [
+  { match: "iobit", name: "IObit" },
+  { match: "itop", name: "iTop" },
+  { match: "driver booster", name: "IObit" },
+  { match: "advanced systemcare", name: "IObit" },
+  { match: "smart defrag", name: "IObit" },
+  { match: "malware fighter", name: "IObit" },
+  { match: "aomei", name: "AOMEI" },
+  { match: "easeus", name: "EaseUS" },
+  { match: "wondershare", name: "Wondershare" },
+  { match: "ashampoo", name: "Ashampoo" },
+  { match: "wise", name: "WiseCleaner" },
+  { match: "glary", name: "Glarysoft" },
+  { match: "ccleaner", name: "Piriform" },
+  { match: "avast", name: "Avast" },
+  { match: "avg", name: "AVG" }
+];
+
+function slugify(input) {
+  return String(input)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/** Derive a vendor display name from a program title. */
+function deriveVendorName(title) {
+  const lower = String(title).toLowerCase();
+  for (const rule of BRAND_RULES) {
+    if (lower.includes(rule.match)) return rule.name;
+  }
+  // Fallback: first word, title-cased.
+  const first = String(title).trim().split(/\s+/)[0] || "Unknown";
+  return first.charAt(0).toUpperCase() + first.slice(1);
+}
+
+async function main() {
+  const programs = await client.fetch(
+    `*[_type == "program"]{ _id, title, "slug": slug.current, "vendorRef": vendor._ref }`
+  );
+
+  const vendorsToCreate = new Map(); // slug -> name
+  const links = []; // { programId, title, vendorId, vendorName }
+
+  for (const p of programs) {
+    const vendorName = deriveVendorName(p.title);
+    const vendorSlug = slugify(vendorName);
+    const vendorId = `vendor.${vendorSlug}`;
+    if (!vendorsToCreate.has(vendorSlug)) vendorsToCreate.set(vendorSlug, vendorName);
+    if (!p.vendorRef) {
+      links.push({ programId: p._id, title: p.title, vendorId, vendorName });
+    }
+  }
+
+  console.log(`Programs: ${programs.length}`);
+  console.log(`Vendors (${vendorsToCreate.size}):`, [...vendorsToCreate.values()].join(", "));
+  console.log(`Programs needing a vendor link: ${links.length}`);
+  for (const l of links) console.log(`  - "${l.title}" -> ${l.vendorName}`);
+
+  if (!WRITE) {
+    console.log("\nDry run. Re-run with -- --write to apply.");
+    return;
+  }
+
+  const tx = client.transaction();
+  for (const [slug, name] of vendorsToCreate) {
+    tx.createIfNotExists({
+      _id: `vendor.${slug}`,
+      _type: "vendor",
+      name,
+      slug: { _type: "slug", current: slug }
+    });
+  }
+  for (const l of links) {
+    // setIfMissing guards against overwriting a vendor set between fetch and commit.
+    tx.patch(l.programId, patch =>
+      patch.setIfMissing({ vendor: { _type: "reference", _ref: l.vendorId } })
+    );
+  }
+  await tx.commit();
+  console.log("\nDone. Publish drafts if any programs were drafts.");
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/v1/analytics/track/route.ts
+++ b/src/app/api/v1/analytics/track/route.ts
@@ -12,6 +12,7 @@ import { getClientIp, hashIp, getLocationFromIP } from "@/src/lib/api/requestGeo
 import { upsertVisitorOnPageView } from "@/src/lib/visitors/upsertVisitorOnPageView";
 import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
 import { isProgramSlugPublishedCached } from "@/src/lib/sanity/getCachedPublishedProgramSlugs";
+import { getAdminSession } from "@/src/lib/admin/adminAuth";
 
 const ANALYTICS_EVENTS = new Set([
   "copy_cdkey",
@@ -94,6 +95,10 @@ export async function POST(req: NextRequest) {
     const host = req.headers.get("host") || "";
     if (host.startsWith("localhost") || host.includes("127.0.0.1")) {
       return NextResponse.json({ data: { accepted: true, skipped: true }, meta: {} });
+    }
+
+    if (await getAdminSession()) {
+      return NextResponse.json({ data: { accepted: true, skipped: true, reason: "admin" }, meta: {} });
     }
 
     const ua = req.headers.get("user-agent") || undefined;

--- a/src/app/api/v1/key-reports/route.ts
+++ b/src/app/api/v1/key-reports/route.ts
@@ -8,6 +8,7 @@ import { getClientIp, hashIp, getLocationFromIP } from "@/src/lib/api/requestGeo
 import { isVisitorSpammerByHash } from "@/src/lib/visitors/isVisitorSpammerByHash";
 import { upsertVisitorContribution } from "@/src/lib/visitors/upsertVisitorContribution";
 import type { KeyReportEvent } from "@/src/types";
+import { getAdminSession } from "@/src/lib/admin/adminAuth";
 
 const REPORT_EVENTS = new Set<KeyReportEvent>(["report_key_working", "report_key_expired", "report_key_limit_reached"]);
 
@@ -24,6 +25,10 @@ export async function POST(req: NextRequest) {
   }
 
   try {
+    if (await getAdminSession()) {
+      return NextResponse.json({ data: { skipped: true, reason: "admin" }, meta: {} });
+    }
+
     const body = await req.json().catch(() => ({}));
     if (!body || typeof body !== "object") return Errors.badRequest("Request body required");
 

--- a/src/app/api/v1/webhooks/revalidate/route.ts
+++ b/src/app/api/v1/webhooks/revalidate/route.ts
@@ -10,6 +10,7 @@ import {
   TAG_PROGRAMS_FULL,
   TAG_SITEMAP_URLS,
   TAG_STORE_DETAILS,
+  TAG_VENDORS,
   programDetailTag
 } from "@/src/lib/cache/cacheTags";
 import { rebuildSiteNotificationFeed } from "@/src/lib/notifications/notificationFeed.server";
@@ -78,12 +79,20 @@ export async function POST(req: NextRequest) {
       revalidateTag(TAG_HOMEPAGE_STATS, "max");
     } else if (t === "featuredProgramSettings") {
       revalidateTag(TAG_FEATURED_PROGRAM, "max");
+    } else if (t === "vendor") {
+      // Vendor edits change hub copy/metadata and program-card brand labels.
+      revalidateTag(TAG_VENDORS, "max");
+      revalidateTag(TAG_PROGRAM_LISTINGS, "max");
+      revalidateTag(TAG_SITEMAP_URLS, "max");
+      revalidatePath("/sitemap.xml");
     } else if (t === "program" || t === "cdKey") {
       revalidateTag(TAG_PROGRAMS_FULL, "max");
       revalidateTag(TAG_PROGRAM_LISTINGS, "max");
       revalidateTag(TAG_HOMEPAGE_PROGRAMS, "max");
       revalidateTag(TAG_HOMEPAGE_STATS, "max");
       revalidateTag(TAG_FEATURED_PROGRAM, "max");
+      // Vendor→program assignment changes vendor hub membership and counts.
+      revalidateTag(TAG_VENDORS, "max");
 
       const slug = await resolveProgramSlugForWebhook(body);
       if (slug) revalidateTag(programDetailTag(slug), "max");

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,7 @@ import { LogoData, SocialData } from "@/src/types";
 import { urlFor } from "../sanity/lib/image";
 import { getImageDimensions } from "@sanity/asset-utils";
 import { generateHomePageMetadata } from "@/src/lib/seo/metadata";
+import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"]
@@ -92,6 +93,7 @@ export default async function RootLayout({
   const socialData: SocialData = {
     socialLinks: storeData?.socialLinks ?? []
   };
+  const siteBaseUrl = resolveSiteBaseUrl(storeData?.seo);
   const renderedHeadMetaTags = Object.entries(HEAD_METADATA_GROUPS).flatMap(([groupName, tags]) =>
     tags
       .filter(tag => tag.condition !== false)
@@ -114,7 +116,7 @@ export default async function RootLayout({
             <div className="mainContent flex min-h-screen flex-col bg-[#0f1923] text-[#c6d4df]">
               <Header logoData={logoData} socialData={socialData} />
               <main className="w-full page-bg">{children}</main>
-              <Footer logoData={logoData} socialData={socialData} />
+              <Footer logoData={logoData} socialData={socialData} siteBaseUrl={siteBaseUrl} />
             </div>
           </StoreDetailsProvider>
         </SessionProvider>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,4 +1,9 @@
+import type { Metadata } from "next";
 import NotFoundView from "@/src/components/site/NotFoundView";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: true }
+};
 
 export default function NotFound() {
   return <NotFoundView variant="page" />;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { generateHomePageJsonLd } from "@/src/lib/seo/jsonLd";
 import { resolveHomePageSeo } from "@/src/lib/seo/storeSeoResolve";
 import JsonLd from "@/src/components/JsonLd";
 import { getFeaturedProgram } from "@/src/lib/sanity/sanityActions";
+import { getCachedVendorsWithCounts } from "@/src/lib/vendors/getVendors";
 import HeroSection from "@/src/components/home/HeroSection";
 import FeaturesSection from "@/src/components/home/FeaturesSection";
 import PopularProgramsSection from "@/src/components/home/PopularProgramsSection";
@@ -31,11 +32,12 @@ export default async function HomePage() {
   weekAgo.setDate(weekAgo.getDate() - 7);
   const weekAgoISO = weekAgo.toISOString();
 
-  const [rawPopularPrograms, stats, store, featuredProgram] = await Promise.all([
+  const [rawPopularPrograms, stats, store, featuredProgram, vendors] = await Promise.all([
     client.fetch(programsWithStatsQuery, {}, { next: { tags: [TAG_HOMEPAGE_PROGRAMS] } }),
     client.fetch(siteStatsQuery, { weekAgo: weekAgoISO }, { next: { tags: [TAG_HOMEPAGE_STATS] } }),
     getCachedStoreDetailsDocument(),
-    getFeaturedProgram()
+    getFeaturedProgram(),
+    getCachedVendorsWithCounts()
   ]);
 
   const popularPrograms = mergeProgramStats((rawPopularPrograms ?? []) as ProgramWithStats[])
@@ -63,7 +65,7 @@ export default async function HomePage() {
       <JsonLd data={jsonLd} />
       <HeroSection socialData={socialData} stats={stats} />
       <FeaturedProgramSection program={featuredProgram} />
-      <PopularProgramsSection programs={normalizedPopularPrograms} />
+      <PopularProgramsSection programs={normalizedPopularPrograms} vendors={vendors} />
       <FeaturesSection />
       <StatsSection stats={stats} />
       <CTASection otherLinks={store?.otherLinks ?? []} />

--- a/src/app/program/[slug]/not-found.tsx
+++ b/src/app/program/[slug]/not-found.tsx
@@ -1,4 +1,10 @@
+import type { Metadata } from "next";
 import NotFoundView from "@/src/components/site/NotFoundView";
+
+export const metadata: Metadata = {
+  title: "Program not found | KeyAway",
+  robots: { index: false, follow: true }
+};
 
 export default function NotFound() {
   return <NotFoundView variant="program" />;

--- a/src/app/program/[slug]/page.tsx
+++ b/src/app/program/[slug]/page.tsx
@@ -21,6 +21,7 @@ import {
 import { getProgramBySlug } from "@/src/lib/sanity/sanityActions";
 import { getCachedRelatedPrograms } from "@/src/lib/sanity/getCachedRelatedPrograms";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
+import { getProgramAggregateRating } from "@/src/lib/program/programAggregateRating";
 import { generateProgramMetadata } from "@/src/lib/seo/metadata";
 import { generateProgramPageJsonLd } from "@/src/lib/seo/jsonLd";
 import JsonLd from "@/src/components/JsonLd";
@@ -75,7 +76,11 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
   const introVersionConfirmation = getCdKeyTableIntroVersionConfirmation(program, highestKeyVersion);
   const versionSummaryLine = formatVersionSummaryLine(program, highestKeyVersion);
 
-  const [allPrograms, store] = await Promise.all([getCachedRelatedPrograms(), getCachedStoreDetailsDocument()]);
+  const [allPrograms, store, communityRating] = await Promise.all([
+    getCachedRelatedPrograms(),
+    getCachedStoreDetailsDocument(),
+    getProgramAggregateRating(slug)
+  ]);
 
   const socialData: SocialData = {
     socialLinks: store?.socialLinks ?? []
@@ -90,7 +95,7 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
     program.faq?.filter((f: ProgramFaqItem) => f.question?.trim() && portableTextHasContent(f.answer)) ?? [];
 
   const storeInfo = store || { title: "KeyAway" };
-  const jsonLd = generateProgramPageJsonLd(program, workingKeys, totalKeys, storeInfo);
+  const jsonLd = generateProgramPageJsonLd(program, workingKeys, totalKeys, storeInfo, communityRating);
   const i18n = await loadMessages({ locale: "en", namespaces: ["common", "program"], programFlow });
 
   return (
@@ -103,6 +108,7 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
             totalKeys={totalKeys}
             workingKeys={workingKeys}
             socialData={socialData}
+            communityRating={communityRating}
           />
           <CDKeyTable
             cdKeys={sortedCdKeys}

--- a/src/app/program/[slug]/page.tsx
+++ b/src/app/program/[slug]/page.tsx
@@ -26,7 +26,7 @@ import { getProgramAggregateRating } from "@/src/lib/program/programAggregateRat
 import { generateProgramMetadata } from "@/src/lib/seo/metadata";
 import { generateProgramPageJsonLd } from "@/src/lib/seo/jsonLd";
 import JsonLd from "@/src/components/JsonLd";
-import Breadcrumbs from "@/src/components/layout/Breadcrumbs";
+import ProgramBreadcrumbs from "@/src/components/program/ProgramBreadcrumbs";
 import { portableTextHasContent } from "@/src/lib/portableText/toPlainText";
 import type { Program, ProgramFaqItem } from "@/src/types/program";
 import { normalizeProgramFlow } from "@/src/lib/program/activationEntry";
@@ -105,16 +105,7 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
       <JsonLd data={jsonLd} />
       <I18nShell locale={i18n.locale} messages={i18n.messages}>
         <div className="mx-auto max-w-3xl px-4 pt-6 sm:px-6 lg:max-w-360 lg:px-8">
-          <Breadcrumbs
-            items={[
-              { label: "Home", href: "/" },
-              { label: "Programs", href: "/programs" },
-              ...(program.vendor
-                ? [{ label: program.vendor.name, href: `/vendors/${program.vendor.slug}` }]
-                : []),
-              { label: program.title }
-            ]}
-          />
+          <ProgramBreadcrumbs program={program} />
         </div>
         <ProgramVisitorProvider>
           <ProgramInformation

--- a/src/app/program/[slug]/page.tsx
+++ b/src/app/program/[slug]/page.tsx
@@ -25,6 +25,7 @@ import { getProgramAggregateRating } from "@/src/lib/program/programAggregateRat
 import { generateProgramMetadata } from "@/src/lib/seo/metadata";
 import { generateProgramPageJsonLd } from "@/src/lib/seo/jsonLd";
 import JsonLd from "@/src/components/JsonLd";
+import Breadcrumbs from "@/src/components/layout/Breadcrumbs";
 import { portableTextHasContent } from "@/src/lib/portableText/toPlainText";
 import type { Program, ProgramFaqItem } from "@/src/types/program";
 import { normalizeProgramFlow } from "@/src/lib/program/activationEntry";
@@ -102,6 +103,18 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
     <>
       <JsonLd data={jsonLd} />
       <I18nShell locale={i18n.locale} messages={i18n.messages}>
+        <div className="mx-auto max-w-3xl px-4 pt-6 sm:px-6 lg:max-w-360 lg:px-8">
+          <Breadcrumbs
+            items={[
+              { label: "Home", href: "/" },
+              { label: "Programs", href: "/programs" },
+              ...(program.vendor
+                ? [{ label: program.vendor.name, href: `/vendors/${program.vendor.slug}` }]
+                : []),
+              { label: program.title }
+            ]}
+          />
+        </div>
         <ProgramVisitorProvider>
           <ProgramInformation
             program={program}

--- a/src/app/program/[slug]/page.tsx
+++ b/src/app/program/[slug]/page.tsx
@@ -27,6 +27,10 @@ import { generateProgramMetadata } from "@/src/lib/seo/metadata";
 import { generateProgramPageJsonLd } from "@/src/lib/seo/jsonLd";
 import JsonLd from "@/src/components/JsonLd";
 import ProgramBreadcrumbs from "@/src/components/program/ProgramBreadcrumbs";
+import ProgramSocialShare from "@/src/components/program/social-share/ProgramSocialShare";
+import { getProgramShareCounts } from "@/src/lib/program/getProgramShareCounts";
+import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
+import { urlFor } from "@/src/sanity/lib/image";
 import { portableTextHasContent } from "@/src/lib/portableText/toPlainText";
 import type { Program, ProgramFaqItem } from "@/src/types/program";
 import { normalizeProgramFlow } from "@/src/lib/program/activationEntry";
@@ -78,11 +82,15 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
   const introVersionConfirmation = getCdKeyTableIntroVersionConfirmation(program, highestKeyVersion);
   const versionSummaryLine = formatVersionSummaryLine(program, highestKeyVersion);
 
-  const [allPrograms, store, communityRating] = await Promise.all([
+  const [allPrograms, store, communityRating, shareCounts] = await Promise.all([
     getCachedRelatedPrograms(),
     getCachedStoreDetailsDocument(),
-    getProgramAggregateRating(slug)
+    getProgramAggregateRating(slug),
+    getProgramShareCounts(slug)
   ]);
+
+  const pageUrl = `${resolveSiteBaseUrl(store?.seo)}/program/${slug}`;
+  const shareImageUrl = program.image ? urlFor(program.image).width(1200).height(630).url() : undefined;
 
   const socialData: SocialData = {
     socialLinks: store?.socialLinks ?? []
@@ -114,6 +122,14 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
             workingKeys={workingKeys}
             socialData={socialData}
             communityRating={communityRating}
+          />
+          <ProgramSocialShare
+            programTitle={program.title}
+            programSlug={slug}
+            pageUrl={pageUrl}
+            workingKeys={workingKeys}
+            imageUrl={shareImageUrl}
+            shareCounts={shareCounts}
           />
           <CDKeyTable
             cdKeys={sortedCdKeys}

--- a/src/app/program/[slug]/page.tsx
+++ b/src/app/program/[slug]/page.tsx
@@ -10,6 +10,7 @@ import ActivationInstructions from "@/src/components/program/ActivationInstructi
 import RelatedPrograms from "@/src/components/program/RelatedPrograms";
 import CommentsSection from "@/src/components/program/comments/CommentsSection";
 import AffiliateProCta from "@/src/components/program/AffiliateProCta";
+import FreeVsProComparison from "@/src/components/program/FreeVsProComparison";
 import KeySourcePanel from "@/src/components/program/KeySourcePanel";
 import { sortCdKeysByStatus } from "@/src/lib/program/cdKeyUtils";
 import {
@@ -134,6 +135,7 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
             versionSummaryLine={versionSummaryLine}
           />
           <KeySourcePanel program={program} totalKeys={totalKeys} />
+          <FreeVsProComparison program={program} />
           <AffiliateProCta program={program} />
         </ProgramVisitorProvider>
         <ActivationInstructions programTitle={program.title} downloadLink={program.downloadLink} />

--- a/src/app/programs/ProgramsPageClient.tsx
+++ b/src/app/programs/ProgramsPageClient.tsx
@@ -22,7 +22,11 @@ function readListParams(searchParams: URLSearchParams) {
   };
 }
 
-export default function ProgramsPageClient() {
+function listParamsKey(p: { searchTerm: string; filter: FilterType; sortBy: SortType; page: number }): string {
+  return `${p.searchTerm}|${p.filter}|${p.sortBy}|${p.page}`;
+}
+
+export default function ProgramsPageClient({ initialListData }: { initialListData: ProgramsListData }) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -30,14 +34,24 @@ export default function ProgramsPageClient() {
   searchParamsRef.current = searchParams;
 
   const [isPending, startTransition] = useTransition();
-  const [isLoading, setIsLoading] = useState(true);
-  const [listData, setListData] = useState<ProgramsListData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [listData, setListData] = useState<ProgramsListData | null>(initialListData);
   const [fetchError, setFetchError] = useState(false);
 
   const wasPending = useRef(false);
   const scrollAfterPaginationRef = useRef(false);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fetchGenRef = useRef(0);
+  /** First effect run reuses server data when URL params match what was rendered. */
+  const initialParamsKey = useRef(
+    listParamsKey({
+      searchTerm: initialListData.searchTerm,
+      filter: initialListData.filter,
+      sortBy: initialListData.sortBy,
+      page: initialListData.page
+    })
+  );
+  const skipInitialFetchRef = useRef(true);
 
   const params = readListParams(searchParams);
   const { searchTerm, filter, sortBy, page } = params;
@@ -79,6 +93,10 @@ export default function ProgramsPageClient() {
   }, []);
 
   useEffect(() => {
+    if (skipInitialFetchRef.current) {
+      skipInitialFetchRef.current = false;
+      if (listParamsKey(readListParams(searchParams)) === initialParamsKey.current) return;
+    }
     void loadList(searchParams);
   }, [searchParams, loadList]);
 

--- a/src/app/programs/ProgramsPageClient.tsx
+++ b/src/app/programs/ProgramsPageClient.tsx
@@ -9,6 +9,8 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { scrollToSectionWithHeaderOffset } from "@/src/lib/dom/scrollToSection";
 import { normalizeFilterType, normalizeSortType } from "@/src/lib/program/programUtils";
 import type { ProgramWithStats } from "@/src/types/home";
+import HomeVendorBrowse from "@/src/components/home/HomeVendorBrowse";
+import type { VendorListItem } from "@/src/lib/vendors/getVendors";
 
 const SEARCH_DEBOUNCE_MS = 400;
 const EMPTY_PROGRAMS: ProgramWithStats[] = [];
@@ -26,7 +28,13 @@ function listParamsKey(p: { searchTerm: string; filter: FilterType; sortBy: Sort
   return `${p.searchTerm}|${p.filter}|${p.sortBy}|${p.page}`;
 }
 
-export default function ProgramsPageClient({ initialListData }: { initialListData: ProgramsListData }) {
+export default function ProgramsPageClient({
+  initialListData,
+  vendors = []
+}: {
+  initialListData: ProgramsListData;
+  vendors?: VendorListItem[];
+}) {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -195,6 +203,8 @@ export default function ProgramsPageClient({ initialListData }: { initialListDat
 
   return (
     <div id="programs-grid" className="mx-auto max-w-360 px-4 py-8 sm:px-6 sm:py-10 lg:px-8 lg:py-12">
+      {!fetchError && !showLoading && <HomeVendorBrowse vendors={vendors} position="top" />}
+
       <ProgramsFilter
         searchTerm={localSearch}
         filter={filter}

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -1,7 +1,9 @@
 import { Suspense } from "react";
 import { generateProgramsPageMetadata } from "@/src/lib/seo/metadata";
 import { generateProgramsPageJsonLd } from "@/src/lib/seo/jsonLd";
-import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
+import ProgramsPageSocialShare from "@/src/components/social-share/ProgramsPageSocialShare";
+import { getPageShareCounts } from "@/src/lib/share/getPageShareCounts";
+import { resolveSiteBaseUrl, resolveDefaultOgImageUrl } from "@/src/lib/seo/storeSeoResolve";
 import JsonLd from "@/src/components/JsonLd";
 import ProgramsPageClient from "@/src/app/programs/ProgramsPageClient";
 import { ProgramsHero, ContributeSection, WhyUseSection } from "@/src/components/programs";
@@ -30,14 +32,19 @@ interface ProgramsPageProps {
 /** SSR first page for crawlers; client hydrates for filter/sort/pagination via cached `/api/v1/programs/list`. */
 export default async function ProgramsPage({ searchParams }: ProgramsPageProps) {
   const sp = await searchParams;
-  const [storeRow, featuredProgram, heroTotals, jsonLdPrograms, initialListData, vendors] = await Promise.all([
-    getCachedStoreDetailsDocument(),
-    getFeaturedProgram(),
-    getCachedProgramsHeroTotals(),
-    getCachedProgramsForJsonLd(),
-    getProgramsListData(sp.search, sp.filter, sp.sort, sp.page),
-    getCachedVendorsWithCounts()
-  ]);
+  const [storeRow, featuredProgram, heroTotals, jsonLdPrograms, initialListData, vendors, shareCounts] =
+    await Promise.all([
+      getCachedStoreDetailsDocument(),
+      getFeaturedProgram(),
+      getCachedProgramsHeroTotals(),
+      getCachedProgramsForJsonLd(),
+      getProgramsListData(sp.search, sp.filter, sp.sort, sp.page),
+      getCachedVendorsWithCounts(),
+      getPageShareCounts("/programs")
+    ]);
+
+  const programsPageUrl = `${resolveSiteBaseUrl(storeRow?.seo)}/programs`;
+  const programsShareImageUrl = resolveDefaultOgImageUrl(storeRow?.seo);
 
   const socialData: SocialData = {
     socialLinks: storeRow?.socialLinks ?? []
@@ -51,7 +58,14 @@ export default async function ProgramsPage({ searchParams }: ProgramsPageProps) 
       <ProgramsHero totalCount={heroTotals.totalCount} totalKeys={heroTotals.totalKeys} />
 
       <section className="border-b border-[#2a475e] bg-[#16202d] py-8">
-        <div className="max-w-360 mx-auto px-4 sm:px-6 lg:px-8 flex justify-center">
+        <div className="mx-auto flex max-w-360 flex-col items-center gap-6 px-4 sm:px-6 lg:px-8">
+          <ProgramsPageSocialShare
+            pageUrl={programsPageUrl}
+            programCount={heroTotals.totalCount}
+            totalKeys={heroTotals.totalKeys}
+            imageUrl={programsShareImageUrl}
+            shareCounts={shareCounts}
+          />
           <FacebookGroupButton socialData={socialData} variant="outline" className="text-base" />
         </div>
       </section>

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -9,7 +9,11 @@ import FeaturedProgramSection from "@/src/components/home/FeaturedProgramSection
 import { FacebookGroupButton } from "@/src/components/social";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
 import { getFeaturedProgram } from "@/src/lib/sanity/sanityActions";
-import { getCachedProgramsForJsonLd, getCachedProgramsHeroTotals } from "@/src/lib/programs/getProgramsPageData";
+import {
+  getCachedProgramsForJsonLd,
+  getCachedProgramsHeroTotals,
+  getProgramsListData
+} from "@/src/lib/programs/getProgramsPageData";
 import type { SocialData } from "@/src/types";
 /** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` in `@/src/lib/cache/constants` (Next.js requires a literal). */
 export const revalidate = 43200;
@@ -18,13 +22,19 @@ export async function generateMetadata() {
   return await generateProgramsPageMetadata();
 }
 
-/** Static shell — list/filter/sort/pagination via cached `/api/v1/programs/list`. */
-export default async function ProgramsPage() {
-  const [storeRow, featuredProgram, heroTotals, jsonLdPrograms] = await Promise.all([
+interface ProgramsPageProps {
+  searchParams: Promise<{ search?: string; filter?: string; sort?: string; page?: string }>;
+}
+
+/** SSR first page for crawlers; client hydrates for filter/sort/pagination via cached `/api/v1/programs/list`. */
+export default async function ProgramsPage({ searchParams }: ProgramsPageProps) {
+  const sp = await searchParams;
+  const [storeRow, featuredProgram, heroTotals, jsonLdPrograms, initialListData] = await Promise.all([
     getCachedStoreDetailsDocument(),
     getFeaturedProgram(),
     getCachedProgramsHeroTotals(),
-    getCachedProgramsForJsonLd()
+    getCachedProgramsForJsonLd(),
+    getProgramsListData(sp.search, sp.filter, sp.sort, sp.page)
   ]);
 
   const socialData: SocialData = {
@@ -50,7 +60,7 @@ export default async function ProgramsPage() {
             <p className="text-sm text-neutral-100">Loading programs…</p>
           </div>
         }>
-        <ProgramsPageClient />
+        <ProgramsPageClient initialListData={initialListData} />
       </Suspense>
 
       <ContributeSection />

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -9,6 +9,7 @@ import FeaturedProgramSection from "@/src/components/home/FeaturedProgramSection
 import { FacebookGroupButton } from "@/src/components/social";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
 import { getFeaturedProgram } from "@/src/lib/sanity/sanityActions";
+import { getCachedVendorsWithCounts } from "@/src/lib/vendors/getVendors";
 import {
   getCachedProgramsForJsonLd,
   getCachedProgramsHeroTotals,
@@ -29,12 +30,13 @@ interface ProgramsPageProps {
 /** SSR first page for crawlers; client hydrates for filter/sort/pagination via cached `/api/v1/programs/list`. */
 export default async function ProgramsPage({ searchParams }: ProgramsPageProps) {
   const sp = await searchParams;
-  const [storeRow, featuredProgram, heroTotals, jsonLdPrograms, initialListData] = await Promise.all([
+  const [storeRow, featuredProgram, heroTotals, jsonLdPrograms, initialListData, vendors] = await Promise.all([
     getCachedStoreDetailsDocument(),
     getFeaturedProgram(),
     getCachedProgramsHeroTotals(),
     getCachedProgramsForJsonLd(),
-    getProgramsListData(sp.search, sp.filter, sp.sort, sp.page)
+    getProgramsListData(sp.search, sp.filter, sp.sort, sp.page),
+    getCachedVendorsWithCounts()
   ]);
 
   const socialData: SocialData = {
@@ -60,7 +62,7 @@ export default async function ProgramsPage({ searchParams }: ProgramsPageProps) 
             <p className="text-sm text-neutral-100">Loading programs…</p>
           </div>
         }>
-        <ProgramsPageClient initialListData={initialListData} />
+        <ProgramsPageClient initialListData={initialListData} vendors={vendors} />
       </Suspense>
 
       <ContributeSection />

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,11 @@
 import { MetadataRoute } from "next";
+import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
+import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
 
-export default function robots(): MetadataRoute.Robots {
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  const store = await getCachedStoreDetailsDocument();
+  const baseUrl = resolveSiteBaseUrl(store?.seo);
+
   return {
     rules: [
       {
@@ -14,7 +19,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/studio/", "/api/", "/admin/"]
       }
     ],
-    sitemap: "https://www.keyaway.app/sitemap.xml",
-    host: "https://www.keyaway.app"
+    sitemap: `${baseUrl}/sitemap.xml`,
+    host: baseUrl
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,7 +2,7 @@ import { MetadataRoute } from "next";
 import { TAG_SITEMAP_URLS } from "@/src/lib/cache/cacheTags";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
 import { client } from "@/src/sanity/lib/client";
-import { allProgramsQuery } from "@/src/lib/sanity/queries";
+import { allProgramsQuery, vendorSlugsQuery } from "@/src/lib/sanity/queries";
 import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
 import { Program, CDKey } from "@/src/types";
 /** ISR fallback; URL set busts use `TAG_SITEMAP_URLS` (admin + selective webhook). */
@@ -10,9 +10,10 @@ import { Program, CDKey } from "@/src/types";
 export const revalidate = 43200;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const [store, programs] = await Promise.all([
+  const [store, programs, vendorSlugs] = await Promise.all([
     getCachedStoreDetailsDocument(),
-    client.fetch(allProgramsQuery, {}, { next: { tags: [TAG_SITEMAP_URLS] } })
+    client.fetch(allProgramsQuery, {}, { next: { tags: [TAG_SITEMAP_URLS] } }),
+    client.fetch<{ slug: string }[]>(vendorSlugsQuery, {}, { next: { tags: [TAG_SITEMAP_URLS] } })
   ]);
   const baseUrl = resolveSiteBaseUrl(store?.seo);
   const currentDate = new Date();
@@ -32,6 +33,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: currentDate,
       changeFrequency: "daily",
       priority: 0.9
+    },
+    {
+      url: `${baseUrl}/vendors`,
+      lastModified: currentDate,
+      changeFrequency: "weekly",
+      priority: 0.7
     },
     ...trustPaths.map(path => ({
       url: `${baseUrl}${path}`,
@@ -94,5 +101,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Sort programs by priority (highest first) for better crawling order
   const sortedProgramRoutes = programRoutes.sort((a, b) => (b.priority || 0) - (a.priority || 0));
 
-  return [...staticRoutes, ...sortedProgramRoutes];
+  const vendorRoutes: MetadataRoute.Sitemap = (vendorSlugs ?? [])
+    .map(v => v.slug)
+    .filter(Boolean)
+    .map(slug => ({
+      url: `${baseUrl}/vendors/${slug}`,
+      lastModified: currentDate,
+      changeFrequency: "weekly" as const,
+      priority: 0.6
+    }));
+
+  return [...staticRoutes, ...sortedProgramRoutes, ...vendorRoutes];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -18,7 +18,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = resolveSiteBaseUrl(store?.seo);
   const currentDate = new Date();
 
-  const trustPaths = ["/about", "/how-it-works", "/affiliate-disclosure", "/verification-policy", "/dmca", "/partners"];
+  const trustPaths = ["/about", "/how-it-works", "/affiliate-disclosure", "/verification-policy", "/dmca", "/partners", "/updates"];
 
   // Static routes with proper SEO optimization
   const staticRoutes: MetadataRoute.Sitemap = [

--- a/src/app/updates/UpdatesContent.tsx
+++ b/src/app/updates/UpdatesContent.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import JsonLd from "@/src/components/JsonLd";
+import UpdateFeedItem from "@/src/components/updates/UpdateFeedItem";
+import { readSiteNotificationFeed } from "@/src/lib/notifications/notificationFeed.server";
+import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
+import { generateUpdatesPageJsonLd } from "@/src/lib/seo/jsonLd";
+import { resolveUpdatesPageSeo } from "@/src/lib/seo/trustPageSeo";
+
+/** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` (Next.js requires a literal). */
+export const revalidate = 43200;
+
+export default async function UpdatesContent() {
+  const [store, updates] = await Promise.all([getCachedStoreDetailsDocument(), readSiteNotificationFeed()]);
+  const { pageUrl: siteUrl, storeTitle } = resolveUpdatesPageSeo(store);
+  const jsonLd = generateUpdatesPageJsonLd(updates, siteUrl);
+
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+
+      <div className="min-h-screen static-bg text-[#c6d4df]">
+        <section className="border-b border-[#2a475e]">
+          <div className="mx-auto max-w-3xl px-4 py-10 text-center sm:px-6 sm:py-12 lg:px-8">
+            <h1 className="section-title">
+              Latest <span className="text-gradient-pro">updates</span>
+            </h1>
+            <p className="section-text mx-auto mt-3 max-w-xl">
+              New programs and fresh giveaway keys added to {storeTitle} in the last 30 days. This feed updates
+              automatically when our catalog changes.
+            </p>
+          </div>
+        </section>
+
+        <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+          {updates.length === 0 ? (
+            <div className="rounded-sm border border-[#2a475e] bg-[#1b2838] px-5 py-10 text-center">
+              <p className="text-sm text-neutral-100 sm:text-base">No catalog updates in the last 30 days.</p>
+              <Link
+                href="/programs"
+                className="mt-4 inline-block text-sm font-semibold text-[#66c0f4] transition-colors hover:text-white">
+                Browse all programs →
+              </Link>
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {updates.map(item => (
+                <UpdateFeedItem key={item.id} notification={item} />
+              ))}
+            </ul>
+          )}
+
+          <p className="mt-8 text-center text-xs text-[#8f98a0] sm:text-sm">
+            Want everything?{" "}
+            <Link href="/programs" className="font-semibold text-[#66c0f4] hover:text-white">
+              Browse the full program catalog
+            </Link>
+          </p>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/app/updates/UpdatesContent.tsx
+++ b/src/app/updates/UpdatesContent.tsx
@@ -1,7 +1,14 @@
 import Link from "next/link";
 import JsonLd from "@/src/components/JsonLd";
 import UpdateFeedItem from "@/src/components/updates/UpdateFeedItem";
-import { readSiteNotificationFeed } from "@/src/lib/notifications/notificationFeed.server";
+import {
+  filterNotificationsByDays,
+  hasOlderNotifications,
+  readSiteNotificationHistory,
+  resolveUpdatesPageDays,
+  UPDATES_PAGE_DAYS_INCREMENT,
+  UPDATES_PAGE_MAX_DAYS
+} from "@/src/lib/notifications/notificationFeed.server";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
 import { generateUpdatesPageJsonLd } from "@/src/lib/seo/jsonLd";
 import { resolveUpdatesPageSeo } from "@/src/lib/seo/trustPageSeo";
@@ -9,8 +16,19 @@ import { resolveUpdatesPageSeo } from "@/src/lib/seo/trustPageSeo";
 /** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` (Next.js requires a literal). */
 export const revalidate = 43200;
 
-export default async function UpdatesContent() {
-  const [store, updates] = await Promise.all([getCachedStoreDetailsDocument(), readSiteNotificationFeed()]);
+interface UpdatesContentProps {
+  searchParams: Promise<{ days?: string }>;
+}
+
+export default async function UpdatesContent({ searchParams }: UpdatesContentProps) {
+  const sp = await searchParams;
+  const days = resolveUpdatesPageDays(sp.days);
+
+  const [store, allUpdates] = await Promise.all([getCachedStoreDetailsDocument(), readSiteNotificationHistory()]);
+  const updates = filterNotificationsByDays(allUpdates, days);
+  const showViewMore = hasOlderNotifications(allUpdates, days) && days < UPDATES_PAGE_MAX_DAYS;
+  const nextDays = Math.min(days + UPDATES_PAGE_DAYS_INCREMENT, UPDATES_PAGE_MAX_DAYS);
+
   const { pageUrl: siteUrl, storeTitle } = resolveUpdatesPageSeo(store);
   const jsonLd = generateUpdatesPageJsonLd(updates, siteUrl);
 
@@ -25,7 +43,7 @@ export default async function UpdatesContent() {
               Latest <span className="text-gradient-pro">updates</span>
             </h1>
             <p className="section-text mx-auto mt-3 max-w-xl">
-              New programs and fresh giveaway keys added to {storeTitle} in the last 30 days. This feed updates
+              New programs and fresh giveaway keys added to {storeTitle} in the last {days} days. This feed updates
               automatically when our catalog changes.
             </p>
           </div>
@@ -34,7 +52,7 @@ export default async function UpdatesContent() {
         <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
           {updates.length === 0 ? (
             <div className="rounded-sm border border-[#2a475e] bg-[#1b2838] px-5 py-10 text-center">
-              <p className="text-sm text-neutral-100 sm:text-base">No catalog updates in the last 30 days.</p>
+              <p className="text-sm text-neutral-100 sm:text-base">No catalog updates in the last {days} days.</p>
               <Link
                 href="/programs"
                 className="mt-4 inline-block text-sm font-semibold text-[#66c0f4] transition-colors hover:text-white">
@@ -48,6 +66,16 @@ export default async function UpdatesContent() {
               ))}
             </ul>
           )}
+
+          {showViewMore ? (
+            <div className="mt-8 flex justify-center">
+              <Link
+                href={`/updates?days=${nextDays}`}
+                className="inline-flex min-h-11 items-center justify-center rounded-sm border border-[#4a90c4] bg-[#1a3a5c] px-6 py-2.5 text-sm font-semibold text-[#c6d4df] transition-colors hover:border-[#66c0f4] hover:bg-[#213246] hover:text-white">
+                View more updates
+              </Link>
+            </div>
+          ) : null}
 
           <p className="mt-8 text-center text-xs text-[#8f98a0] sm:text-sm">
             Want everything?{" "}

--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -5,6 +5,10 @@ export async function generateMetadata() {
   return generateUpdatesMetadata();
 }
 
-export default function UpdatesPage() {
-  return <UpdatesContent />;
+interface UpdatesPageProps {
+  searchParams: Promise<{ days?: string }>;
+}
+
+export default function UpdatesPage({ searchParams }: UpdatesPageProps) {
+  return <UpdatesContent searchParams={searchParams} />;
 }

--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -1,0 +1,10 @@
+import { generateUpdatesMetadata } from "@/src/lib/seo/metadata";
+import UpdatesContent from "./UpdatesContent";
+
+export async function generateMetadata() {
+  return generateUpdatesMetadata();
+}
+
+export default function UpdatesPage() {
+  return <UpdatesContent />;
+}

--- a/src/app/vendors/[slug]/page.tsx
+++ b/src/app/vendors/[slug]/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import Image from "next/image";
 import JsonLd from "@/src/components/JsonLd";
 import VendorBreadcrumbs from "@/src/components/vendors/VendorBreadcrumbs";
+import VendorLogoFrame from "@/src/components/vendors/VendorLogoFrame";
 import RichText from "@/src/components/portableText/RichText";
 import ProgramsGrid from "@/src/components/programs/ProgramsGrid";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
@@ -10,7 +10,6 @@ import { getCachedVendorSlugs, getVendorBySlug } from "@/src/lib/vendors/getVend
 import { generateVendorPageJsonLd } from "@/src/lib/seo/jsonLd";
 import { resolveVendorHubSeo } from "@/src/lib/seo/vendorSeo";
 import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
-import { urlFor } from "@/src/sanity/lib/image";
 
 /** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` (Next.js requires a literal). */
 export const revalidate = 43200;
@@ -83,15 +82,15 @@ export default async function VendorPage({ params }: VendorPageProps) {
 
           <div className="flex items-center gap-4">
             {vendor.logo && (
-              <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-sm border border-[#2a475e] bg-[#0e1621]">
-                <Image
-                  src={urlFor(vendor.logo).width(128).height(128).fit("max").url()}
-                  alt={`${vendor.name} logo`}
-                  width={64}
-                  height={64}
-                  className="h-full w-full object-contain p-1.5"
-                />
-              </div>
+              <VendorLogoFrame
+                name={vendor.name}
+                logo={vendor.logo}
+                logoBackgroundColor={vendor.logoBackgroundColor}
+                imageSize={128}
+                displayMaxSize={64}
+                frameClassName="flex h-16 w-16 shrink-0 items-center justify-center rounded-sm border border-[#2a475e]"
+                alt={`${vendor.name} logo`}
+              />
             )}
             <div>
               <div className="section-label">Vendor</div>

--- a/src/app/vendors/[slug]/page.tsx
+++ b/src/app/vendors/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import JsonLd from "@/src/components/JsonLd";
 import VendorBreadcrumbs from "@/src/components/vendors/VendorBreadcrumbs";
 import VendorLogoFrame from "@/src/components/vendors/VendorLogoFrame";
+import GiveawayVsOfficial from "@/src/components/vendors/GiveawayVsOfficial";
 import RichText from "@/src/components/portableText/RichText";
 import ProgramsGrid from "@/src/components/programs/ProgramsGrid";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
@@ -114,6 +115,8 @@ export default async function VendorPage({ params }: VendorPageProps) {
         </h2>
         <ProgramsGrid programs={vendor.programs} maxViews={maxViews} maxDownloads={maxDownloads} />
       </section>
+
+      <GiveawayVsOfficial rows={vendor.giveawayVsOfficial} vendorName={vendor.name} />
     </>
   );
 }

--- a/src/app/vendors/[slug]/page.tsx
+++ b/src/app/vendors/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import JsonLd from "@/src/components/JsonLd";
-import Breadcrumbs from "@/src/components/layout/Breadcrumbs";
+import VendorBreadcrumbs from "@/src/components/vendors/VendorBreadcrumbs";
 import RichText from "@/src/components/portableText/RichText";
 import ProgramsGrid from "@/src/components/programs/ProgramsGrid";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
@@ -79,14 +79,7 @@ export default async function VendorPage({ params }: VendorPageProps) {
 
       <section className="border-b border-[#2a475e]">
         <div className="mx-auto w-full max-w-360 px-4 pb-8 pt-10 sm:px-6 sm:pb-10 sm:pt-12 lg:px-8">
-          <Breadcrumbs
-            className="mb-4"
-            items={[
-              { label: "Home", href: "/" },
-              { label: "Vendors", href: "/vendors" },
-              { label: vendor.name }
-            ]}
-          />
+          <VendorBreadcrumbs className="mb-4" vendor={vendor} />
 
           <div className="flex items-center gap-4">
             {vendor.logo && (

--- a/src/app/vendors/[slug]/page.tsx
+++ b/src/app/vendors/[slug]/page.tsx
@@ -1,0 +1,127 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Image from "next/image";
+import JsonLd from "@/src/components/JsonLd";
+import Breadcrumbs from "@/src/components/layout/Breadcrumbs";
+import RichText from "@/src/components/portableText/RichText";
+import ProgramsGrid from "@/src/components/programs/ProgramsGrid";
+import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
+import { getCachedVendorSlugs, getVendorBySlug } from "@/src/lib/vendors/getVendors";
+import { generateVendorPageJsonLd } from "@/src/lib/seo/jsonLd";
+import { resolveVendorHubSeo } from "@/src/lib/seo/vendorSeo";
+import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
+import { urlFor } from "@/src/sanity/lib/image";
+
+/** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` (Next.js requires a literal). */
+export const revalidate = 43200;
+
+interface VendorPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  const slugs = await getCachedVendorSlugs();
+  return slugs.map(slug => ({ slug }));
+}
+
+export async function generateMetadata({ params }: VendorPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const [store, vendor] = await Promise.all([getCachedStoreDetailsDocument(), getVendorBySlug(slug)]);
+  if (!vendor) return { title: "Vendor not found", robots: { index: false, follow: true } };
+
+  const { title, description, pageUrl: url, ogImageUrl, storeTitle } = resolveVendorHubSeo(store, {
+    name: vendor.name,
+    slug: vendor.slug,
+    programCount: vendor.programs.length,
+    seo: vendor.seo
+  });
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: storeTitle,
+      type: "website",
+      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${vendor.name} on ${storeTitle}` }]
+    },
+    twitter: { card: "summary_large_image", title, description, images: [ogImageUrl] },
+    alternates: { canonical: url }
+  };
+}
+
+export default async function VendorPage({ params }: VendorPageProps) {
+  const { slug } = await params;
+  const [store, vendor] = await Promise.all([getCachedStoreDetailsDocument(), getVendorBySlug(slug)]);
+  if (!vendor) return notFound();
+
+  const { siteUrl } = resolveVendorHubSeo(store, {
+    name: vendor.name,
+    slug: vendor.slug,
+    programCount: vendor.programs.length
+  });
+
+  const jsonLd = generateVendorPageJsonLd(
+    { name: vendor.name, slug: vendor.slug, description: portableTextToPlainText(vendor.description) || undefined },
+    vendor.programs,
+    siteUrl
+  );
+
+  const maxViews = vendor.programs.reduce((m, p) => Math.max(m, p.viewCount ?? 0), 0);
+  const maxDownloads = vendor.programs.reduce((m, p) => Math.max(m, p.downloadCount ?? 0), 0);
+  const hasDescription = portableTextToPlainText(vendor.description).length > 0;
+
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+
+      <section className="border-b border-[#2a475e]">
+        <div className="mx-auto w-full max-w-360 px-4 pb-8 pt-10 sm:px-6 sm:pb-10 sm:pt-12 lg:px-8">
+          <Breadcrumbs
+            className="mb-4"
+            items={[
+              { label: "Home", href: "/" },
+              { label: "Vendors", href: "/vendors" },
+              { label: vendor.name }
+            ]}
+          />
+
+          <div className="flex items-center gap-4">
+            {vendor.logo && (
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-sm border border-[#2a475e] bg-[#0e1621]">
+                <Image
+                  src={urlFor(vendor.logo).width(128).height(128).fit("max").url()}
+                  alt={`${vendor.name} logo`}
+                  width={64}
+                  height={64}
+                  className="h-full w-full object-contain p-1.5"
+                />
+              </div>
+            )}
+            <div>
+              <div className="section-label">Vendor</div>
+              <h1 className="section-title mt-1">
+                {vendor.name} <span className="text-gradient-pro">CD keys &amp; giveaways</span>
+              </h1>
+            </div>
+          </div>
+
+          {hasDescription && (
+            <div className="section-text mt-4 max-w-3xl">
+              <RichText value={vendor.description} />
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-360 px-4 py-8 sm:px-6 lg:px-8">
+        <h2 className="mb-5 text-lg font-semibold text-[#c6d4df] sm:text-xl">
+          {vendor.programs.length} program{vendor.programs.length === 1 ? "" : "s"} from {vendor.name}
+        </h2>
+        <ProgramsGrid programs={vendor.programs} maxViews={maxViews} maxDownloads={maxDownloads} />
+      </section>
+    </>
+  );
+}

--- a/src/app/vendors/page.tsx
+++ b/src/app/vendors/page.tsx
@@ -1,0 +1,92 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Image from "next/image";
+import JsonLd from "@/src/components/JsonLd";
+import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
+import { getCachedVendorsWithCounts } from "@/src/lib/vendors/getVendors";
+import { generateVendorsPageJsonLd } from "@/src/lib/seo/jsonLd";
+import { resolveVendorsIndexSeo } from "@/src/lib/seo/vendorSeo";
+import { urlFor } from "@/src/sanity/lib/image";
+
+/** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` (Next.js requires a literal). */
+export const revalidate = 43200;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const store = await getCachedStoreDetailsDocument();
+  const { title, description, pageUrl: url, ogImageUrl, storeTitle } = resolveVendorsIndexSeo(store);
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: storeTitle,
+      type: "website",
+      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${storeTitle} — Vendors` }]
+    },
+    twitter: { card: "summary_large_image", title, description, images: [ogImageUrl] },
+    alternates: { canonical: url }
+  };
+}
+
+export default async function VendorsPage() {
+  const [store, vendors] = await Promise.all([getCachedStoreDetailsDocument(), getCachedVendorsWithCounts()]);
+  const { siteUrl } = resolveVendorsIndexSeo(store);
+  const jsonLd = generateVendorsPageJsonLd(vendors, siteUrl);
+
+  return (
+    <>
+      <JsonLd data={jsonLd} />
+
+      <section className="border-b border-[#2a475e]">
+        <div className="mx-auto w-full max-w-360 px-4 pb-8 pt-10 sm:px-6 sm:pb-10 sm:pt-12 lg:px-8">
+          <div className="section-label">Vendors</div>
+          <h1 className="section-title mt-2">
+            Software <span className="text-gradient-pro">publishers &amp; brands</span>
+          </h1>
+          <p className="section-text mt-3 max-w-2xl">
+            Browse giveaways and free CD keys grouped by the company that makes the software. Each hub lists every
+            program we track for that vendor, plus official PRO upgrade options.
+          </p>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-360 px-4 py-8 sm:px-6 lg:px-8">
+        {vendors.length === 0 ? (
+          <p className="text-sm text-neutral-100">No vendors published yet.</p>
+        ) : (
+          <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {vendors.map(vendor => (
+              <li key={vendor._id}>
+                <Link
+                  href={`/vendors/${vendor.slug}`}
+                  className="group flex h-full items-center gap-4 rounded-sm border border-[#2a475e] bg-[#16202d] p-4 transition-colors hover:border-[#4a90c4]">
+                  <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-sm border border-[#2a475e] bg-[#0e1621]">
+                    {vendor.logo ? (
+                      <Image
+                        src={urlFor(vendor.logo).width(112).height(112).fit("max").url()}
+                        alt={`${vendor.name} logo`}
+                        width={56}
+                        height={56}
+                        className="h-full w-full object-contain p-1"
+                      />
+                    ) : (
+                      <span className="text-lg font-bold text-[#66c0f4]">{vendor.name.charAt(0)}</span>
+                    )}
+                  </div>
+                  <div className="min-w-0">
+                    <div className="truncate font-semibold text-[#c6d4df] group-hover:text-white">{vendor.name}</div>
+                    <div className="mt-0.5 text-xs text-neutral-100">
+                      {vendor.programCount} program{vendor.programCount === 1 ? "" : "s"}
+                    </div>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </>
+  );
+}

--- a/src/app/vendors/page.tsx
+++ b/src/app/vendors/page.tsx
@@ -1,12 +1,11 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import Image from "next/image";
 import JsonLd from "@/src/components/JsonLd";
+import VendorLogoFrame from "@/src/components/vendors/VendorLogoFrame";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
 import { getCachedVendorsWithCounts } from "@/src/lib/vendors/getVendors";
 import { generateVendorsPageJsonLd } from "@/src/lib/seo/jsonLd";
 import { resolveVendorsIndexSeo } from "@/src/lib/seo/vendorSeo";
-import { urlFor } from "@/src/sanity/lib/image";
 
 /** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` (Next.js requires a literal). */
 export const revalidate = 43200;
@@ -62,19 +61,16 @@ export default async function VendorsPage() {
                 <Link
                   href={`/vendors/${vendor.slug}`}
                   className="group flex h-full items-center gap-4 rounded-sm border border-[#2a475e] bg-[#16202d] p-4 transition-colors hover:border-[#4a90c4]">
-                  <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-sm border border-[#2a475e] bg-[#0e1621]">
-                    {vendor.logo ? (
-                      <Image
-                        src={urlFor(vendor.logo).width(112).height(112).fit("max").url()}
-                        alt={`${vendor.name} logo`}
-                        width={56}
-                        height={56}
-                        className="h-full w-full object-contain p-1"
-                      />
-                    ) : (
-                      <span className="text-lg font-bold text-[#66c0f4]">{vendor.name.charAt(0)}</span>
-                    )}
-                  </div>
+                  <VendorLogoFrame
+                    name={vendor.name}
+                    logo={vendor.logo}
+                    logoBackgroundColor={vendor.logoBackgroundColor}
+                    imageSize={112}
+                    displayMaxSize={56}
+                    frameClassName="flex h-14 w-14 shrink-0 items-center justify-center rounded-sm border border-[#2a475e]"
+                    alt={`${vendor.name} logo`}
+                    fallbackClassName="text-lg font-bold text-[#66c0f4]"
+                  />
                   <div className="min-w-0">
                     <div className="truncate font-semibold text-[#c6d4df] group-hover:text-white">{vendor.name}</div>
                     <div className="mt-0.5 text-xs text-neutral-100">

--- a/src/components/NotFoundTracker.tsx
+++ b/src/components/NotFoundTracker.tsx
@@ -5,6 +5,7 @@ import { useLayoutEffect } from "react";
 import { usePathname } from "next/navigation";
 import { trackEvent } from "@/src/lib/analytics/trackEvent";
 import { pageViewSkipKey } from "@/src/lib/analytics/pageViewSkip";
+import { isAdminSession } from "@/src/lib/admin/isAdminSession";
 import { shouldSkipClientPageView } from "@/src/lib/analytics/shouldSendPageView";
 
 const EXCLUDED_HOSTNAMES = new Set(["localhost"]);
@@ -16,12 +17,16 @@ export default function NotFoundTracker() {
     if (typeof window === "undefined") return;
     if (EXCLUDED_HOSTNAMES.has(window.location.hostname)) return;
     if (shouldSkipClientPageView()) return;
-    try {
-      sessionStorage.setItem(pageViewSkipKey(pathname), "1");
-    } catch {
-      // sessionStorage unavailable (e.g. private mode)
-    }
-    void trackEvent("page_viewed", { path: pathname, notFound: true });
+
+    void (async () => {
+      if (await isAdminSession()) return;
+      try {
+        sessionStorage.setItem(pageViewSkipKey(pathname), "1");
+      } catch {
+        // sessionStorage unavailable (e.g. private mode)
+      }
+      void trackEvent("page_viewed", { path: pathname, notFound: true });
+    })();
   }, [pathname]);
 
   return null;

--- a/src/components/PageViewTracker.tsx
+++ b/src/components/PageViewTracker.tsx
@@ -7,6 +7,7 @@ import { trackEvent } from "@/src/lib/analytics/trackEvent";
 import { getUTMParameters } from "@/src/lib/analytics/utmUtils";
 import { pageViewSkipKey } from "@/src/lib/analytics/pageViewSkip";
 import { primaryReferrerForPageView } from "@/src/lib/analytics/referrerResolve";
+import { isAdminSession } from "@/src/lib/admin/isAdminSession";
 import { shouldSkipClientPageView, waitForPageViewEngagement } from "@/src/lib/analytics/shouldSendPageView";
 
 const log = (...args: unknown[]) => {
@@ -40,6 +41,8 @@ export default function PageViewTracker() {
 
     const trackPageView = async () => {
       try {
+        if (await isAdminSession()) return log("skipped admin session", pathname);
+
         try {
           await waitForPageViewEngagement(controller.signal);
         } catch {

--- a/src/components/home/HomeVendorBrowse.tsx
+++ b/src/components/home/HomeVendorBrowse.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
-import Image from "next/image";
-import { urlFor } from "@/src/sanity/lib/image";
+import VendorLogoFrame from "@/src/components/vendors/VendorLogoFrame";
 import type { VendorListItem } from "@/src/lib/vendors/getVendors";
 
 const HOMEPAGE_VENDOR_LIMIT = 10;
@@ -27,22 +26,14 @@ export default function HomeVendorBrowse({ vendors, position = "bottom" }: HomeV
             <Link
               href={`/vendors/${vendor.slug}`}
               className="card-base group flex w-24 flex-col items-center rounded-sm px-2 py-3 transition-colors hover:border-[#4a90c4] sm:w-32 sm:px-2.5 sm:py-3.5">
-              <div className="mb-2 flex h-12 w-12 items-center justify-center overflow-hidden rounded-sm border border-[#2a475e] bg-[#0e1621] sm:h-16 sm:w-16">
-                {vendor.logo ? (
-                  <Image
-                    src={urlFor(vendor.logo).width(96).height(96).fit("max").url()}
-                    alt=""
-                    width={48}
-                    height={48}
-                    className="h-full w-full object-contain p-1"
-                    aria-hidden
-                  />
-                ) : (
-                  <span className="text-base font-bold text-[#66c0f4]" aria-hidden>
-                    {vendor.name.charAt(0)}
-                  </span>
-                )}
-              </div>
+              <VendorLogoFrame
+                name={vendor.name}
+                logo={vendor.logo}
+                logoBackgroundColor={vendor.logoBackgroundColor}
+                imageSize={128}
+                displayMaxSize={64}
+                frameClassName="mb-2 flex h-12 w-12 shrink-0 items-center justify-center rounded-sm border border-[#2a475e] sm:h-16 sm:w-16"
+              />
               <span className="line-clamp-2 min-h-8 text-center text-xs font-semibold leading-tight text-[#c6d4df] group-hover:text-white sm:min-h-9 sm:text-xs">
                 {vendor.name}
               </span>

--- a/src/components/home/HomeVendorBrowse.tsx
+++ b/src/components/home/HomeVendorBrowse.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import Image from "next/image";
+import { urlFor } from "@/src/sanity/lib/image";
+import type { VendorListItem } from "@/src/lib/vendors/getVendors";
+
+const HOMEPAGE_VENDOR_LIMIT = 10;
+
+type HomeVendorBrowseProps = {
+  vendors: VendorListItem[];
+  position?: "top" | "bottom";
+};
+
+/** Compact vendor logo strip — rendered inside the popular programs section. */
+export default function HomeVendorBrowse({ vendors, position = "bottom" }: HomeVendorBrowseProps) {
+  const items = vendors.slice(0, HOMEPAGE_VENDOR_LIMIT);
+  if (items.length === 0) return null;
+
+  return (
+    <div className={`text-center ${position === "top" ? "mb-10" : "mt-10"}`}>
+      <h3 className="mb-5 text-xl font-semibold text-[#c6d4df] sm:mb-6 sm:text-2xl">
+        Browse by <span className="text-gradient-pro">Vendor</span>
+      </h3>
+
+      <ul className="flex flex-wrap items-stretch justify-center gap-2.5 sm:gap-3">
+        {items.map(vendor => (
+          <li key={vendor._id}>
+            <Link
+              href={`/vendors/${vendor.slug}`}
+              className="card-base group flex w-24 flex-col items-center rounded-sm px-2 py-3 transition-colors hover:border-[#4a90c4] sm:w-32 sm:px-2.5 sm:py-3.5">
+              <div className="mb-2 flex h-12 w-12 items-center justify-center overflow-hidden rounded-sm border border-[#2a475e] bg-[#0e1621] sm:h-16 sm:w-16">
+                {vendor.logo ? (
+                  <Image
+                    src={urlFor(vendor.logo).width(96).height(96).fit("max").url()}
+                    alt=""
+                    width={48}
+                    height={48}
+                    className="h-full w-full object-contain p-1"
+                    aria-hidden
+                  />
+                ) : (
+                  <span className="text-base font-bold text-[#66c0f4]" aria-hidden>
+                    {vendor.name.charAt(0)}
+                  </span>
+                )}
+              </div>
+              <span className="line-clamp-2 min-h-8 text-center text-xs font-semibold leading-tight text-[#c6d4df] group-hover:text-white sm:min-h-9 sm:text-xs">
+                {vendor.name}
+              </span>
+              <span className="mt-0.5 text-xs text-[#8f98a0] group-hover:text-neutral-100">
+                {vendor.programCount} {vendor.programCount === 1 ? "program" : "programs"}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
+      <Link
+        href="/vendors"
+        className="mt-5 inline-block text-base font-semibold text-[#66c0f4] transition-colors hover:text-white sm:mt-6 sm:text-lg">
+        View all vendors →
+      </Link>
+    </div>
+  );
+}

--- a/src/components/home/PopularProgramsSection.tsx
+++ b/src/components/home/PopularProgramsSection.tsx
@@ -2,8 +2,10 @@
 
 import { FaFire } from "react-icons/fa";
 import { ProgramsGrid } from "@/src/components/programs";
+import HomeVendorBrowse from "@/src/components/home/HomeVendorBrowse";
 import { PopularProgramsSectionProps } from "@/src/types/home";
-export default function PopularProgramsSection({ programs }: PopularProgramsSectionProps) {
+
+export default function PopularProgramsSection({ programs, vendors = [] }: PopularProgramsSectionProps) {
   const maxViews = Math.max(...programs.map(p => p.viewCount), 0);
   const maxDownloads = Math.max(...programs.map(p => p.downloadCount), 0);
 
@@ -24,7 +26,6 @@ export default function PopularProgramsSection({ programs }: PopularProgramsSect
           </p>
         </div>
 
-        {/* Programs Grid with CTAs */}
         <ProgramsGrid
           programs={programs}
           maxViews={maxViews}
@@ -32,6 +33,8 @@ export default function PopularProgramsSection({ programs }: PopularProgramsSect
           showBrowseAllCTA={true}
           limit={8}
         />
+
+        <HomeVendorBrowse vendors={vendors} position="bottom" />
       </div>
     </section>
   );

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -2,6 +2,7 @@ export { default as HeroSection } from "./HeroSection";
 export { default as HeroVisual } from "./HeroVisual";
 export { default as FeaturesSection } from "./FeaturesSection";
 export { default as PopularProgramsSection } from "./PopularProgramsSection";
+export { default as HomeVendorBrowse } from "./HomeVendorBrowse";
 export { default as AllProgramsSection } from "./AllProgramsSection";
 export { default as StatsSection } from "./StatsSection";
 export { default as CTASection } from "./CTASection";

--- a/src/components/layout/AnnouncementNotifications.tsx
+++ b/src/components/layout/AnnouncementNotifications.tsx
@@ -93,7 +93,10 @@ export default function AnnouncementNotifications({ notifications, socialData }:
           onClick={handleMiniPopupClick}
           className="absolute right-0 top-full z-110 mt-2 cursor-pointer whitespace-nowrap rounded-sm border border-[#2a475e] bg-[#1b2838] px-3 py-2 text-left text-xs font-medium text-[#c6d4df] shadow-[0_8px_24px_rgba(0,0,0,0.55)] animate-[fadeIn_0.5s_ease-out]"
           aria-label="New announcements — open list">
-          <span className="pointer-events-none absolute -top-1 right-4 h-2 w-2 rotate-45 border-l border-t border-[#2a475e] bg-[#1b2838]" aria-hidden />
+          <span
+            className="pointer-events-none absolute -top-1 right-4 h-2 w-2 rotate-45 border-l border-t border-[#2a475e] bg-[#1b2838]"
+            aria-hidden
+          />
           <span className="relative flex items-center gap-2">
             <span className="h-1.5 w-1.5 shrink-0 animate-pulse rounded-full bg-[#5ba32b]" aria-hidden />
             <span>New updates available!</span>
@@ -138,12 +141,18 @@ export default function AnnouncementNotifications({ notifications, socialData }:
             ) : null}
           </div>
 
-          <div className="border-t border-[#2a475e] bg-[#16202d] px-4 py-2.5">
+          <div className="border-t border-[#2a475e] bg-[#16202d] px-4 py-2.5 flex flex-wrap justify-between items-center gap-x-4 gap-y-1">
+            <Link
+              href="/updates"
+              onClick={() => setIsOpen(false)}
+              className="text-xs font-medium text-[#66d9ff] underline-offset-2 hover:text-white hover:underline">
+              View all updates →
+            </Link>
             <Link
               href="/programs"
               onClick={() => setIsOpen(false)}
-              className="text-xs font-medium text-[#66d9ff] underline-offset-2 hover:text-white hover:underline">
-              View all programs →
+              className="text-xs font-medium text-[#8f98a0] underline-offset-2 hover:text-[#c6d4df] hover:underline">
+              Browse programs →
             </Link>
           </div>
         </div>

--- a/src/components/layout/Breadcrumbs.tsx
+++ b/src/components/layout/Breadcrumbs.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+
+export interface Crumb {
+  label: string;
+  /** Omit on the current (last) crumb. */
+  href?: string;
+}
+
+/** Visible breadcrumb trail. Keep items in sync with the page's BreadcrumbList JSON-LD. */
+export default function Breadcrumbs({ items, className }: { items: Crumb[]; className?: string }) {
+  return (
+    <nav aria-label="Breadcrumb" className={`text-xs text-neutral-100 ${className ?? ""}`}>
+      <ol className="flex flex-wrap items-center gap-y-1">
+        {items.map((item, i) => {
+          const isLast = i === items.length - 1;
+          return (
+            <li key={i} className="flex items-center">
+              {item.href && !isLast ? (
+                <Link href={item.href} className="hover:text-white">
+                  {item.label}
+                </Link>
+              ) : (
+                <span className={isLast ? "text-[#c6d4df]" : undefined} aria-current={isLast ? "page" : undefined}>
+                  {item.label}
+                </span>
+              )}
+              {!isLast && (
+                <span className="mx-1.5 text-[#8f98a0]" aria-hidden>
+                  /
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -89,6 +89,15 @@ export default function Footer({ logoData, socialData }: FooterProps) {
           <div>
             <h4 className="section-label mb-4 text-neutral-50">Navigate</h4>
             <ul className="space-y-2">
+              <li>
+                <Link
+                  href="/vendors"
+                  className={`transition-colors ${
+                    pathname === "/vendors" ? "font-medium text-white" : "text-neutral-150 hover:text-neutral-50"
+                  }`}>
+                  Vendors
+                </Link>
+              </li>
               {footerLinks &&
                 footerLinks.map((link, i) => {
                   let isActive = false;

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -21,7 +21,8 @@ const TRUST_FOOTER_LINKS = [
   { href: "/how-it-works", label: "How it works" },
   { href: "/affiliate-disclosure", label: "Affiliate disclosure" },
   { href: "/verification-policy", label: "Verification policy" },
-  { href: "/partners", label: "Partners" }
+  { href: "/partners", label: "Partners" },
+  { href: "/updates", label: "Updates" }
 ] as const;
 
 export default function Footer({ logoData, socialData }: FooterProps) {

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -11,6 +11,7 @@ import { usePathname } from "next/navigation";
 import { FaKey, FaEnvelope, FaChevronRight } from "react-icons/fa";
 import { ContactModal, ContactModalTrigger } from "@/src/components/contact";
 import { Socials, FacebookGroupButton } from "@/src/components/social";
+import FooterMiniSocialShare from "@/src/components/social-share/FooterMiniSocialShare";
 import { trackEvent } from "@/src/lib/analytics/trackEvent";
 import TrustpilotReviewWidget from "@/src/components/trustpilot/TrustpilotReviewWidget";
 import { getTrustpilotReviewUrl } from "@/src/lib/social/socialUtils";
@@ -25,7 +26,7 @@ const TRUST_FOOTER_LINKS = [
   { href: "/updates", label: "Updates" }
 ] as const;
 
-export default function Footer({ logoData, socialData }: FooterProps) {
+export default function Footer({ logoData, socialData, siteBaseUrl }: FooterProps) {
   const storeData = useStoreDetails();
   const pathname = usePathname();
   const trustpilotUrl = getTrustpilotReviewUrl(socialData);
@@ -51,10 +52,10 @@ export default function Footer({ logoData, socialData }: FooterProps) {
   return (
     <footer className="mt-auto border-t border-[#2a475e] bg-[#0E141B] text-neutral-100">
       <div className="mx-auto w-full max-w-360 px-4 py-12 sm:px-6 lg:px-8">
-        <div className="grid grid-cols-1 xs:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-8">
+        <div className="grid grid-cols-1 xs:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-y-8 gap-x-2">
           {/* Brand Section */}
           <div className="col-span-1 xs:col-span-2 flex flex-col gap-4">
-            <Link href="/" className="inline-block">
+            <Link href="/" className="inline-block w-fit pr-4">
               {isLogo ? (
                 <IdealImageClient {...logoData} className="h-12 w-auto" />
               ) : (
@@ -147,15 +148,6 @@ export default function Footer({ logoData, socialData }: FooterProps) {
                   </Link>
                 </li>
               ))}
-              <li>
-                <a
-                  href="/llms.txt"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-neutral-150 transition-colors hover:text-neutral-50">
-                  llms.txt
-                </a>
-              </li>
             </ul>
           </div>
 
@@ -192,47 +184,51 @@ export default function Footer({ logoData, socialData }: FooterProps) {
               </ContactModalTrigger>
             </div>
 
-            {hasSupportLinks ? (
-              <div className="mt-6 border-t border-[#2a475e] pt-6">
-                <p className="mb-3 text-xs">Support the Project</p>
-                <div className="flex flex-col gap-3">
-                  <div className="flex flex-wrap items-center gap-2">
-                    {buyMeACoffeeUrl ? (
-                      <Link
-                        href={buyMeACoffeeUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        onClick={() => {
-                          trackEvent("social_click", {
-                            social: "buymeacoffee",
-                            path: window.location.pathname
-                          });
-                        }}
-                        className="inline-flex items-center gap-2 rounded-sm bg-[#7d3315] px-3 py-2 text-xs font-semibold text-neutral-50 transition-colors hover:bg-[#a3421b] hover:text-white">
-                        🥕 Carrot Juice
-                      </Link>
-                    ) : null}
-                    {githubRepoUrl ? (
-                      <Link
-                        href={githubRepoUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        aria-label="Open KeyAway source code on GitHub"
-                        title="KeyAway repository on GitHub"
-                        onClick={() => {
-                          trackEvent("social_click", {
-                            social: "github keyaway",
-                            path: window.location.pathname
-                          });
-                        }}
-                        className="inline-flex items-center gap-2 rounded-sm bg-[#213246] px-3 py-2 text-xs font-semibold text-neutral-50 hover:text-white transition-colors hover:bg-[#2a475e]">
-                        ⭐ KeyAway repo
-                      </Link>
-                    ) : null}
+            <div className="mt-6 border-t border-[#2a475e] pt-6">
+              <FooterMiniSocialShare siteBaseUrl={siteBaseUrl} />
+
+              {hasSupportLinks ? (
+                <>
+                  <p className="mb-3 mt-6 text-xs">Support the Project</p>
+                  <div className="flex flex-col gap-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      {buyMeACoffeeUrl ? (
+                        <Link
+                          href={buyMeACoffeeUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={() => {
+                            trackEvent("social_click", {
+                              social: "buymeacoffee",
+                              path: window.location.pathname
+                            });
+                          }}
+                          className="inline-flex items-center gap-2 rounded-sm bg-[#7d3315] px-3 py-2 text-xs font-semibold text-neutral-50 transition-colors hover:bg-[#a3421b] hover:text-white">
+                          🥕 Carrot Juice
+                        </Link>
+                      ) : null}
+                      {githubRepoUrl ? (
+                        <Link
+                          href={githubRepoUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          aria-label="Open KeyAway source code on GitHub"
+                          title="KeyAway repository on GitHub"
+                          onClick={() => {
+                            trackEvent("social_click", {
+                              social: "github keyaway",
+                              path: window.location.pathname
+                            });
+                          }}
+                          className="inline-flex items-center gap-2 rounded-sm bg-[#213246] px-3 py-2 text-xs font-semibold text-neutral-50 hover:text-white transition-colors hover:bg-[#2a475e]">
+                          ⭐ KeyAway repo
+                        </Link>
+                      ) : null}
+                    </div>
                   </div>
-                </div>
-              </div>
-            ) : null}
+                </>
+              ) : null}
+            </div>
           </div>
         </div>
 
@@ -254,6 +250,13 @@ export default function Footer({ logoData, socialData }: FooterProps) {
             <Link href="/terms" className="text-sm text-[#8f98a0] transition-colors hover:text-white">
               Terms
             </Link>
+            <a
+              href="/llms.txt"
+              target="_blank"
+              rel="noreferrer"
+              className="text-sm text-[#8f98a0] transition-colors hover:text-white">
+              llms.txt
+            </a>
           </div>
         </div>
       </div>

--- a/src/components/program/FreeVsProComparison.tsx
+++ b/src/components/program/FreeVsProComparison.tsx
@@ -14,17 +14,15 @@ export default function FreeVsProComparison({ program }: FreeVsProComparisonProp
   const vendorName = program.vendor?.name;
 
   return (
-    <section
-      className="mx-auto max-w-360 px-4 pb-6 pt-2 sm:px-6 sm:pb-8 lg:px-8"
-      aria-labelledby="free-vs-pro-heading">
+    <section className="mx-auto max-w-360 px-4 pb-6 pt-2 sm:px-6 sm:pb-8 lg:px-8" aria-labelledby="free-vs-pro-heading">
       <div className="overflow-hidden rounded-sm border border-[#2a475e] bg-[#16202d]">
         <div className="border-b border-[#2a475e] px-4 py-4 sm:px-6">
-          <p className="mb-1 text-xs font-bold uppercase tracking-wider text-[#66c0f4]">Free vs PRO</p>
+          <p className="mb-1 text-xs font-bold uppercase tracking-wider text-[#66c0f4]">Free vs Official PRO</p>
           <h2 id="free-vs-pro-heading" className="text-lg font-bold text-white sm:text-xl">
-            Why upgrade{vendorName ? ` to ${vendorName} PRO` : ""}?
+            What you get with{vendorName ? ` ${vendorName} PRO` : " PRO"}
           </h2>
           <p className="mt-2 text-sm text-neutral-100">
-            Giveaway keys are great for trying the software. PRO keeps updates, support, and features running long-term.
+            The free edition covers the basics. Official PRO unlocks the full feature set, with updates and support.
           </p>
         </div>
 
@@ -35,19 +33,17 @@ export default function FreeVsProComparison({ program }: FreeVsProComparisonProp
                 <th scope="col" className="px-4 py-3 font-semibold text-[#c6d4df] sm:px-6">
                   Feature
                 </th>
-                <th scope="col" className="px-4 py-3 font-semibold text-[#8f98a0] sm:px-6">
-                  Free / Giveaway
+                <th scope="col" className="px-4 py-3 font-semibold text-[#66c0f4] sm:px-6">
+                  Free
                 </th>
                 <th scope="col" className="px-4 py-3 font-semibold text-[#5ba32b] sm:px-6">
-                  PRO
+                  Official PRO
                 </th>
               </tr>
             </thead>
             <tbody>
               {rows.map((row, i) => (
-                <tr
-                  key={`${row.feature}-${i}`}
-                  className={i % 2 === 0 ? "bg-[#16202d]" : "bg-[#1b2838]/60"}>
+                <tr key={`${row.feature}-${i}`} className={i % 2 === 0 ? "bg-[#16202d]" : "bg-[#1b2838]/60"}>
                   <th scope="row" className="px-4 py-3 font-medium text-[#c6d4df] sm:px-6">
                     {row.feature}
                   </th>
@@ -62,8 +58,8 @@ export default function FreeVsProComparison({ program }: FreeVsProComparisonProp
         {affiliateUrl ? (
           <div className="border-t border-[#2a475e] bg-[#1b2838]/80 px-4 py-3 sm:px-6">
             <p className="text-xs leading-relaxed text-[#8f98a0] sm:text-sm">
-              <span className="font-semibold text-[#c6d4df]">Pro tip:</span> Giveaway keys usually lack auto-updates.
-              Grab the official PRO license via the button below.{" "}
+              <span className="font-semibold text-[#c6d4df]">Pro tip:</span> want every feature above, permanently, with
+              updates and support? Grab the official PRO license via the button below.{" "}
               <Link href="/affiliate-disclosure" className="text-[#66c0f4] underline hover:text-white">
                 Affiliate disclosure
               </Link>

--- a/src/components/program/FreeVsProComparison.tsx
+++ b/src/components/program/FreeVsProComparison.tsx
@@ -1,0 +1,76 @@
+import Link from "next/link";
+import type { Program } from "@/src/types/program";
+import { resolveFreeVsProRows } from "@/src/lib/program/resolveFreeVsProRows";
+
+type FreeVsProComparisonProps = {
+  program: Program;
+};
+
+export default function FreeVsProComparison({ program }: FreeVsProComparisonProps) {
+  const rows = resolveFreeVsProRows(program);
+  if (rows.length === 0) return null;
+
+  const affiliateUrl = program.affiliatePro?.affiliateProUrl?.trim();
+  const vendorName = program.vendor?.name;
+
+  return (
+    <section
+      className="mx-auto max-w-360 px-4 pb-6 pt-2 sm:px-6 sm:pb-8 lg:px-8"
+      aria-labelledby="free-vs-pro-heading">
+      <div className="overflow-hidden rounded-sm border border-[#2a475e] bg-[#16202d]">
+        <div className="border-b border-[#2a475e] px-4 py-4 sm:px-6">
+          <p className="mb-1 text-xs font-bold uppercase tracking-wider text-[#66c0f4]">Free vs PRO</p>
+          <h2 id="free-vs-pro-heading" className="text-lg font-bold text-white sm:text-xl">
+            Why upgrade{vendorName ? ` to ${vendorName} PRO` : ""}?
+          </h2>
+          <p className="mt-2 text-sm text-neutral-100">
+            Giveaway keys are great for trying the software. PRO keeps updates, support, and features running long-term.
+          </p>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[480px] border-collapse text-left text-sm">
+            <thead>
+              <tr className="border-b border-[#2a475e] bg-[#1b2838]">
+                <th scope="col" className="px-4 py-3 font-semibold text-[#c6d4df] sm:px-6">
+                  Feature
+                </th>
+                <th scope="col" className="px-4 py-3 font-semibold text-[#8f98a0] sm:px-6">
+                  Free / Giveaway
+                </th>
+                <th scope="col" className="px-4 py-3 font-semibold text-[#5ba32b] sm:px-6">
+                  PRO
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <tr
+                  key={`${row.feature}-${i}`}
+                  className={i % 2 === 0 ? "bg-[#16202d]" : "bg-[#1b2838]/60"}>
+                  <th scope="row" className="px-4 py-3 font-medium text-[#c6d4df] sm:px-6">
+                    {row.feature}
+                  </th>
+                  <td className="px-4 py-3 text-neutral-100 sm:px-6">{row.free?.trim() || "—"}</td>
+                  <td className="px-4 py-3 font-medium text-[#c6d4df] sm:px-6">{row.pro?.trim() || "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {affiliateUrl ? (
+          <div className="border-t border-[#2a475e] bg-[#1b2838]/80 px-4 py-3 sm:px-6">
+            <p className="text-xs leading-relaxed text-[#8f98a0] sm:text-sm">
+              <span className="font-semibold text-[#c6d4df]">Pro tip:</span> Giveaway keys usually lack auto-updates.
+              Grab the official PRO license via the button below.{" "}
+              <Link href="/affiliate-disclosure" className="text-[#66c0f4] underline hover:text-white">
+                Affiliate disclosure
+              </Link>
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/program/ProgramBreadcrumbs.tsx
+++ b/src/components/program/ProgramBreadcrumbs.tsx
@@ -1,0 +1,12 @@
+import Breadcrumbs from "@/src/components/layout/Breadcrumbs";
+import { buildProgramBreadcrumbItems } from "@/src/lib/seo/breadcrumbs";
+import type { Program } from "@/src/types/program";
+
+type ProgramBreadcrumbsProps = {
+  program: Pick<Program, "title" | "vendor">;
+  className?: string;
+};
+
+export default function ProgramBreadcrumbs({ program, className }: ProgramBreadcrumbsProps) {
+  return <Breadcrumbs className={className} items={buildProgramBreadcrumbItems(program)} />;
+}

--- a/src/components/program/ProgramInformation.tsx
+++ b/src/components/program/ProgramInformation.tsx
@@ -49,7 +49,8 @@ export default function ProgramInformation({
   totalKeys,
   workingKeys,
   socialData,
-  visitorHint: visitorHintProp
+  visitorHint: visitorHintProp,
+  communityRating
 }: ProgramInformationProps) {
   const { visitorHint: visitorHintCtx } = useProgramVisitor();
   const visitorHint = visitorHintProp ?? visitorHintCtx;
@@ -137,6 +138,14 @@ export default function ProgramInformation({
                 </div>
               ))}
             </div>
+
+            {communityRating ? (
+              <p className="text-xs text-neutral-100 sm:text-sm">
+                <span className="font-semibold text-[#5ba32b]">{communityRating.successPercent}%</span> community
+                success · {communityRating.ratingCount}{" "}
+                {communityRating.ratingCount === 1 ? "report" : "reports"}
+              </p>
+            ) : null}
           </div>
         </div>
       </div>

--- a/src/components/program/social-share/ProgramSocialShare.tsx
+++ b/src/components/program/social-share/ProgramSocialShare.tsx
@@ -1,0 +1,31 @@
+import SocialShare from "@/src/components/social-share/SocialShare";
+import { buildProgramShareInput } from "@/src/lib/share/buildSharePayload";
+import type { ProgramShareCounts } from "@/src/lib/program/getProgramShareCounts";
+
+export type ProgramSocialShareProps = {
+  programTitle: string;
+  programSlug: string;
+  pageUrl: string;
+  workingKeys: number;
+  imageUrl?: string;
+  shareCounts?: ProgramShareCounts;
+};
+
+export default function ProgramSocialShare({
+  programTitle,
+  programSlug,
+  pageUrl,
+  workingKeys,
+  imageUrl,
+  shareCounts
+}: ProgramSocialShareProps) {
+  return (
+    <SocialShare
+      shareId={programSlug}
+      shareInput={buildProgramShareInput({ programTitle, programSlug, pageUrl, workingKeys, imageUrl })}
+      programSlug={programSlug}
+      shareCounts={shareCounts}
+      ariaLabel="Share this program"
+    />
+  );
+}

--- a/src/components/social-share/FooterMiniSocialShare.tsx
+++ b/src/components/social-share/FooterMiniSocialShare.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
+import SocialShare from "@/src/components/social-share/SocialShare";
+import { buildPageShareInput } from "@/src/lib/share/buildSharePayload";
+
+type FooterMiniSocialShareProps = {
+  siteBaseUrl: string;
+};
+
+export default function FooterMiniSocialShare({ siteBaseUrl }: FooterMiniSocialShareProps) {
+  const pathname = usePathname();
+  const [documentTitle, setDocumentTitle] = useState<string>();
+
+  useEffect(() => {
+    setDocumentTitle(document.title);
+  }, [pathname]);
+
+  const shareInput = useMemo(() => {
+    const pageUrl = `${siteBaseUrl}${pathname}`;
+    return buildPageShareInput(pageUrl, documentTitle);
+  }, [siteBaseUrl, pathname, documentTitle]);
+
+  if (pathname.startsWith("/admin") || pathname.startsWith("/studio")) {
+    return null;
+  }
+
+  const shareId = `footer${pathname.replace(/\//g, "-") || "-home"}`;
+
+  return (
+    <SocialShare
+      variant="mini"
+      shareId={shareId}
+      shareInput={shareInput}
+      ariaLabel="Share this page"
+      showCounts={false}
+    />
+  );
+}

--- a/src/components/social-share/ProgramsPageSocialShare.tsx
+++ b/src/components/social-share/ProgramsPageSocialShare.tsx
@@ -1,0 +1,28 @@
+import SocialShare from "@/src/components/social-share/SocialShare";
+import { buildProgramsIndexShareInput } from "@/src/lib/share/buildSharePayload";
+import type { ShareCounts } from "@/src/lib/share/buildSharePayload";
+
+export type ProgramsPageSocialShareProps = {
+  pageUrl: string;
+  programCount: number;
+  totalKeys: number;
+  imageUrl?: string;
+  shareCounts?: ShareCounts;
+};
+
+export default function ProgramsPageSocialShare({
+  pageUrl,
+  programCount,
+  totalKeys,
+  imageUrl,
+  shareCounts
+}: ProgramsPageSocialShareProps) {
+  return (
+    <SocialShare
+      shareId="programs"
+      shareInput={buildProgramsIndexShareInput(pageUrl, programCount, totalKeys, imageUrl)}
+      shareCounts={shareCounts}
+      ariaLabel="Share all programs"
+    />
+  );
+}

--- a/src/components/social-share/SocialShare.tsx
+++ b/src/components/social-share/SocialShare.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { usePathname } from "next/navigation";
+import { FaFacebook, FaLinkedin, FaPinterest, FaShare, FaTelegram, FaTumblr, FaXTwitter } from "react-icons/fa6";
+import type { IconType } from "react-icons";
+import { trackEvent } from "@/src/lib/analytics/trackEvent";
+import {
+  buildShareUrl,
+  SHARE_TRACKING_KEYS,
+  type ShareCounts,
+  type ShareNetworkId,
+  type SharePayloadInput
+} from "@/src/lib/share/buildSharePayload";
+import "./social-share.css";
+
+type NetworkConfig = {
+  id: ShareNetworkId;
+  label: string;
+  ariaLabel: string;
+  bg: string;
+  text: string;
+  badgeBg: string;
+  badgeText: string;
+  Icon: IconType;
+};
+
+export const SHARE_NETWORKS: NetworkConfig[] = [
+  {
+    id: "facebook",
+    label: "Share",
+    ariaLabel: "Share on Facebook",
+    bg: "#4267B2",
+    text: "#ffffff",
+    badgeBg: "#29487d",
+    badgeText: "#ffffff",
+    Icon: FaFacebook
+  },
+  {
+    id: "twitter",
+    label: "Tweet",
+    ariaLabel: "Share on X",
+    bg: "#000000",
+    text: "#ffffff",
+    badgeBg: "#333333",
+    badgeText: "#ffffff",
+    Icon: FaXTwitter
+  },
+  {
+    id: "telegram",
+    label: "Share",
+    ariaLabel: "Share on Telegram",
+    bg: "#0088cc",
+    text: "#ffffff",
+    badgeBg: "#006699",
+    badgeText: "#ffffff",
+    Icon: FaTelegram
+  },
+  {
+    id: "pinterest",
+    label: "Pin",
+    ariaLabel: "Share on Pinterest",
+    bg: "#E60023",
+    text: "#ffffff",
+    badgeBg: "#ad001b",
+    badgeText: "#ffffff",
+    Icon: FaPinterest
+  },
+  {
+    id: "tumblr",
+    label: "Post",
+    ariaLabel: "Share on Tumblr",
+    bg: "#35465c",
+    text: "#ffffff",
+    badgeBg: "#222b37",
+    badgeText: "#ffffff",
+    Icon: FaTumblr
+  },
+  {
+    id: "linkedin",
+    label: "Share",
+    ariaLabel: "Share on LinkedIn",
+    bg: "#0077b5",
+    text: "#ffffff",
+    badgeBg: "#005885",
+    badgeText: "#ffffff",
+    Icon: FaLinkedin
+  }
+];
+
+const POPUP_FEATURES =
+  "width=626,height=436,left=120,top=120,scrollbars=yes,resizable=yes,toolbar=no,menubar=no,noopener,noreferrer";
+
+export type SocialShareProps = {
+  variant?: "default" | "mini";
+  shareId: string;
+  shareInput: SharePayloadInput;
+  programSlug?: string;
+  shareCounts?: ShareCounts;
+  ariaLabel?: string;
+  className?: string;
+  showCounts?: boolean;
+};
+
+export default function SocialShare({
+  variant = "default",
+  shareId,
+  shareInput,
+  programSlug,
+  shareCounts = {},
+  ariaLabel = "Share",
+  className = "",
+  showCounts = true
+}: SocialShareProps) {
+  const pathname = usePathname();
+  const [expanded, setExpanded] = useState(false);
+  const isMini = variant === "mini";
+
+  const trackShare = useCallback(
+    (network: ShareNetworkId) => {
+      void trackEvent("social_click", {
+        social: SHARE_TRACKING_KEYS[network],
+        ...(programSlug ? { programSlug } : {}),
+        path: pathname || "/"
+      });
+    },
+    [pathname, programSlug]
+  );
+
+  const openShareWindow = useCallback(
+    (url: string, network: ShareNetworkId) => {
+      trackShare(network);
+      const popup = window.open(url, `SocialShare_${shareId}_${network}`, POPUP_FEATURES);
+      if (popup) popup.opener = null;
+    },
+    [shareId, trackShare]
+  );
+
+  const handleShareClick = (e: React.MouseEvent<HTMLAnchorElement>, network: ShareNetworkId, url: string) => {
+    if (e.defaultPrevented || e.button !== 0) return;
+    e.preventDefault();
+
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+      const tab = window.open(url, "_blank", "noopener,noreferrer");
+      if (tab) tab.opener = null;
+      trackShare(network);
+      return;
+    }
+
+    openShareWindow(url, network);
+  };
+
+  const showToggle = !isMini && SHARE_NETWORKS.length > 3;
+  const rootClass = [
+    "social-share",
+    "social-share--toggle-share-arrow",
+    expanded ? "social-share--expanded" : "",
+    isMini ? "social-share--mini" : "",
+    !isMini ? className : ""
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const bar = (
+    <div className={rootClass} data-social-share-root>
+      <div className="social-share__track" id={`social-share-track-${shareId}`}>
+        {SHARE_NETWORKS.map(network => {
+          const shareUrl = buildShareUrl(network.id, shareInput);
+          const count = shareCounts[network.id];
+          const { Icon } = network;
+
+          return (
+            <div key={network.id} className="social-share__item">
+              <a
+                href={shareUrl}
+                className="social-share__link"
+                rel="nofollow noreferrer"
+                target="_blank"
+                aria-label={network.ariaLabel}
+                style={{ background: network.bg, color: network.text }}
+                data-social-share-item
+                onClick={e => handleShareClick(e, network.id, shareUrl)}>
+                <span className="social-share__icon" aria-hidden>
+                  <Icon />
+                </span>
+                <span className="social-share__label">{network.label}</span>
+                {showCounts && !isMini && typeof count === "number" && count > 0 ? (
+                  <span
+                    className="social-share__count"
+                    style={{ background: network.badgeBg, color: network.badgeText }}>
+                    {count}
+                  </span>
+                ) : null}
+              </a>
+            </div>
+          );
+        })}
+      </div>
+
+      {showToggle ? (
+        <button
+          type="button"
+          className="social-share__toggle"
+          data-social-share-toggle
+          aria-expanded={expanded}
+          aria-controls={`social-share-track-${shareId}`}
+          aria-label={expanded ? "Show fewer sharing options" : "Show more sharing options"}
+          onClick={() => setExpanded(v => !v)}>
+          <span className="social-share__toggle-icon" aria-hidden>
+            <FaShare />
+          </span>
+        </button>
+      ) : null}
+    </div>
+  );
+
+  if (isMini) {
+    return (
+      <div aria-label={ariaLabel} className={className}>
+        {bar}
+      </div>
+    );
+  }
+
+  return (
+    <section
+      className={`mx-auto w-full max-w-3xl px-4 pb-2 pt-2 sm:px-6 lg:max-w-360 lg:px-8 ${className}`.trim()}
+      aria-label={ariaLabel}>
+      {bar}
+    </section>
+  );
+}

--- a/src/components/social-share/social-share.css
+++ b/src/components/social-share/social-share.css
@@ -1,0 +1,198 @@
+/* Ported from reference/social-share.css — share bar + mini footer variant */
+.social-share {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: var(--social-share-gap, 8px);
+  max-width: 100%;
+  min-width: 0;
+  width: 100%;
+  --social-share-gap: 8px;
+  --social-share-radius: 4px;
+  --social-share-toggle-bg: #d0d0d0;
+  --social-share-toggle-icon: #ffffff;
+}
+.social-share__track {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: var(--social-share-gap, 8px);
+  flex: 1;
+  min-width: 0;
+}
+.social-share__item {
+  flex: 1;
+  min-width: 0;
+  width: 100%;
+}
+.social-share__item:nth-child(n + 4) {
+  flex: unset;
+  width: auto;
+}
+
+/* Collapsed: hide secondary networks (all breakpoints except mini) */
+.social-share:not(.social-share--mini):not(.social-share--expanded) .social-share__item:nth-child(n + 4) {
+  display: none;
+}
+.social-share__link {
+  min-width: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 44px;
+  padding: 8px 14px;
+  border-radius: var(--social-share-radius, 4px);
+  text-decoration: none;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.2;
+  white-space: nowrap;
+  box-sizing: border-box;
+  transition: opacity 0.2s ease;
+  border: none;
+  cursor: pointer;
+}
+.social-share__link:hover {
+  opacity: 0.75;
+}
+.social-share__icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  align-items: center;
+  justify-content: center;
+}
+.social-share__icon svg {
+  width: 20px;
+  height: 20px;
+}
+.social-share__count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+.social-share__toggle {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0;
+  border: none;
+  cursor: pointer;
+  flex-shrink: 0;
+  background: var(--social-share-toggle-bg, #d0d0d0);
+  color: var(--social-share-toggle-icon, #ffffff);
+  border-radius: var(--social-share-radius, 4px);
+  transition: opacity 0.2s ease;
+}
+.social-share__toggle:hover {
+  opacity: 0.75;
+}
+.social-share__toggle-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transform-origin: center center;
+  transition: transform 0.22s ease;
+}
+.social-share__toggle-icon svg {
+  width: 18px;
+  height: 18px;
+}
+.social-share--toggle-share-arrow.social-share--expanded .social-share__toggle-icon {
+  transform: rotate(180deg);
+}
+/* Mini — footer icon strip */
+.social-share--mini {
+  width: auto;
+  --social-share-gap: 6px;
+}
+.social-share--mini .social-share__track {
+  flex: 0 1 auto;
+  flex-wrap: wrap;
+}
+.social-share--mini .social-share__item,
+.social-share--mini .social-share__item:nth-child(n + 4) {
+  flex: 0 0 auto;
+  width: auto;
+}
+.social-share--mini .social-share__link {
+  width: 34px;
+  min-width: 34px;
+  min-height: 34px;
+  padding: 7px;
+}
+.social-share--mini .social-share__icon,
+.social-share--mini .social-share__icon svg {
+  width: 16px;
+  height: 16px;
+}
+.social-share--mini .social-share__label,
+.social-share--mini .social-share__count,
+.social-share--mini .social-share__toggle {
+  display: none !important;
+}
+.social-share--mini .social-share__item:nth-child(n + 4) {
+  display: block !important;
+}
+
+@media screen and (min-width: 768px) {
+  .social-share:not(.social-share--mini) .social-share__item:nth-child(n + 4) .social-share__link {
+    padding: 10px;
+    min-width: 44px;
+  }
+
+  .social-share:not(.social-share--mini) .social-share__item:nth-child(n + 4) .social-share__label,
+  .social-share:not(.social-share--mini) .social-share__item:nth-child(n + 4) .social-share__count {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .social-share:not(.social-share--mini) .social-share__label,
+  .social-share:not(.social-share--mini) .social-share__count {
+    display: none !important;
+  }
+
+  .social-share:not(.social-share--mini) .social-share__track {
+    flex-wrap: wrap;
+  }
+
+  .social-share:not(.social-share--mini) .social-share__item {
+    flex: 0 0 44px;
+    width: 44px;
+    min-width: 44px;
+  }
+
+  .social-share:not(.social-share--mini) .social-share__item:nth-child(n + 4) {
+    flex: 0 0 44px;
+    width: 44px;
+  }
+
+  .social-share:not(.social-share--mini) .social-share__link {
+    width: 44px;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 10px;
+  }
+
+  .social-share:not(.social-share--mini) .social-share__toggle {
+    flex: 0 0 44px;
+  }
+}

--- a/src/components/trustpilot/TrustpilotReviewWidget.tsx
+++ b/src/components/trustpilot/TrustpilotReviewWidget.tsx
@@ -22,7 +22,7 @@ export default function TrustpilotReviewWidget({ className, reviewUrl }: Trustpi
       target="_blank"
       rel="noopener"
       onClick={handleClick}
-      className={`inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-gray-100 px-4 py-2 text-sm font-medium text-black transition-colors hover:border-gray-600 hover:bg-gray-200 hover:text-black ${className || ""}`}>
+      className={`inline-flex items-center justify-center gap-2 rounded-lg border border-gray-200 bg-gray-100 p-2 text-sm font-medium text-black transition-colors hover:border-gray-600 hover:bg-gray-200 hover:text-black ${className || ""}`}>
       <span>Leave a review on</span>
       <span className="inline-flex items-center gap-2 text-black">
         <img

--- a/src/components/updates/UpdateFeedItem.tsx
+++ b/src/components/updates/UpdateFeedItem.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import Image from "next/image";
+import type { Notification } from "@/src/types/notifications";
+
+type UpdateFeedItemProps = {
+  notification: Notification;
+};
+
+export default function UpdateFeedItem({ notification }: UpdateFeedItemProps) {
+  const isNewProgram = notification.type === "new_program" || notification.type === "new_program_with_keys";
+  const message = notification.message?.trim() ?? "";
+  const createdAt = new Date(notification.createdAt);
+
+  return (
+    <li>
+      <Link
+        href={`/program/${notification.programSlug}`}
+        className="group flex items-start gap-3 rounded-sm border border-[#2a475e] bg-[#1b2838] px-4 py-3 transition-colors hover:border-[#4a90c4] hover:bg-[#213246] sm:px-5 sm:py-4">
+        {notification.imageUrl ? (
+          <div className="h-11 w-11 shrink-0 overflow-hidden rounded-sm border border-[#2a475e]">
+            <Image
+              src={notification.imageUrl}
+              alt=""
+              width={44}
+              height={44}
+              className="h-full w-full object-cover"
+              sizes="44px"
+              unoptimized
+            />
+          </div>
+        ) : (
+          <div
+            className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-sm border ${
+              isNewProgram ? "border-[#4a90c4] bg-[#1a3a5c]" : "border-[#3d6e1c] bg-[#1a3a2a]"
+            }`}>
+            <span className="text-lg" aria-hidden>
+              {isNewProgram ? "✨" : "🔑"}
+            </span>
+          </div>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <p className="font-semibold text-[#c6d4df] transition-colors group-hover:text-white">
+            {notification.programTitle}
+          </p>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-[#8f98a0]">
+            {isNewProgram ? (
+              <span className="inline-flex rounded-sm border border-[#4a90c4] bg-[#1a3a5c] px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-[#9fc6e3]">
+                New listing
+              </span>
+            ) : (
+              <span className="inline-flex rounded-sm border border-[#3d6e1c] bg-[#1a3a2a] px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-[#8bc34a]">
+                Keys added
+              </span>
+            )}
+            {message ? <span>{message}</span> : null}
+            <time dateTime={notification.createdAt}>
+              {createdAt.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+            </time>
+          </div>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/src/components/vendors/GiveawayVsOfficial.tsx
+++ b/src/components/vendors/GiveawayVsOfficial.tsx
@@ -1,0 +1,69 @@
+import type { GiveawayComparisonRow } from "@/src/types/program";
+
+type GiveawayVsOfficialProps = {
+  rows?: GiveawayComparisonRow[] | null;
+  vendorName: string;
+};
+
+/**
+ * Vendor-hub explainer: how a community giveaway key compares to buying the
+ * official PRO license. A giveaway key unlocks the real PRO version — the
+ * honest trade-off is longevity/reliability, not features.
+ */
+export default function GiveawayVsOfficial({ rows, vendorName }: GiveawayVsOfficialProps) {
+  const validRows = (rows ?? []).filter(r => r.feature?.trim());
+  if (validRows.length === 0) return null;
+
+  return (
+    <section
+      className="mx-auto w-full max-w-360 px-4 py-8 sm:px-6 lg:px-8"
+      aria-labelledby="giveaway-vs-official-heading">
+      <div className="overflow-hidden rounded-sm border border-[#2a475e] bg-[#16202d]">
+        <div className="border-b border-[#2a475e] px-4 py-4 sm:px-6">
+          <p className="mb-1 text-xs font-bold uppercase tracking-wider text-[#66c0f4]">
+            Giveaway key vs official PRO
+          </p>
+          <h2 id="giveaway-vs-official-heading" className="text-lg font-bold text-white sm:text-xl">
+            Using a {vendorName} giveaway key vs buying official
+          </h2>
+          <p className="mt-2 text-sm text-neutral-100">
+            A giveaway key unlocks the <span className="font-semibold text-white">full PRO version</span> — for free,
+            while it lasts. Buying the official license is what keeps it running long-term. Here&apos;s the honest
+            trade-off.
+          </p>
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[480px] border-collapse text-left text-sm">
+            <thead>
+              <tr className="border-b border-[#2a475e] bg-[#1b2838]">
+                <th scope="col" className="px-4 py-3 font-semibold text-[#c6d4df] sm:px-6">
+                  &nbsp;
+                </th>
+                <th scope="col" className="px-4 py-3 font-semibold text-[#66c0f4] sm:px-6">
+                  Giveaway key
+                </th>
+                <th scope="col" className="px-4 py-3 font-semibold text-[#5ba32b] sm:px-6">
+                  Official PRO
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {validRows.map((row, i) => (
+                <tr
+                  key={`${row.feature}-${i}`}
+                  className={i % 2 === 0 ? "bg-[#16202d]" : "bg-[#1b2838]/60"}>
+                  <th scope="row" className="px-4 py-3 font-medium text-[#c6d4df] sm:px-6">
+                    {row.feature}
+                  </th>
+                  <td className="px-4 py-3 text-neutral-100 sm:px-6">{row.giveaway?.trim() || "—"}</td>
+                  <td className="px-4 py-3 font-medium text-[#c6d4df] sm:px-6">{row.officialPro?.trim() || "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/vendors/VendorBreadcrumbs.tsx
+++ b/src/components/vendors/VendorBreadcrumbs.tsx
@@ -1,0 +1,11 @@
+import Breadcrumbs from "@/src/components/layout/Breadcrumbs";
+import { buildVendorBreadcrumbItems } from "@/src/lib/seo/breadcrumbs";
+
+type VendorBreadcrumbsProps = {
+  vendor: { name: string };
+  className?: string;
+};
+
+export default function VendorBreadcrumbs({ vendor, className }: VendorBreadcrumbsProps) {
+  return <Breadcrumbs className={className} items={buildVendorBreadcrumbItems(vendor)} />;
+}

--- a/src/components/vendors/VendorLogoFrame.tsx
+++ b/src/components/vendors/VendorLogoFrame.tsx
@@ -1,13 +1,12 @@
 import Image from "next/image";
-import { getImageDimensions } from "@sanity/asset-utils";
+import { getImageDimensions, SanityImageSource } from "@sanity/asset-utils";
 import { urlFor } from "@/src/sanity/lib/image";
 import { resolveVendorLogoBackgroundColor } from "@/src/lib/vendors/resolveVendorLogoBackgroundColor";
 import type { VendorLogoBackgroundColor } from "@/src/lib/vendors/resolveVendorLogoBackgroundColor";
-import type { SanityImageField } from "@/src/types/program";
 
 type VendorLogoFrameProps = {
   name: string;
-  logo?: SanityImageField;
+  logo?: SanityImageSource;
   logoBackgroundColor?: VendorLogoBackgroundColor | null;
   /** Max edge length (px) for the logo box and Sanity CDN width hint. */
   imageSize: number;
@@ -58,7 +57,7 @@ export default function VendorLogoFrame({
     );
   }
 
-  const intrinsic = getImageDimensions(logo);
+  const intrinsic = getImageDimensions(logo as SanityImageSource);
   const boxMax = displayMaxSize ?? Math.round(imageSize / 2);
   const display = fitInsideBox(intrinsic.width, intrinsic.height, boxMax, boxMax);
 

--- a/src/components/vendors/VendorLogoFrame.tsx
+++ b/src/components/vendors/VendorLogoFrame.tsx
@@ -1,0 +1,84 @@
+import Image from "next/image";
+import { getImageDimensions } from "@sanity/asset-utils";
+import { urlFor } from "@/src/sanity/lib/image";
+import { resolveVendorLogoBackgroundColor } from "@/src/lib/vendors/resolveVendorLogoBackgroundColor";
+import type { VendorLogoBackgroundColor } from "@/src/lib/vendors/resolveVendorLogoBackgroundColor";
+import type { SanityImageField } from "@/src/types/program";
+
+type VendorLogoFrameProps = {
+  name: string;
+  logo?: SanityImageField;
+  logoBackgroundColor?: VendorLogoBackgroundColor | null;
+  /** Max edge length (px) for the logo box and Sanity CDN width hint. */
+  imageSize: number;
+  /** Max rendered edge length inside the frame; defaults to half of imageSize. */
+  displayMaxSize?: number;
+  frameClassName: string;
+  imageClassName?: string;
+  alt?: string;
+  fallbackClassName?: string;
+};
+
+function fitInsideBox(
+  width: number,
+  height: number,
+  maxWidth: number,
+  maxHeight: number
+): { width: number; height: number } {
+  if (width <= 0 || height <= 0) {
+    return { width: maxWidth, height: maxHeight };
+  }
+  const scale = Math.min(maxWidth / width, maxHeight / height, 1);
+  return {
+    width: Math.max(1, Math.round(width * scale)),
+    height: Math.max(1, Math.round(height * scale))
+  };
+}
+
+export default function VendorLogoFrame({
+  name,
+  logo,
+  logoBackgroundColor,
+  imageSize,
+  displayMaxSize,
+  frameClassName,
+  imageClassName = "block max-h-full max-w-full object-contain",
+  alt,
+  fallbackClassName = "text-base font-bold text-[#66c0f4]"
+}: VendorLogoFrameProps) {
+  const backgroundColor = resolveVendorLogoBackgroundColor(logoBackgroundColor);
+
+  if (!logo) {
+    return (
+      <div className={frameClassName} style={backgroundColor ? { backgroundColor } : undefined}>
+        <span className={fallbackClassName} aria-hidden>
+          {name.charAt(0)}
+        </span>
+      </div>
+    );
+  }
+
+  const intrinsic = getImageDimensions(logo);
+  const boxMax = displayMaxSize ?? Math.round(imageSize / 2);
+  const display = fitInsideBox(intrinsic.width, intrinsic.height, boxMax, boxMax);
+
+  return (
+    <div className={frameClassName} style={backgroundColor ? { backgroundColor } : undefined}>
+      <div className={`flex h-full w-full items-center justify-center p-1`}>
+        <Image
+          src={urlFor(logo)
+            .width(imageSize * 2)
+            .fit("max")
+            .auto("format")
+            .url()}
+          alt={alt ?? ""}
+          width={display.width}
+          height={display.height}
+          className={imageClassName}
+          sizes={`${imageSize}px`}
+          aria-hidden={alt === "" || alt === undefined}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/admin/isAdminSession.ts
+++ b/src/lib/admin/isAdminSession.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { getSession } from "next-auth/react";
+
+/** Client-side: whether the current NextAuth session is an authenticated admin. */
+export async function isAdminSession(): Promise<boolean> {
+  try {
+    const session = await getSession();
+    return (session?.user as { isAdmin?: boolean })?.isAdmin === true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/analytics/trackEvent.ts
+++ b/src/lib/analytics/trackEvent.ts
@@ -1,7 +1,10 @@
 import { AnalyticsEvent, KeyReportEvent, TrackEventMeta } from "@/src/types";
+import { isAdminSession } from "@/src/lib/admin/isAdminSession";
 
 export async function trackEvent(event: AnalyticsEvent | KeyReportEvent, meta?: TrackEventMeta) {
   try {
+    if (await isAdminSession()) return;
+
     await fetch("/api/v1/analytics/track", {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/src/lib/cache/cacheTags.ts
+++ b/src/lib/cache/cacheTags.ts
@@ -8,6 +8,9 @@ export const TAG_PROGRAMS_FULL = "programs";
 /** Card/list projections: homepage popular strip, /programs grid, program page sidebar list. */
 export const TAG_PROGRAM_LISTINGS = "program-listings";
 
+/** Vendor docs + vendor hubs (/vendors, /vendors/[slug]) and vendor program counts. */
+export const TAG_VENDORS = "vendors";
+
 /** Homepage popular programs query (not site-wide stats). */
 export const TAG_HOMEPAGE_PROGRAMS = "homepage-programs";
 

--- a/src/lib/notifications/notificationFeed.server.ts
+++ b/src/lib/notifications/notificationFeed.server.ts
@@ -5,14 +5,25 @@ import { client } from "@/src/sanity/lib/client";
 import { urlFor } from "@/src/sanity/lib/image";
 import type { Notification, NotificationType } from "@/src/types/notifications";
 
-/** Fixed `_id` so only one feed document exists in the dataset. */
+/** Legacy singleton `_id` (migrated to append-only feed documents). */
 export const SITE_NOTIFICATION_FEED_DOCUMENT_ID = "siteNotificationFeed";
 
-/** Max rows stored on the singleton feed (after global sort by activity time). */
-const MAX_ITEMS = 15;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
-/** ~1 month: program must be touched in Sanity in this window to appear; same window for “new listing” / key dates. */
-const FEED_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+/** Activity window when building each snapshot (header + new feed rows). */
+export const NOTIFICATION_SNAPSHOT_WINDOW_DAYS = 30;
+const SNAPSHOT_WINDOW_MS = NOTIFICATION_SNAPSHOT_WINDOW_DAYS * DAY_MS;
+
+/** Max rows per snapshot document (after global sort by activity time). */
+const MAX_ITEMS_PER_SNAPSHOT = 15;
+
+/** Default /updates page window; extended via `?days=` query param. */
+export const UPDATES_PAGE_DEFAULT_DAYS = 90;
+export const UPDATES_PAGE_DAYS_INCREMENT = 90;
+export const UPDATES_PAGE_MAX_DAYS = 365 * 2;
+
+/** Cap stored feed documents so the dataset stays bounded. */
+const MAX_FEED_DOCUMENTS = 120;
 
 const NOTIFICATION_ID_PREFIX = "program-notify-";
 
@@ -24,6 +35,13 @@ type FeedRow = {
   message?: string;
   createdAt?: string;
   imageUrl?: string;
+};
+
+type FeedDocument = {
+  _id: string;
+  _createdAt?: string;
+  generatedAt?: string;
+  items?: FeedRow[];
 };
 
 function programImageUrl(image: unknown): string | undefined {
@@ -54,12 +72,89 @@ function stableItemKey(id: string): string {
   return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 120) || "item";
 }
 
-/** Recompute feed from all programs (heavy — call only from webhook/admin/cron, not per GET). */
+function parseFeedRow(raw: FeedRow): Notification | null {
+  if (
+    typeof raw?.id !== "string" ||
+    typeof raw.programSlug !== "string" ||
+    typeof raw.programTitle !== "string" ||
+    typeof raw.createdAt !== "string" ||
+    typeof raw.type !== "string"
+  ) {
+    return null;
+  }
+  const t = raw.type as NotificationType;
+  if (t !== "new_program" && t !== "new_program_with_keys" && t !== "new_keys") return null;
+  return {
+    id: raw.id,
+    type: t,
+    programSlug: raw.programSlug,
+    programTitle: raw.programTitle,
+    ...(typeof raw.message === "string" && raw.message.length ? { message: raw.message } : {}),
+    createdAt: raw.createdAt,
+    ...(typeof raw.imageUrl === "string" && raw.imageUrl.length ? { imageUrl: raw.imageUrl } : {})
+  };
+}
+
+function snapshotSignature(items: FeedRow[]): string {
+  return JSON.stringify(
+    items.map(i => ({
+      id: i.id,
+      type: i.type,
+      createdAt: i.createdAt,
+      message: i.message
+    }))
+  );
+}
+
+function mergeNotificationsFromDocuments(docs: FeedDocument[]): Notification[] {
+  const byId = new Map<string, Notification>();
+
+  for (const doc of docs) {
+    for (const raw of doc.items ?? []) {
+      const parsed = parseFeedRow(raw);
+      if (!parsed) continue;
+      const existing = byId.get(parsed.id);
+      if (!existing || new Date(parsed.createdAt).getTime() > new Date(existing.createdAt).getTime()) {
+        byId.set(parsed.id, parsed);
+      }
+    }
+  }
+
+  return [...byId.values()].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+}
+
+async function fetchFeedDocuments(cached = false): Promise<FeedDocument[]> {
+  const docs = await client.fetch<FeedDocument[]>(
+    `*[_type == "siteNotificationFeed"] | order(coalesce(generatedAt, _createdAt) desc) {
+      _id,
+      _createdAt,
+      generatedAt,
+      items
+    }`,
+    {},
+    cached ? { next: { tags: [TAG_NOTIFICATION_FEED] } } : undefined
+  );
+  return docs ?? [];
+}
+
+async function pruneOldFeedDocuments(docs: FeedDocument[]): Promise<void> {
+  if (docs.length <= MAX_FEED_DOCUMENTS) return;
+  const excess = docs.slice(MAX_FEED_DOCUMENTS);
+  for (const doc of excess) {
+    if (doc._id === SITE_NOTIFICATION_FEED_DOCUMENT_ID) continue;
+    try {
+      await client.delete(doc._id);
+    } catch {
+      // non-fatal
+    }
+  }
+}
+
+/** Recompute snapshot from programs and append a new feed document (does not rewrite history). */
 export async function rebuildSiteNotificationFeed(): Promise<void> {
   const now = Date.now();
-  const windowStartMs = now - FEED_WINDOW_MS;
+  const windowStartMs = now - SNAPSHOT_WINDOW_MS;
 
-  /** Every program is scanned; only rows with `_updatedAt` in the window qualify (embedding key edits bumps this). */
   const programs = await client.fetch<
     Array<{
       _id: string;
@@ -104,13 +199,11 @@ export async function rebuildSiteNotificationFeed(): Promise<void> {
           })
         : [];
 
-    /** Skip meaningless bumps (e.g. title-only) with no listing/key signal in-window. */
     if (!isNewListing && newlyAddedKeys.length === 0) continue;
 
     const canonicalId = `${NOTIFICATION_ID_PREFIX}${program._id}`;
     const imageUrl = programImageUrl(program.image);
 
-    // Exactly one notification per program: pick a single merged row (prefer “new listing + keys”, else listing, else keys).
     if (isNewListing && newlyAddedKeys.length > 0) {
       const mostRecentKey = newlyAddedKeys.reduce((latest, key) => {
         const keyDate = new Date(key.createdAt || key.validFrom);
@@ -163,7 +256,7 @@ export async function rebuildSiteNotificationFeed(): Promise<void> {
 
   const sorted = notifications
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-    .slice(0, MAX_ITEMS);
+    .slice(0, MAX_ITEMS_PER_SNAPSHOT);
 
   const items = sorted.map(n => ({
     _key: stableItemKey(n.id),
@@ -176,47 +269,71 @@ export async function rebuildSiteNotificationFeed(): Promise<void> {
     ...(n.imageUrl ? { imageUrl: n.imageUrl } : {})
   }));
 
-  await client.createOrReplace({
-    _id: SITE_NOTIFICATION_FEED_DOCUMENT_ID,
-    _type: "siteNotificationFeed",
-    items
-  });
+  const existingDocs = await fetchFeedDocuments();
+  const latestDoc = existingDocs[0];
+
+  if (items.length > 0) {
+    const nextSignature = snapshotSignature(items);
+    const latestSignature = latestDoc?.items ? snapshotSignature(latestDoc.items) : null;
+
+    if (nextSignature !== latestSignature) {
+      await client.create({
+        _type: "siteNotificationFeed",
+        generatedAt: new Date().toISOString(),
+        windowDays: NOTIFICATION_SNAPSHOT_WINDOW_DAYS,
+        items
+      });
+    }
+  }
+
+  const refreshedDocs = await fetchFeedDocuments();
+  await pruneOldFeedDocuments(refreshedDocs);
 
   revalidateTag(TAG_NOTIFICATION_FEED, "max");
   revalidatePath("/api/v1/notifications/recent");
   revalidatePath("/updates");
 }
 
+/** Latest snapshot — used by header bell API. */
 export async function readSiteNotificationFeed(): Promise<Notification[]> {
-  const row = await client.fetch<{ items?: FeedRow[] } | null>(
-    `*[_id == $id][0]{ items }`,
-    { id: SITE_NOTIFICATION_FEED_DOCUMENT_ID },
-    { next: { tags: [TAG_NOTIFICATION_FEED] } }
-  );
+  const docs = await fetchFeedDocuments(true);
+  const latest = docs[0];
+  if (!latest?.items?.length) return [];
 
-  const list = row?.items ?? [];
   const out: Notification[] = [];
-  for (const raw of list) {
-    if (
-      typeof raw?.id !== "string" ||
-      typeof raw.programSlug !== "string" ||
-      typeof raw.programTitle !== "string" ||
-      typeof raw.createdAt !== "string" ||
-      typeof raw.type !== "string"
-    ) {
-      continue;
-    }
-    const t = raw.type as NotificationType;
-    if (t !== "new_program" && t !== "new_program_with_keys" && t !== "new_keys") continue;
-    out.push({
-      id: raw.id,
-      type: t,
-      programSlug: raw.programSlug,
-      programTitle: raw.programTitle,
-      ...(typeof raw.message === "string" && raw.message.length ? { message: raw.message } : {}),
-      createdAt: raw.createdAt,
-      ...(typeof raw.imageUrl === "string" && raw.imageUrl.length ? { imageUrl: raw.imageUrl } : {})
-    });
+  for (const raw of latest.items) {
+    const parsed = parseFeedRow(raw);
+    if (parsed) out.push(parsed);
   }
   return out;
+}
+
+/** Merged history across all feed snapshots (deduped by notification id). */
+export async function readSiteNotificationHistory(): Promise<Notification[]> {
+  const docs = await fetchFeedDocuments(true);
+  return mergeNotificationsFromDocuments(docs);
+}
+
+export function filterNotificationsByDays(notifications: Notification[], days: number): Notification[] {
+  const cutoffMs = Date.now() - days * DAY_MS;
+  return notifications.filter(n => {
+    const ts = new Date(n.createdAt).getTime();
+    return Number.isFinite(ts) && ts >= cutoffMs;
+  });
+}
+
+export function hasOlderNotifications(notifications: Notification[], days: number): boolean {
+  const cutoffMs = Date.now() - days * DAY_MS;
+  return notifications.some(n => {
+    const ts = new Date(n.createdAt).getTime();
+    return Number.isFinite(ts) && ts < cutoffMs;
+  });
+}
+
+export function resolveUpdatesPageDays(raw?: string): number {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed < UPDATES_PAGE_DEFAULT_DAYS) {
+    return UPDATES_PAGE_DEFAULT_DAYS;
+  }
+  return Math.min(parsed, UPDATES_PAGE_MAX_DAYS);
 }

--- a/src/lib/notifications/notificationFeed.server.ts
+++ b/src/lib/notifications/notificationFeed.server.ts
@@ -184,6 +184,7 @@ export async function rebuildSiteNotificationFeed(): Promise<void> {
 
   revalidateTag(TAG_NOTIFICATION_FEED, "max");
   revalidatePath("/api/v1/notifications/recent");
+  revalidatePath("/updates");
 }
 
 export async function readSiteNotificationFeed(): Promise<Notification[]> {

--- a/src/lib/program/buildProgramSharePayload.ts
+++ b/src/lib/program/buildProgramSharePayload.ts
@@ -1,0 +1,8 @@
+export {
+  buildProgramShareInput,
+  buildProgramShareText,
+  buildShareUrl,
+  SHARE_TRACKING_KEYS,
+  type ProgramShareInput,
+  type ShareNetworkId
+} from "@/src/lib/share/buildSharePayload";

--- a/src/lib/program/getProgramShareCounts.ts
+++ b/src/lib/program/getProgramShareCounts.ts
@@ -1,0 +1,25 @@
+import { cache } from "react";
+import { programDetailTag } from "@/src/lib/cache/cacheTags";
+import { client } from "@/src/sanity/lib/client";
+import { programShareCountsQuery } from "@/src/lib/sanity/queries";
+import type { ShareCounts, ShareNetworkId } from "@/src/lib/share/buildSharePayload";
+
+export type ProgramShareCounts = ShareCounts;
+
+/** Aggregate share-click counts per network for a program (singular trackingEvent rows). */
+export const getProgramShareCounts = cache(async (slug: string): Promise<ProgramShareCounts> => {
+  const row = await client.fetch<Record<string, number> | null>(
+    programShareCountsQuery,
+    { slug },
+    { next: { tags: [programDetailTag(slug)] } }
+  );
+  if (!row) return {};
+
+  const out: ProgramShareCounts = {};
+  for (const [key, value] of Object.entries(row)) {
+    if (typeof value === "number" && value > 0) {
+      out[key as ShareNetworkId] = value;
+    }
+  }
+  return out;
+});

--- a/src/lib/program/programAggregateRating.ts
+++ b/src/lib/program/programAggregateRating.ts
@@ -1,0 +1,34 @@
+/** @fileoverview Community aggregateRating derived from all key reports (every row, every status) for a program. */
+import { client } from "@/src/sanity/lib/client";
+import { programKeyReportCountsQuery } from "@/src/lib/sanity/queries";
+
+/** Below this, ratings are too thin to publish as rich-result signals. */
+const MIN_REPORTS_FOR_RATING = 3;
+
+export interface ProgramRating {
+  /** 1–5 scale (working share × 5), one decimal. */
+  ratingValue: number;
+  /** Total reports across all rows and statuses. */
+  ratingCount: number;
+  /** Working share as a whole percentage, for UI copy. */
+  successPercent: number;
+}
+
+/** Returns null when the program has fewer than `MIN_REPORTS_FOR_RATING` reports. */
+export async function getProgramAggregateRating(slug: string): Promise<ProgramRating | null> {
+  const counts = await client.fetch<{ working?: number; expired?: number; limitReached?: number }>(
+    programKeyReportCountsQuery,
+    { slug }
+  );
+
+  const working = counts?.working ?? 0;
+  const ratingCount = working + (counts?.expired ?? 0) + (counts?.limitReached ?? 0);
+  if (ratingCount < MIN_REPORTS_FOR_RATING) return null;
+
+  const share = working / ratingCount;
+  return {
+    ratingValue: Math.round(share * 5 * 10) / 10,
+    ratingCount,
+    successPercent: Math.round(share * 100)
+  };
+}

--- a/src/lib/program/resolveFreeVsProRows.ts
+++ b/src/lib/program/resolveFreeVsProRows.ts
@@ -1,14 +1,6 @@
 import type { FreeVsProRow, Program } from "@/src/types/program";
 
-function validRows(rows: FreeVsProRow[] | null | undefined): FreeVsProRow[] {
-  return (rows ?? []).filter(r => r.feature?.trim());
-}
-
-/** Program-specific rows win; otherwise inherit from the linked vendor's defaults. */
-export function resolveFreeVsProRows(
-  program: Pick<Program, "freeVsProComparison" | "vendor">
-): FreeVsProRow[] {
-  const programRows = validRows(program.freeVsProComparison);
-  if (programRows.length > 0) return programRows;
-  return validRows(program.vendor?.freeVsProDefaults);
+/** Valid rows only (a non-empty feature label). */
+export function resolveFreeVsProRows(program: Pick<Program, "freeVsProComparison">): FreeVsProRow[] {
+  return (program.freeVsProComparison ?? []).filter(r => r.feature?.trim());
 }

--- a/src/lib/program/resolveFreeVsProRows.ts
+++ b/src/lib/program/resolveFreeVsProRows.ts
@@ -1,0 +1,14 @@
+import type { FreeVsProRow, Program } from "@/src/types/program";
+
+function validRows(rows: FreeVsProRow[] | null | undefined): FreeVsProRow[] {
+  return (rows ?? []).filter(r => r.feature?.trim());
+}
+
+/** Program-specific rows win; otherwise inherit from the linked vendor's defaults. */
+export function resolveFreeVsProRows(
+  program: Pick<Program, "freeVsProComparison" | "vendor">
+): FreeVsProRow[] {
+  const programRows = validRows(program.freeVsProComparison);
+  if (programRows.length > 0) return programRows;
+  return validRows(program.vendor?.freeVsProDefaults);
+}

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -264,6 +264,25 @@ export const programKeyReportCountsQuery = `{
   "limitReached": count(*[_type == "keyReport" && programSlug == $slug && eventType == "report_key_limit_reached"])
 }`;
 
+/* ------------ Program share counts (social_click per network) ------------ */
+export const programShareCountsQuery = `{
+  "facebook": count(*[_type == "trackingEvent" && event == "social_click" && programSlug == $slug && social == "share-facebook"]),
+  "twitter": count(*[_type == "trackingEvent" && event == "social_click" && programSlug == $slug && social == "share-twitter"]),
+  "telegram": count(*[_type == "trackingEvent" && event == "social_click" && programSlug == $slug && social == "share-telegram"]),
+  "pinterest": count(*[_type == "trackingEvent" && event == "social_click" && programSlug == $slug && social == "share-pinterest"]),
+  "tumblr": count(*[_type == "trackingEvent" && event == "social_click" && programSlug == $slug && social == "share-tumblr"]),
+  "linkedin": count(*[_type == "trackingEvent" && event == "social_click" && programSlug == $slug && social == "share-linkedin"])
+}`;
+
+export const pageShareCountsQuery = `{
+  "facebook": count(*[_type == "trackingEvent" && event == "social_click" && path == $path && social == "share-facebook"]),
+  "twitter": count(*[_type == "trackingEvent" && event == "social_click" && path == $path && social == "share-twitter"]),
+  "telegram": count(*[_type == "trackingEvent" && event == "social_click" && path == $path && social == "share-telegram"]),
+  "pinterest": count(*[_type == "trackingEvent" && event == "social_click" && path == $path && social == "share-pinterest"]),
+  "tumblr": count(*[_type == "trackingEvent" && event == "social_click" && path == $path && social == "share-tumblr"]),
+  "linkedin": count(*[_type == "trackingEvent" && event == "social_click" && path == $path && social == "share-linkedin"])
+}`;
+
 /* ------------ Vendors ------------ */
 /** /vendors index + homepage chips: vendors that have at least one program, with counts. */
 export const vendorsWithCountsQuery = `*[_type == "vendor" && count(*[_type == "program" && references(^._id)]) > 0]{

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -59,6 +59,7 @@ export const programsListingProjection = `
   description,
   image,
   _createdAt,
+  "vendor": vendor->{ name, "slug": slug.current },
   "keyCount": count(cdKeys[]),
   "hasKeys": count(cdKeys[]) > 0,
   ${programStatsProjection}
@@ -95,6 +96,7 @@ export const adminProgramsQuery = `
   description,
   ${featuredBlockProjection},
   latestOfficialVersion,
+  "vendor": vendor->{ name, "slug": slug.current, "freeVsProDefaults": freeVsProDefaults },
   seo,
   aboutSections,
   faq,
@@ -161,6 +163,7 @@ export const programBySlugQuery = `
   description,
   ${featuredBlockProjection},
   latestOfficialVersion,
+  "vendor": vendor->{ name, "slug": slug.current, "freeVsProDefaults": freeVsProDefaults },
   seo,
   aboutSections,
   faq,
@@ -257,6 +260,35 @@ export const programKeyReportCountsQuery = `{
   "working": count(*[_type == "keyReport" && programSlug == $slug && eventType == "report_key_working"]),
   "expired": count(*[_type == "keyReport" && programSlug == $slug && eventType == "report_key_expired"]),
   "limitReached": count(*[_type == "keyReport" && programSlug == $slug && eventType == "report_key_limit_reached"])
+}`;
+
+/* ------------ Vendors ------------ */
+/** /vendors index + homepage chips: vendors that have at least one program, with counts. */
+export const vendorsWithCountsQuery = `*[_type == "vendor" && count(*[_type == "program" && references(^._id)]) > 0]{
+  _id,
+  name,
+  "slug": slug.current,
+  logo,
+  "programCount": count(*[_type == "program" && references(^._id)])
+} | order(programCount desc, name asc)`;
+
+/** Slugs for generateStaticParams + sitemap (only vendors with programs are worth indexing). */
+export const vendorSlugsQuery = `*[_type == "vendor" && defined(slug.current) && count(*[_type == "program" && references(^._id)]) > 0]{
+  "slug": slug.current
+}`;
+
+/** /vendors/{slug} hub: vendor doc + its programs (listing projection, popularity-sorted). */
+export const vendorBySlugQuery = `*[_type == "vendor" && slug.current == $slug][0]{
+  _id,
+  name,
+  "slug": slug.current,
+  description,
+  logo,
+  seo,
+  freeVsProDefaults,
+  "programs": *[_type == "program" && references(^._id)]{
+    ${programsListingProjection}
+  } | order(popularityScore desc, _createdAt desc)
 }`;
 
 /* ------------ Cron Runs ------------ */

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -109,6 +109,7 @@ export const adminProgramsQuery = `
       "affiliateProLabel": affiliateProLabel
     })
   ),
+  freeVsProComparison,
   programComments[]{
     _key,
     authorName,
@@ -176,6 +177,7 @@ export const programBySlugQuery = `
       "affiliateProLabel": affiliateProLabel
     })
   ),
+  freeVsProComparison,
   programComments[]{
     _key,
     authorName,

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -252,6 +252,13 @@ export const keyReportsQuery = `*[_type=="keyReport" && _createdAt >= $since]{
       label
     } | order(_createdAt desc)`;
 
+/* ------------ Program key report counts (community aggregateRating) ------------ */
+export const programKeyReportCountsQuery = `{
+  "working": count(*[_type == "keyReport" && programSlug == $slug && eventType == "report_key_working"]),
+  "expired": count(*[_type == "keyReport" && programSlug == $slug && eventType == "report_key_expired"]),
+  "limitReached": count(*[_type == "keyReport" && programSlug == $slug && eventType == "report_key_limit_reached"])
+}`;
+
 /* ------------ Cron Runs ------------ */
 export const cronRunsQuery = `*[_type == "cronRun" && ranAt >= $since]{
   _id, job, source, status, details, ranAt

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -96,7 +96,7 @@ export const adminProgramsQuery = `
   description,
   ${featuredBlockProjection},
   latestOfficialVersion,
-  "vendor": vendor->{ name, "slug": slug.current, "freeVsProDefaults": freeVsProDefaults },
+  "vendor": vendor->{ name, "slug": slug.current },
   seo,
   aboutSections,
   faq,
@@ -164,7 +164,7 @@ export const programBySlugQuery = `
   description,
   ${featuredBlockProjection},
   latestOfficialVersion,
-  "vendor": vendor->{ name, "slug": slug.current, "freeVsProDefaults": freeVsProDefaults },
+  "vendor": vendor->{ name, "slug": slug.current },
   seo,
   aboutSections,
   faq,
@@ -308,7 +308,7 @@ export const vendorBySlugQuery = `*[_type == "vendor" && slug.current == $slug][
   logo,
   logoBackgroundColor,
   seo,
-  freeVsProDefaults,
+  giveawayVsOfficial,
   "programs": *[_type == "program" && references(^._id)]{
     ${programsListingProjection}
   } | order(popularityScore desc, _createdAt desc)

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -290,6 +290,7 @@ export const vendorsWithCountsQuery = `*[_type == "vendor" && count(*[_type == "
   name,
   "slug": slug.current,
   logo,
+  logoBackgroundColor,
   "programCount": count(*[_type == "program" && references(^._id)])
 } | order(programCount desc, name asc)`;
 
@@ -305,6 +306,7 @@ export const vendorBySlugQuery = `*[_type == "vendor" && slug.current == $slug][
   "slug": slug.current,
   description,
   logo,
+  logoBackgroundColor,
   seo,
   freeVsProDefaults,
   "programs": *[_type == "program" && references(^._id)]{

--- a/src/lib/seo/breadcrumbs.ts
+++ b/src/lib/seo/breadcrumbs.ts
@@ -1,0 +1,48 @@
+import type { Crumb } from "@/src/components/layout/Breadcrumbs";
+import type { Program } from "@/src/types/program";
+
+type ProgramBreadcrumbSource = Pick<Program, "title" | "slug" | "vendor">;
+
+export function buildProgramBreadcrumbItems(program: Pick<Program, "title" | "vendor">): Crumb[] {
+  return [
+    { label: "Home", href: "/" },
+    { label: "Programs", href: "/programs" },
+    ...(program.vendor ? [{ label: program.vendor.name, href: `/vendors/${program.vendor.slug}` }] : []),
+    { label: program.title }
+  ];
+}
+
+export function buildVendorBreadcrumbItems(vendor: { name: string }): Crumb[] {
+  return [
+    { label: "Home", href: "/" },
+    { label: "Vendors", href: "/vendors" },
+    { label: vendor.name }
+  ];
+}
+
+/** BreadcrumbList block for program page JSON-LD — keep in sync with buildProgramBreadcrumbItems(). */
+export function buildProgramBreadcrumbJsonLd(program: ProgramBreadcrumbSource, base: string, pageUrl: string) {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: base },
+      { "@type": "ListItem", position: 2, name: "Programs", item: `${base}/programs` },
+      ...(program.vendor
+        ? [
+            {
+              "@type": "ListItem",
+              position: 3,
+              name: program.vendor.name,
+              item: `${base}/vendors/${program.vendor.slug}`
+            }
+          ]
+        : []),
+      {
+        "@type": "ListItem",
+        position: program.vendor ? 4 : 3,
+        name: program.title,
+        item: pageUrl
+      }
+    ]
+  };
+}

--- a/src/lib/seo/jsonLd.ts
+++ b/src/lib/seo/jsonLd.ts
@@ -10,6 +10,7 @@ import { urlFor } from "@/src/sanity/lib/image";
 import { cdKeyHasExpiry } from "@/src/lib/program/cdKeyUtils";
 import { buildSoftwareApplicationDescription, getSoftwareVersionForSchema } from "@/src/lib/program/versionSummary";
 import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
+import { buildProgramBreadcrumbJsonLd } from "@/src/lib/seo/breadcrumbs";
 import type { StoreSeo } from "@/src/types/layout";
 
 const BASE_URL = "https://www.keyaway.app";
@@ -186,29 +187,7 @@ export function generateProgramPageJsonLd(
             availability: "https://schema.org/InStock",
             description: offerDescGeneric
           },
-    breadcrumb: {
-      "@type": "BreadcrumbList",
-      itemListElement: [
-        { "@type": "ListItem", position: 1, name: "Home", item: base },
-        { "@type": "ListItem", position: 2, name: "Programs", item: `${base}/programs` },
-        ...(program.vendor
-          ? [
-              {
-                "@type": "ListItem",
-                position: 3,
-                name: program.vendor.name,
-                item: `${base}/vendors/${program.vendor.slug}`
-              }
-            ]
-          : []),
-        {
-          "@type": "ListItem",
-          position: program.vendor ? 4 : 3,
-          name: program.title,
-          item: pageUrl
-        }
-      ]
-    }
+    breadcrumb: buildProgramBreadcrumbJsonLd(program, base, pageUrl)
   };
 
   if (softwareVersion) {
@@ -355,6 +334,38 @@ export function generateVendorPageJsonLd(
         { "@type": "ListItem", position: 1, name: "Home", item: base },
         { "@type": "ListItem", position: 2, name: "Vendors", item: `${base}/vendors` },
         { "@type": "ListItem", position: 3, name: vendor.name, item: vendorUrl }
+      ]
+    }
+  };
+}
+
+// JSON-LD for /updates — ItemList of recent catalog changes (feeds from siteNotificationFeed).
+export function generateUpdatesPageJsonLd(
+  updates: Array<{ programTitle: string; programSlug: string; createdAt: string }>,
+  siteBaseUrl?: string
+) {
+  const base = (siteBaseUrl || BASE_URL).replace(/\/$/, "");
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Latest giveaway updates",
+    description: "Recently added programs and fresh CD keys on KeyAway.",
+    url: `${base}/updates`,
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: updates.length,
+      itemListElement: updates.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: item.programTitle,
+        item: `${base}/program/${item.programSlug}`
+      }))
+    },
+    breadcrumb: {
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: base },
+        { "@type": "ListItem", position: 2, name: "Updates", item: `${base}/updates` }
       ]
     }
   };

--- a/src/lib/seo/jsonLd.ts
+++ b/src/lib/seo/jsonLd.ts
@@ -122,9 +122,8 @@ export function generateProgramPageJsonLd(
   rating?: { ratingValue: number; ratingCount: number } | null
 ) {
   const base = resolveSiteBaseUrl(storeData.seo).replace(/\/$/, "");
-  // Extract brand from title (e.g., "IOBIT Malware Fighter" -> "IOBIT")
-  const brandMatch = program.title.match(/^([A-Za-z]+)/);
-  const brand = brandMatch ? brandMatch[1] : "Unknown";
+  // Prefer the linked vendor brand; fall back to the first word of the title for legacy docs.
+  const brand = program.vendor?.name || program.title.match(/^([A-Za-z]+)/)?.[1] || "Unknown";
 
   const pageUrl = `${base}/program/${program.slug.current}`;
   const appDescription = buildSoftwareApplicationDescription(program);
@@ -190,21 +189,21 @@ export function generateProgramPageJsonLd(
     breadcrumb: {
       "@type": "BreadcrumbList",
       itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: base },
+        { "@type": "ListItem", position: 2, name: "Programs", item: `${base}/programs` },
+        ...(program.vendor
+          ? [
+              {
+                "@type": "ListItem",
+                position: 3,
+                name: program.vendor.name,
+                item: `${base}/vendors/${program.vendor.slug}`
+              }
+            ]
+          : []),
         {
           "@type": "ListItem",
-          position: 1,
-          name: "Home",
-          item: base
-        },
-        {
-          "@type": "ListItem",
-          position: 2,
-          name: "Programs",
-          item: `${base}/programs`
-        },
-        {
-          "@type": "ListItem",
-          position: 3,
+          position: program.vendor ? 4 : 3,
           name: program.title,
           item: pageUrl
         }
@@ -266,6 +265,98 @@ export function generateProgramPageJsonLd(
   return {
     "@context": "https://schema.org",
     ...softwareApp
+  };
+}
+
+interface VendorLd {
+  name: string;
+  slug: string;
+  programCount?: number;
+}
+
+// JSON-LD for /vendors index — CollectionPage listing every vendor hub.
+export function generateVendorsPageJsonLd(
+  vendors: VendorLd[],
+  siteBaseUrl?: string
+) {
+  const base = (siteBaseUrl || BASE_URL).replace(/\/$/, "");
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Software Vendors",
+    description: "Browse software publishers with free promotional CD keys and giveaways.",
+    url: `${base}/vendors`,
+    mainEntity: {
+      "@type": "ItemList",
+      numberOfItems: vendors.length,
+      itemListElement: vendors.map((v, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: v.name,
+        item: `${base}/vendors/${v.slug}`
+      }))
+    },
+    breadcrumb: {
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: base },
+        { "@type": "ListItem", position: 2, name: "Vendors", item: `${base}/vendors` }
+      ]
+    }
+  };
+}
+
+// JSON-LD for /vendors/{slug} hub — CollectionPage of the vendor's programs.
+export function generateVendorPageJsonLd(
+  vendor: { name: string; slug: string; description?: string },
+  programs: Program[],
+  siteBaseUrl?: string
+) {
+  const base = (siteBaseUrl || BASE_URL).replace(/\/$/, "");
+  const vendorUrl = `${base}/vendors/${vendor.slug}`;
+  const items = programs.slice(0, 30).map((program, index) => ({
+    "@type": "ListItem",
+    position: index + 1,
+    item: {
+      "@type": "SoftwareApplication",
+      name: program.title,
+      url: `${base}/program/${program.slug.current}`,
+      image: program.image ? urlFor(program.image).width(400).height(400).url() : undefined,
+      applicationCategory: "SoftwareApplication",
+      operatingSystem: "Windows",
+      author: { "@type": "Organization", name: vendor.name },
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "USD",
+        availability: "https://schema.org/InStock",
+        description: "Free CD Key"
+      }
+    }
+  }));
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: `${vendor.name} — Free CD Keys & Giveaways`,
+    description:
+      vendor.description || `Free promotional CD keys and giveaways for ${vendor.name} software.`,
+    url: vendorUrl,
+    about: { "@type": "Organization", name: vendor.name },
+    mainEntity: {
+      "@type": "ItemList",
+      name: `${vendor.name} programs`,
+      numberOfItems: programs.length,
+      itemListElement: items
+    },
+    breadcrumb: {
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: base },
+        { "@type": "ListItem", position: 2, name: "Vendors", item: `${base}/vendors` },
+        { "@type": "ListItem", position: 3, name: vendor.name, item: vendorUrl }
+      ]
+    }
   };
 }
 

--- a/src/lib/seo/jsonLd.ts
+++ b/src/lib/seo/jsonLd.ts
@@ -42,7 +42,7 @@ export function generateHomePageJsonLd(storeData: {
       url: base,
       logo: {
         "@type": "ImageObject",
-        url: `${base}/images/KeyAway_Logo.png`,
+        url: `${base}/images/KeyAway_Icon_White.png`,
         width: 400,
         height: 400
       }
@@ -116,9 +116,10 @@ export function generateProgramsPageJsonLd(programs: Program[], totalCount: numb
 // JSON-LD for Individual Program Page - SoftwareApplication schema (+ optional FAQPage)
 export function generateProgramPageJsonLd(
   program: Program,
-  workingKeys: number,
+  _workingKeys: number,
   _totalKeys: number,
-  storeData: { title: string; seo?: StoreSeo }
+  storeData: { title: string; seo?: StoreSeo },
+  rating?: { ratingValue: number; ratingCount: number } | null
 ) {
   const base = resolveSiteBaseUrl(storeData.seo).replace(/\/$/, "");
   // Extract brand from title (e.g., "IOBIT Malware Fighter" -> "IOBIT")
@@ -171,7 +172,7 @@ export function generateProgramPageJsonLd(
       url: base,
       logo: {
         "@type": "ImageObject",
-        url: `${base}/images/KeyAway_Logo.png`,
+        url: `${base}/images/KeyAway_Icon_White.png`,
         width: 400,
         height: 400
       }
@@ -186,13 +187,6 @@ export function generateProgramPageJsonLd(
             availability: "https://schema.org/InStock",
             description: offerDescGeneric
           },
-    aggregateRating: {
-      "@type": "AggregateRating",
-      ratingValue: "4.5",
-      ratingCount: workingKeys || 1,
-      bestRating: "5",
-      worstRating: "1"
-    },
     breadcrumb: {
       "@type": "BreadcrumbList",
       itemListElement: [
@@ -220,6 +214,16 @@ export function generateProgramPageJsonLd(
 
   if (softwareVersion) {
     softwareApp.softwareVersion = softwareVersion;
+  }
+
+  if (rating && rating.ratingCount > 0) {
+    softwareApp.aggregateRating = {
+      "@type": "AggregateRating",
+      ratingValue: String(rating.ratingValue),
+      ratingCount: rating.ratingCount,
+      bestRating: "5",
+      worstRating: "1"
+    };
   }
 
   // Add image if available

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_STORE_NAME,
   buildStoreSeoVariableMap,
   resolveHomePageSeo,
+  resolveDefaultOgImageUrl,
   resolveMetaKeywordList,
   resolvePrivacyPageSeo,
   resolveProgramsPageSeo,
@@ -106,6 +107,9 @@ export async function generateProgramMetadata(slug: string): Promise<Metadata> {
     const baseUrl = resolveSiteBaseUrl(storeData?.seo);
     const url = `${baseUrl}/program/${slug}`;
     const programKeywords = resolveMetaKeywordList(program.seo?.metaKeywords, buildStoreSeoVariableMap(storeData));
+    const ogImageUrl = program.image
+      ? urlFor(program.image).width(1200).height(630).url()
+      : resolveDefaultOgImageUrl(storeData?.seo);
 
     return {
       title,
@@ -116,22 +120,20 @@ export async function generateProgramMetadata(slug: string): Promise<Metadata> {
         description,
         type: "website",
         url,
-        images: program.image
-          ? [
-              {
-                url: urlFor(program.image).width(1200).height(630).url(),
-                width: 1200,
-                height: 630,
-                alt: program.title
-              }
-            ]
-          : []
+        images: [
+          {
+            url: ogImageUrl,
+            width: 1200,
+            height: 630,
+            alt: program.title
+          }
+        ]
       },
       twitter: {
         card: "summary_large_image",
         title,
         description,
-        images: program.image ? [urlFor(program.image).width(1200).height(630).url()] : []
+        images: [ogImageUrl]
       },
       alternates: {
         canonical: url

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -247,6 +247,11 @@ export async function generatePartnersMetadata(): Promise<Metadata> {
   return generateTrustRouteMetadata(resolvePartnersPageSeo);
 }
 
+export async function generateUpdatesMetadata(): Promise<Metadata> {
+  const { resolveUpdatesPageSeo } = await import("@/src/lib/seo/trustPageSeo");
+  return generateTrustRouteMetadata(resolveUpdatesPageSeo);
+}
+
 export async function generateProgramsPageMetadata(): Promise<Metadata> {
   const storeData = await getCachedStoreDetailsDocument();
   const { title, description, pageUrl: url, ogImageUrl, storeTitle, keywords } =

--- a/src/lib/seo/storeSeoResolve.ts
+++ b/src/lib/seo/storeSeoResolve.ts
@@ -6,7 +6,7 @@ import type { StoreDetails } from "@/src/types/layout";
 
 export const DEFAULT_STORE_NAME = "KeyAway";
 export const DEFAULT_SITE_URL = "https://www.keyaway.app";
-export const DEFAULT_OG_IMAGE_URL = "https://www.keyaway.app/images/KeyAway_Card.png";
+export const DEFAULT_OG_IMAGE_URL = "https://www.keyaway.app/images/KeyAway_Showcase_Card.png";
 
 export type StoreDetailsForSeo = Partial<StoreDetails> & {
   title?: string;

--- a/src/lib/seo/trustPageSeo.ts
+++ b/src/lib/seo/trustPageSeo.ts
@@ -69,3 +69,12 @@ export function resolvePartnersPageSeo(store: StoreDetailsForSeo | null | undefi
     "Work with [title] on official software giveaways and promotional listings."
   );
 }
+
+export function resolveUpdatesPageSeo(store: StoreDetailsForSeo | null | undefined) {
+  return resolveTrustPageSeo(
+    store,
+    "/updates",
+    "Latest Updates | [title]",
+    "New programs and fresh giveaway keys added to [title] in the last 30 days — auto-updated from our catalog."
+  );
+}

--- a/src/lib/seo/trustPageSeo.ts
+++ b/src/lib/seo/trustPageSeo.ts
@@ -75,6 +75,6 @@ export function resolveUpdatesPageSeo(store: StoreDetailsForSeo | null | undefin
     store,
     "/updates",
     "Latest Updates | [title]",
-    "New programs and fresh giveaway keys added to [title] in the last 30 days — auto-updated from our catalog."
+    "New programs and fresh giveaway keys added to [title] in the last 90 days — auto-updated from our catalog."
   );
 }

--- a/src/lib/seo/vendorSeo.ts
+++ b/src/lib/seo/vendorSeo.ts
@@ -1,0 +1,47 @@
+import type { StoreDetailsForSeo } from "@/src/lib/seo/storeSeoResolve";
+import { buildStoreSeoVariableMap, resolveDefaultOgImageUrl, resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
+
+export interface VendorSeoInput {
+  name: string;
+  slug: string;
+  programCount?: number;
+  seo?: { metaTitle?: string; metaDescription?: string };
+}
+
+/** SEO for the /vendors index page. */
+export function resolveVendorsIndexSeo(store: StoreDetailsForSeo | null | undefined) {
+  const s = store ?? {};
+  const vars = buildStoreSeoVariableMap(s);
+  const siteUrl = resolveSiteBaseUrl(s.seo);
+  return {
+    title: `Software Vendors | ${vars.title}`,
+    description: `Browse software publishers on ${vars.title} — free promotional CD keys, giveaways, and PRO upgrade deals grouped by vendor.`,
+    pageUrl: `${siteUrl}/vendors`,
+    ogImageUrl: resolveDefaultOgImageUrl(s.seo),
+    storeTitle: vars.title,
+    siteUrl
+  };
+}
+
+/** SEO for a /vendors/{slug} hub page (vendor overrides win, else derived defaults). */
+export function resolveVendorHubSeo(store: StoreDetailsForSeo | null | undefined, vendor: VendorSeoInput) {
+  const s = store ?? {};
+  const vars = buildStoreSeoVariableMap(s);
+  const siteUrl = resolveSiteBaseUrl(s.seo);
+  const count = vendor.programCount ?? 0;
+  const countLabel = count > 0 ? `${count} program${count === 1 ? "" : "s"}` : "programs";
+
+  const title = vendor.seo?.metaTitle?.trim() || `${vendor.name} — Free CD Keys & Giveaways | ${vars.title}`;
+  const description =
+    vendor.seo?.metaDescription?.trim() ||
+    `Free ${vendor.name} promotional CD keys and giveaways on ${vars.title}. Browse ${countLabel}, verified community reports, and official PRO upgrade deals.`;
+
+  return {
+    title,
+    description,
+    pageUrl: `${siteUrl}/vendors/${vendor.slug}`,
+    ogImageUrl: resolveDefaultOgImageUrl(s.seo),
+    storeTitle: vars.title,
+    siteUrl
+  };
+}

--- a/src/lib/share/buildSharePayload.ts
+++ b/src/lib/share/buildSharePayload.ts
@@ -1,0 +1,102 @@
+export type ShareNetworkId = "facebook" | "twitter" | "telegram" | "pinterest" | "tumblr" | "linkedin";
+
+export const SHARE_TRACKING_KEYS: Record<ShareNetworkId, string> = {
+  facebook: "share-facebook",
+  twitter: "share-twitter",
+  telegram: "share-telegram",
+  pinterest: "share-pinterest",
+  tumblr: "share-tumblr",
+  linkedin: "share-linkedin"
+};
+
+export type ShareCounts = Partial<Record<ShareNetworkId, number>>;
+
+export interface SharePayloadInput {
+  pageUrl: string;
+  shareTitle: string;
+  shareText: string;
+  imageUrl?: string;
+}
+
+export interface ProgramShareInput {
+  programTitle: string;
+  programSlug: string;
+  pageUrl: string;
+  workingKeys?: number;
+  imageUrl?: string;
+}
+
+export function buildProgramShareInput(input: ProgramShareInput): SharePayloadInput {
+  const keys = input.workingKeys ?? 0;
+  const keyLine = keys > 0 ? `${keys} working giveaway key${keys === 1 ? "" : "s"}` : "free giveaway keys";
+
+  return {
+    pageUrl: input.pageUrl,
+    shareTitle: `${input.programTitle} — KeyAway`,
+    shareText: `Free ${input.programTitle} on KeyAway — ${keyLine}. Grab yours before they expire! #KeyAway #FreeSoftware`,
+    imageUrl: input.imageUrl
+  };
+}
+
+export function buildProgramsIndexShareInput(
+  pageUrl: string,
+  programCount: number,
+  totalKeys: number,
+  imageUrl?: string
+): SharePayloadInput {
+  const programLine = programCount > 0 ? `${programCount}+ programs` : "hundreds of programs";
+  const keyLine = totalKeys > 0 ? `${totalKeys}+ free giveaway keys` : "free giveaway CD keys";
+
+  return {
+    pageUrl,
+    shareTitle: "All Programs — KeyAway",
+    shareText: `Browse ${programLine} with ${keyLine} on KeyAway. #KeyAway #FreeSoftware`,
+    imageUrl
+  };
+}
+
+/** Generic page share — footer mini uses current URL + optional document title. */
+export function buildPageShareInput(pageUrl: string, documentTitle?: string): SharePayloadInput {
+  const cleanedTitle = documentTitle?.replace(/\s*[-|–]\s*KeyAway.*$/i, "").trim();
+  const label = cleanedTitle || "KeyAway";
+
+  return {
+    pageUrl,
+    shareTitle: `${label} — KeyAway`,
+    shareText:
+      label === "KeyAway"
+        ? "Free giveaway CD keys for PC software on KeyAway. #KeyAway #FreeSoftware"
+        : `Check out ${label} on KeyAway — free giveaway CD keys for PC software. #KeyAway #FreeSoftware`
+  };
+}
+
+/** @deprecated Use buildProgramShareInput — kept for call sites passing ProgramShareInput shape. */
+export function buildProgramShareText(input: ProgramShareInput): string {
+  return buildProgramShareInput(input).shareText;
+}
+
+export function buildShareUrl(network: ShareNetworkId, input: SharePayloadInput): string {
+  const encodedUrl = encodeURIComponent(input.pageUrl);
+  const encodedText = encodeURIComponent(input.shareText);
+  const encodedTitle = encodeURIComponent(input.shareTitle);
+
+  switch (network) {
+    case "facebook":
+      return `https://www.facebook.com/sharer.php?u=${encodedUrl}`;
+    case "twitter":
+      return `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodedText}`;
+    case "telegram":
+      return `https://t.me/share/url?url=${encodedUrl}&text=${encodedText}`;
+    case "linkedin":
+      return `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`;
+    case "pinterest": {
+      let url = `https://pinterest.com/pin/create/button/?url=${encodedUrl}&description=${encodedText}`;
+      if (input.imageUrl) url += `&media=${encodeURIComponent(input.imageUrl)}`;
+      return url;
+    }
+    case "tumblr":
+      return `https://www.tumblr.com/widgets/share/tool?posttype=link&title=${encodedTitle}&caption=${encodedText}&content=${encodedUrl}&canonicalUrl=${encodedUrl}`;
+    default:
+      return input.pageUrl;
+  }
+}

--- a/src/lib/share/getPageShareCounts.ts
+++ b/src/lib/share/getPageShareCounts.ts
@@ -1,0 +1,23 @@
+import { cache } from "react";
+import { TAG_SITEMAP_URLS } from "@/src/lib/cache/cacheTags";
+import { client } from "@/src/sanity/lib/client";
+import { pageShareCountsQuery } from "@/src/lib/sanity/queries";
+import type { ShareCounts, ShareNetworkId } from "@/src/lib/share/buildSharePayload";
+
+/** Aggregate share-click counts per network for a path (singular trackingEvent rows). */
+export const getPageShareCounts = cache(async (path: string): Promise<ShareCounts> => {
+  const row = await client.fetch<Record<string, number> | null>(
+    pageShareCountsQuery,
+    { path },
+    { next: { tags: [TAG_SITEMAP_URLS] } }
+  );
+  if (!row) return {};
+
+  const out: ShareCounts = {};
+  for (const [key, value] of Object.entries(row)) {
+    if (typeof value === "number" && value > 0) {
+      out[key as ShareNetworkId] = value;
+    }
+  }
+  return out;
+});

--- a/src/lib/vendors/getVendors.ts
+++ b/src/lib/vendors/getVendors.ts
@@ -4,9 +4,9 @@ import { client } from "@/src/sanity/lib/client";
 import { vendorBySlugQuery, vendorSlugsQuery, vendorsWithCountsQuery } from "@/src/lib/sanity/queries";
 import { mergeProgramStats } from "@/src/lib/analytics/eventsApi";
 import type { ProgramWithStats } from "@/src/types/home";
-import type { FreeVsProRow } from "@/src/types/program";
+import type { FreeVsProRow, SanityImageField } from "@/src/types/program";
 import type { PortableTextBlock } from "@portabletext/types";
-import type { SanityImageField } from "@/src/types/program";
+import type { VendorLogoBackgroundColor } from "@/src/lib/vendors/resolveVendorLogoBackgroundColor";
 
 const VENDOR_TAGS = { next: { tags: [TAG_VENDORS, TAG_PROGRAM_LISTINGS] } };
 
@@ -15,6 +15,7 @@ export interface VendorListItem {
   name: string;
   slug: string;
   logo?: SanityImageField;
+  logoBackgroundColor?: VendorLogoBackgroundColor | null;
   programCount: number;
 }
 
@@ -24,6 +25,7 @@ export interface VendorHub {
   slug: string;
   description?: PortableTextBlock[] | string | null;
   logo?: SanityImageField;
+  logoBackgroundColor?: VendorLogoBackgroundColor | null;
   seo?: { metaTitle?: string; metaDescription?: string };
   freeVsProDefaults?: FreeVsProRow[] | null;
   programs: ProgramWithStats[];

--- a/src/lib/vendors/getVendors.ts
+++ b/src/lib/vendors/getVendors.ts
@@ -4,9 +4,10 @@ import { client } from "@/src/sanity/lib/client";
 import { vendorBySlugQuery, vendorSlugsQuery, vendorsWithCountsQuery } from "@/src/lib/sanity/queries";
 import { mergeProgramStats } from "@/src/lib/analytics/eventsApi";
 import type { ProgramWithStats } from "@/src/types/home";
-import type { FreeVsProRow, SanityImageField } from "@/src/types/program";
+import type { GiveawayComparisonRow } from "@/src/types/program";
 import type { PortableTextBlock } from "@portabletext/types";
 import type { VendorLogoBackgroundColor } from "@/src/lib/vendors/resolveVendorLogoBackgroundColor";
+import { SanityImageSource } from "@sanity/asset-utils";
 
 const VENDOR_TAGS = { next: { tags: [TAG_VENDORS, TAG_PROGRAM_LISTINGS] } };
 
@@ -14,7 +15,7 @@ export interface VendorListItem {
   _id: string;
   name: string;
   slug: string;
-  logo?: SanityImageField;
+  logo?: SanityImageSource;
   logoBackgroundColor?: VendorLogoBackgroundColor | null;
   programCount: number;
 }
@@ -24,10 +25,10 @@ export interface VendorHub {
   name: string;
   slug: string;
   description?: PortableTextBlock[] | string | null;
-  logo?: SanityImageField;
+  logo?: SanityImageSource;
   logoBackgroundColor?: VendorLogoBackgroundColor | null;
   seo?: { metaTitle?: string; metaDescription?: string };
-  freeVsProDefaults?: FreeVsProRow[] | null;
+  giveawayVsOfficial?: GiveawayComparisonRow[] | null;
   programs: ProgramWithStats[];
 }
 

--- a/src/lib/vendors/getVendors.ts
+++ b/src/lib/vendors/getVendors.ts
@@ -1,0 +1,52 @@
+import { cache } from "react";
+import { TAG_PROGRAM_LISTINGS, TAG_VENDORS } from "@/src/lib/cache/cacheTags";
+import { client } from "@/src/sanity/lib/client";
+import { vendorBySlugQuery, vendorSlugsQuery, vendorsWithCountsQuery } from "@/src/lib/sanity/queries";
+import { mergeProgramStats } from "@/src/lib/analytics/eventsApi";
+import type { ProgramWithStats } from "@/src/types/home";
+import type { FreeVsProRow } from "@/src/types/program";
+import type { PortableTextBlock } from "@portabletext/types";
+import type { SanityImageField } from "@/src/types/program";
+
+const VENDOR_TAGS = { next: { tags: [TAG_VENDORS, TAG_PROGRAM_LISTINGS] } };
+
+export interface VendorListItem {
+  _id: string;
+  name: string;
+  slug: string;
+  logo?: SanityImageField;
+  programCount: number;
+}
+
+export interface VendorHub {
+  _id: string;
+  name: string;
+  slug: string;
+  description?: PortableTextBlock[] | string | null;
+  logo?: SanityImageField;
+  seo?: { metaTitle?: string; metaDescription?: string };
+  freeVsProDefaults?: FreeVsProRow[] | null;
+  programs: ProgramWithStats[];
+}
+
+/** All vendors that have at least one program, with counts. Popularity/name sorted. */
+export const getCachedVendorsWithCounts = cache(async (): Promise<VendorListItem[]> => {
+  const rows = await client.fetch<VendorListItem[]>(vendorsWithCountsQuery, {}, VENDOR_TAGS);
+  return rows ?? [];
+});
+
+/** Slugs of vendors worth indexing (have programs) — for generateStaticParams + sitemap. */
+export const getCachedVendorSlugs = cache(async (): Promise<string[]> => {
+  const rows = await client.fetch<{ slug: string }[]>(vendorSlugsQuery, {}, VENDOR_TAGS);
+  return (rows ?? []).map(r => r.slug).filter(Boolean);
+});
+
+/** A single vendor hub with its programs (stats merged), or null. */
+export const getVendorBySlug = cache(async (slug: string): Promise<VendorHub | null> => {
+  const vendor = await client.fetch<VendorHub | null>(vendorBySlugQuery, { slug }, VENDOR_TAGS);
+  if (!vendor) return null;
+  return {
+    ...vendor,
+    programs: mergeProgramStats((vendor.programs ?? []) as ProgramWithStats[])
+  };
+});

--- a/src/lib/vendors/resolveVendorLogoBackgroundColor.ts
+++ b/src/lib/vendors/resolveVendorLogoBackgroundColor.ts
@@ -1,0 +1,30 @@
+/** Shape stored by `@sanity/color-input` on vendor.logoBackgroundColor. */
+export type VendorLogoBackgroundColor = {
+  _type?: "color";
+  hex?: string;
+  alpha?: number;
+  rgb?: { r: number; g: number; b: number; a?: number };
+};
+
+/** CSS color for vendor logo tile background; undefined = transparent. */
+export function resolveVendorLogoBackgroundColor(
+  color?: VendorLogoBackgroundColor | null
+): string | undefined {
+  if (!color) return undefined;
+
+  if (color.hex) {
+    const alpha = color.alpha ?? color.rgb?.a;
+    if (typeof alpha === "number" && alpha < 1 && color.rgb) {
+      const { r, g, b } = color.rgb;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+    return color.hex;
+  }
+
+  if (color.rgb) {
+    const { r, g, b, a = 1 } = color.rgb;
+    return a < 1 ? `rgba(${r}, ${g}, ${b}, ${a})` : `rgb(${r}, ${g}, ${b})`;
+  }
+
+  return undefined;
+}

--- a/src/sanity/inputs/VendorProgramsInput.tsx
+++ b/src/sanity/inputs/VendorProgramsInput.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { AddIcon, TrashIcon } from "@sanity/icons";
 import { Box, Button, Card, Flex, Select, Spinner, Stack, Text } from "@sanity/ui";
-import { useClient } from "sanity";
+import { useClient, useFormValue } from "sanity";
 import type { StringInputProps } from "sanity";
 import { apiVersion } from "@/src/sanity/env";
 
@@ -17,8 +17,9 @@ function canonicalDocumentId(id: string | undefined): string | null {
   return id.replace(/^drafts\./, "");
 }
 
-export function VendorProgramsInput(props: StringInputProps) {
-  const vendorRefId = canonicalDocumentId(props.document?._id as string | undefined);
+export function VendorProgramsInput(_props: StringInputProps) {
+  const documentId = useFormValue(["_id"]) as string | undefined;
+  const vendorRefId = canonicalDocumentId(documentId);
   const client = useClient({ apiVersion });
 
   const [assigned, setAssigned] = useState<ProgramRow[]>([]);

--- a/src/sanity/inputs/VendorProgramsInput.tsx
+++ b/src/sanity/inputs/VendorProgramsInput.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { AddIcon, TrashIcon } from "@sanity/icons";
+import { Box, Button, Card, Flex, Select, Spinner, Stack, Text } from "@sanity/ui";
+import { useClient } from "sanity";
+import type { StringInputProps } from "sanity";
+import { apiVersion } from "@/src/sanity/env";
+
+type ProgramRow = {
+  _id: string;
+  title: string;
+};
+
+function canonicalDocumentId(id: string | undefined): string | null {
+  if (!id) return null;
+  return id.replace(/^drafts\./, "");
+}
+
+export function VendorProgramsInput(props: StringInputProps) {
+  const vendorRefId = canonicalDocumentId(props.document?._id as string | undefined);
+  const client = useClient({ apiVersion });
+
+  const [assigned, setAssigned] = useState<ProgramRow[]>([]);
+  const [unassigned, setUnassigned] = useState<ProgramRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedProgramId, setSelectedProgramId] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!vendorRefId) {
+      setAssigned([]);
+      setUnassigned([]);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const [assignedRows, unassignedRows] = await Promise.all([
+        client.fetch<ProgramRow[]>(
+          `*[_type == "program" && vendor._ref == $vendorId] | order(title asc) { _id, title }`,
+          { vendorId: vendorRefId }
+        ),
+        client.fetch<ProgramRow[]>(
+          `*[_type == "program" && !defined(vendor)] | order(title asc) { _id, title }`
+        )
+      ]);
+      setAssigned(assignedRows ?? []);
+      setUnassigned(unassignedRows ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load programs");
+    } finally {
+      setLoading(false);
+    }
+  }, [client, vendorRefId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const addProgram = async () => {
+    if (!vendorRefId || !selectedProgramId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await client
+        .patch(selectedProgramId)
+        .set({
+          vendor: { _type: "reference", _ref: vendorRefId }
+        })
+        .commit();
+      setSelectedProgramId("");
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to assign program");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const removeProgram = async (programId: string) => {
+    if (!vendorRefId) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await client.patch(programId).unset(["vendor"]).commit();
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to remove program");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!vendorRefId) {
+    return (
+      <Card padding={3} radius={2} tone="transparent" border>
+        <Text muted size={1}>
+          Save this vendor first, then assign programs here.
+        </Text>
+      </Card>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Flex align="center" gap={2} padding={2}>
+        <Spinner muted />
+        <Text muted size={1}>
+          Loading programs…
+        </Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Stack space={3}>
+      <Text muted size={1}>
+        Assignments are stored on each program&apos;s <strong>Vendor</strong> field. Only programs without a vendor
+        appear in the add list.
+      </Text>
+
+      {error ? (
+        <Card padding={3} radius={2} tone="critical" border>
+          <Text size={1}>{error}</Text>
+        </Card>
+      ) : null}
+
+      <Card padding={3} radius={2} border>
+        <Stack space={3}>
+          <Text weight="semibold" size={1}>
+            Assigned programs ({assigned.length})
+          </Text>
+
+          {assigned.length === 0 ? (
+            <Text muted size={1}>
+              No programs linked yet.
+            </Text>
+          ) : (
+            <Stack space={2}>
+              {assigned.map(program => (
+                <Flex key={program._id} align="center" justify="space-between" gap={3}>
+                  <Text size={1}>{program.title}</Text>
+                  <Button
+                    icon={TrashIcon}
+                    mode="bleed"
+                    tone="critical"
+                    text="Remove"
+                    disabled={busy}
+                    onClick={() => void removeProgram(program._id)}
+                  />
+                </Flex>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+      </Card>
+
+      <Card padding={3} radius={2} border>
+        <Stack space={3}>
+          <Text weight="semibold" size={1}>
+            Add program
+          </Text>
+
+          {unassigned.length === 0 ? (
+            <Text muted size={1}>
+              No unassigned programs available.
+            </Text>
+          ) : (
+            <Flex gap={2} wrap="wrap">
+              <Box flex={1} style={{ minWidth: "12rem" }}>
+                <Select
+                  fontSize={2}
+                  value={selectedProgramId}
+                  disabled={busy}
+                  onChange={event => setSelectedProgramId(event.currentTarget.value)}>
+                  <option value="">Select a program…</option>
+                  {unassigned.map(program => (
+                    <option key={program._id} value={program._id}>
+                      {program.title}
+                    </option>
+                  ))}
+                </Select>
+              </Box>
+              <Button
+                icon={AddIcon}
+                text="Add"
+                tone="primary"
+                disabled={busy || !selectedProgramId}
+                onClick={() => void addProgram()}
+              />
+            </Flex>
+          )}
+        </Stack>
+      </Card>
+    </Stack>
+  );
+}

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -26,6 +26,7 @@ import { featuredProgramSettings } from "./program/featuredProgramSettings";
 import { freeVsProRow } from "./program/freeVsProRow";
 
 import { vendor } from "./vendor/vendor";
+import { giveawayComparisonRow } from "./vendor/giveawayComparisonRow";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
   types: [
@@ -52,6 +53,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     cdKey,
     featuredProgramSettings,
     freeVsProRow,
+    giveawayComparisonRow,
     vendor,
     visitor
   ]

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -23,6 +23,9 @@ import { programComment, programCommentReply } from "./program/programComment";
 import { faqItem, program } from "./program/program";
 import { cdKey } from "./program/cdKey";
 import { featuredProgramSettings } from "./program/featuredProgramSettings";
+import { freeVsProRow } from "./program/freeVsProRow";
+
+import { vendor } from "./vendor/vendor";
 
 export const schema: { types: SchemaTypeDefinition[] } = {
   types: [
@@ -48,6 +51,8 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     program,
     cdKey,
     featuredProgramSettings,
+    freeVsProRow,
+    vendor,
     visitor
   ]
 };

--- a/src/sanity/schemaTypes/program/freeVsProRow.ts
+++ b/src/sanity/schemaTypes/program/freeVsProRow.ts
@@ -1,9 +1,17 @@
 import { defineField, defineType } from "sanity";
 
-/** Shared comparison row used by `vendor.freeVsProDefaults` and `program.freeVsProComparison`. */
+/**
+ * Per-program "Free vs Official PRO" feature comparison row.
+ * Used by `program.freeVsProComparison` to show what the free edition offers
+ * versus the paid official PRO license (an SEO-friendly feature table).
+ *
+ * NOTE: this is the classic feature comparison. The giveaway-key caveats
+ * (temporary, version-locked, activation-capped) live separately on the
+ * vendor as `giveawayVsOfficial` (see `giveawayComparisonRow`).
+ */
 export const freeVsProRow = defineType({
   name: "freeVsProRow",
-  title: "Free vs PRO row",
+  title: "Free vs Official PRO row",
   type: "object",
   fields: [
     defineField({
@@ -15,15 +23,15 @@ export const freeVsProRow = defineType({
     }),
     defineField({
       name: "free",
-      title: "Free / Giveaway",
+      title: "Free",
       type: "string",
-      description: 'e.g. "Manual only".'
+      description: 'What the free edition offers, e.g. "Manual only".'
     }),
     defineField({
       name: "pro",
-      title: "PRO",
+      title: "Official PRO",
       type: "string",
-      description: 'e.g. "Automatic & background".'
+      description: 'What the paid PRO license adds, e.g. "Automatic & background".'
     })
   ],
   preview: {

--- a/src/sanity/schemaTypes/program/freeVsProRow.ts
+++ b/src/sanity/schemaTypes/program/freeVsProRow.ts
@@ -1,0 +1,38 @@
+import { defineField, defineType } from "sanity";
+
+/** Shared comparison row used by `vendor.freeVsProDefaults` and `program.freeVsProComparison`. */
+export const freeVsProRow = defineType({
+  name: "freeVsProRow",
+  title: "Free vs PRO row",
+  type: "object",
+  fields: [
+    defineField({
+      name: "feature",
+      title: "Feature",
+      type: "string",
+      description: 'e.g. "Updates", "Speed", "Support".',
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "free",
+      title: "Free / Giveaway",
+      type: "string",
+      description: 'e.g. "Manual only".'
+    }),
+    defineField({
+      name: "pro",
+      title: "PRO",
+      type: "string",
+      description: 'e.g. "Automatic & background".'
+    })
+  ],
+  preview: {
+    select: { title: "feature", free: "free", pro: "pro" },
+    prepare({ title, free, pro }) {
+      return {
+        title: title || "Row",
+        subtitle: [free, pro].filter(Boolean).join("  →  ") || undefined
+      };
+    }
+  }
+});

--- a/src/sanity/schemaTypes/program/program.ts
+++ b/src/sanity/schemaTypes/program/program.ts
@@ -65,6 +65,14 @@ export const program = defineType({
       validation: Rule => Rule.required()
     }),
     defineField({
+      name: "vendor",
+      title: "Vendor",
+      type: "reference",
+      to: [{ type: "vendor" }],
+      description: "Software publisher/brand. Powers /vendors/{slug} hubs, breadcrumbs, brand structured data, and vendor filtering.",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
       name: "programFlow",
       title: "Activation flow",
       type: "string",

--- a/src/sanity/schemaTypes/program/program.ts
+++ b/src/sanity/schemaTypes/program/program.ts
@@ -136,11 +136,11 @@ export const program = defineType({
     }),
     defineField({
       name: "freeVsProComparison",
-      title: "Free vs PRO comparison",
+      title: "Free vs Official PRO comparison",
       type: "array",
       of: [{ type: "freeVsProRow" }],
       description:
-        "Optional per-program comparison table. When empty, rows from the linked vendor's Free vs PRO defaults are used instead."
+        "Per-program feature table: what the free edition offers vs the paid official PRO license. Shown on the program page as an SEO section."
     }),
     defineField({
       name: "seo",

--- a/src/sanity/schemaTypes/program/program.ts
+++ b/src/sanity/schemaTypes/program/program.ts
@@ -135,6 +135,14 @@ export const program = defineType({
       ]
     }),
     defineField({
+      name: "freeVsProComparison",
+      title: "Free vs PRO comparison",
+      type: "array",
+      of: [{ type: "freeVsProRow" }],
+      description:
+        "Optional per-program comparison table. When empty, rows from the linked vendor's Free vs PRO defaults are used instead."
+    }),
+    defineField({
       name: "seo",
       title: "SEO",
       type: "object",

--- a/src/sanity/schemaTypes/system/siteNotificationFeed.ts
+++ b/src/sanity/schemaTypes/system/siteNotificationFeed.ts
@@ -22,19 +22,47 @@ const feedItemFields = [
   defineField({ name: "imageUrl", type: "string" })
 ];
 
-/** Single document (`_id` fixed in app). Populated by `rebuildSiteNotificationFeed()` — see README / `notificationFeed.server.ts`. */
+/** Append-only feed snapshots — each rebuild creates a new document when content changes. */
 export const siteNotificationFeed = defineType({
   name: "siteNotificationFeed",
   title: "Site notification feed",
   type: "document",
   fields: [
     defineField({
+      name: "generatedAt",
+      title: "Generated at",
+      type: "datetime",
+      description: "When this snapshot was built (webhook/admin rebuild).",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "windowDays",
+      title: "Activity window (days)",
+      type: "number",
+      description: "Program/key activity window used for this snapshot.",
+      initialValue: 30,
+      validation: Rule => Rule.min(1).max(365)
+    }),
+    defineField({
       name: "items",
       title: "Notifications",
       type: "array",
-      description: "Do not hand-edit for production: webhook/admin rebuild. Capped in code (see MAX_ITEMS).",
+      description: "Capped list snapshot — do not hand-edit in production.",
       validation: Rule => Rule.max(50),
       of: [{ type: "object", fields: feedItemFields }]
     })
-  ]
+  ],
+  preview: {
+    select: {
+      generatedAt: "generatedAt",
+      count: "items"
+    },
+    prepare({ generatedAt, count }) {
+      const n = Array.isArray(count) ? count.length : 0;
+      return {
+        title: generatedAt ? `Feed snapshot` : "Feed snapshot",
+        subtitle: `${n} notification${n === 1 ? "" : "s"}`
+      };
+    }
+  }
 });

--- a/src/sanity/schemaTypes/vendor/giveawayComparisonRow.ts
+++ b/src/sanity/schemaTypes/vendor/giveawayComparisonRow.ts
@@ -1,0 +1,48 @@
+import { defineField, defineType } from "sanity";
+
+/**
+ * Vendor-level "Giveaway key vs Official PRO license" row.
+ *
+ * A giveaway CD key unlocks the *real* PRO version temporarily, so this is NOT
+ * "free tier vs paid features" — it honestly compares the two ways to run PRO:
+ * a community giveaway key (temporary, version-locked, activation-capped) vs an
+ * official license (permanent for its term, latest version, updates, support).
+ *
+ * Lives on the vendor (`vendor.giveawayVsOfficial`) and is shown on the vendor
+ * hub, since the caveats are the same for every product from that vendor.
+ */
+export const giveawayComparisonRow = defineType({
+  name: "giveawayComparisonRow",
+  title: "Giveaway vs Official PRO row",
+  type: "object",
+  fields: [
+    defineField({
+      name: "feature",
+      title: "Aspect",
+      type: "string",
+      description: 'What is being compared, e.g. "Auto-updates", "How long it lasts", "Activation slots".',
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "giveaway",
+      title: "Giveaway key",
+      type: "string",
+      description: 'The community giveaway route, e.g. "Temporary — expires after the promo".'
+    }),
+    defineField({
+      name: "officialPro",
+      title: "Official PRO license",
+      type: "string",
+      description: 'The paid official route, e.g. "Full license term with updates".'
+    })
+  ],
+  preview: {
+    select: { title: "feature", giveaway: "giveaway", officialPro: "officialPro" },
+    prepare({ title, giveaway, officialPro }) {
+      return {
+        title: title || "Row",
+        subtitle: [giveaway, officialPro].filter(Boolean).join("  →  ") || undefined
+      };
+    }
+  }
+});

--- a/src/sanity/schemaTypes/vendor/vendor.ts
+++ b/src/sanity/schemaTypes/vendor/vendor.ts
@@ -1,0 +1,75 @@
+import { defineField, defineType } from "sanity";
+
+const MAX_META_TITLE = 70;
+const MAX_META_DESC = 160;
+
+export const vendor = defineType({
+  name: "vendor",
+  title: "Vendor",
+  type: "document",
+  fields: [
+    defineField({
+      name: "name",
+      title: "Name",
+      type: "string",
+      description: "Software publisher / brand shown on the hub page (e.g. IObit, iTop).",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "slug",
+      title: "Slug",
+      type: "slug",
+      description: "URL segment: /vendors/{slug}.",
+      options: { source: "name" },
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "description",
+      title: "Description",
+      type: "array",
+      of: [{ type: "block" }],
+      description: "Intro copy shown on the /vendors/{slug} hub page."
+    }),
+    defineField({
+      name: "logo",
+      title: "Logo",
+      type: "image",
+      options: { hotspot: true }
+    }),
+    defineField({
+      name: "seo",
+      title: "SEO",
+      type: "object",
+      options: { collapsible: true, collapsed: true },
+      description: "Optional search metadata overrides for this vendor hub page.",
+      fields: [
+        defineField({
+          name: "metaTitle",
+          title: "Meta title override",
+          type: "string",
+          validation: Rule =>
+            Rule.max(MAX_META_TITLE).warning(`Prefer ${MAX_META_TITLE} characters or fewer for Google display.`)
+        }),
+        defineField({
+          name: "metaDescription",
+          title: "Meta description override",
+          type: "text",
+          rows: 3,
+          validation: Rule =>
+            Rule.max(MAX_META_DESC).warning(`Prefer ${MAX_META_DESC} characters or fewer for Google snippets.`)
+        })
+      ]
+    }),
+    defineField({
+      name: "freeVsProDefaults",
+      title: "Free vs PRO defaults",
+      type: "array",
+      of: [{ type: "freeVsProRow" }],
+      description:
+        "Reusable comparison rows applied to this vendor's programs when a program has no rows of its own (e.g. Updates: Manual → Automatic)."
+    })
+  ],
+  preview: {
+    select: { title: "name", media: "logo" }
+  }
+});

--- a/src/sanity/schemaTypes/vendor/vendor.ts
+++ b/src/sanity/schemaTypes/vendor/vendor.ts
@@ -1,4 +1,5 @@
 import { defineField, defineType } from "sanity";
+import { VendorProgramsInput } from "@/src/sanity/inputs/VendorProgramsInput";
 
 const MAX_META_TITLE = 70;
 const MAX_META_DESC = 160;
@@ -35,6 +36,22 @@ export const vendor = defineType({
       title: "Logo",
       type: "image",
       options: { hotspot: true }
+    }),
+    defineField({
+      name: "logoBackgroundColor",
+      title: "Logo background color",
+      type: "color",
+      description: "Optional tile background behind transparent logos. Leave unset for a transparent background.",
+      options: { disableAlpha: false },
+      hidden: ({ document }) => !document?.logo
+    }),
+    defineField({
+      name: "assignedProgramsUi",
+      title: "Programs",
+      type: "string",
+      description: "Manage which programs belong to this vendor. Changes update each program's Vendor reference.",
+      components: { input: VendorProgramsInput },
+      hidden: ({ document }) => !document?._id
     }),
     defineField({
       name: "seo",

--- a/src/sanity/schemaTypes/vendor/vendor.ts
+++ b/src/sanity/schemaTypes/vendor/vendor.ts
@@ -78,12 +78,12 @@ export const vendor = defineType({
       ]
     }),
     defineField({
-      name: "freeVsProDefaults",
-      title: "Free vs PRO defaults",
+      name: "giveawayVsOfficial",
+      title: "Giveaway key vs Official PRO",
       type: "array",
-      of: [{ type: "freeVsProRow" }],
+      of: [{ type: "giveawayComparisonRow" }],
       description:
-        "Reusable comparison rows applied to this vendor's programs when a program has no rows of its own (e.g. Updates: Manual → Automatic)."
+        "Honest comparison of a community giveaway key (temporary, version-locked, activation-capped) vs an official PRO license. Shown on this vendor's hub page. Applies to every program from this vendor — no per-program overrides."
     })
   ],
   preview: {

--- a/src/types/home/index.ts
+++ b/src/types/home/index.ts
@@ -22,8 +22,11 @@ export interface ProgramCardProps {
   showStats?: boolean;
 }
 
+import type { VendorListItem } from "@/src/lib/vendors/getVendors";
+
 export interface PopularProgramsSectionProps {
   programs: ProgramWithStats[];
+  vendors?: VendorListItem[];
 }
 
 // Section props can be added here when needed

--- a/src/types/layout/index.ts
+++ b/src/types/layout/index.ts
@@ -94,6 +94,7 @@ export interface HeaderProps {
 export interface FooterProps {
   logoData: LogoData;
   socialData: SocialData;
+  siteBaseUrl: string;
 }
 
 export interface MobileMenuProps {

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -83,18 +83,30 @@ export interface ProgramFeatured {
   showcaseGif?: SanityImageField;
 }
 
-/** One Free-vs-PRO comparison row (vendor default or program override). */
+/** One per-program "Free vs Official PRO" feature-comparison row. */
 export interface FreeVsProRow {
+  /** The feature being compared, e.g. "Updates". */
   feature: string;
+  /** What the free edition offers. */
   free?: string;
+  /** What the paid official PRO license adds. */
   pro?: string;
 }
 
-/** Vendor reference resolved on a program (name + slug, plus optional inherited comparison rows). */
+/** One vendor-level "Giveaway key vs Official PRO license" row. */
+export interface GiveawayComparisonRow {
+  /** The aspect being compared, e.g. "Auto-updates". */
+  feature: string;
+  /** The community giveaway-key route. */
+  giveaway?: string;
+  /** The paid official PRO license route. */
+  officialPro?: string;
+}
+
+/** Vendor reference resolved on a program (name + slug). */
 export interface VendorRef {
   name: string;
   slug: string;
-  freeVsProDefaults?: FreeVsProRow[] | null;
 }
 
 export interface Program {
@@ -123,7 +135,7 @@ export interface Program {
     affiliateProUrl?: string;
     affiliateProLabel?: string;
   };
-  /** Per-program Free vs PRO rows; falls back to vendor.freeVsProDefaults when empty. */
+  /** Per-program Free vs Official PRO feature-comparison rows. */
   freeVsProComparison?: FreeVsProRow[] | null;
   programComments?: ProgramComment[];
   cdKeys: CDKey[];

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -83,6 +83,20 @@ export interface ProgramFeatured {
   showcaseGif?: SanityImageField;
 }
 
+/** One Free-vs-PRO comparison row (vendor default or program override). */
+export interface FreeVsProRow {
+  feature: string;
+  free?: string;
+  pro?: string;
+}
+
+/** Vendor reference resolved on a program (name + slug, plus optional inherited comparison rows). */
+export interface VendorRef {
+  name: string;
+  slug: string;
+  freeVsProDefaults?: FreeVsProRow[] | null;
+}
+
 export interface Program {
   _id: string;
   title: string;
@@ -91,6 +105,8 @@ export interface Program {
   programFlow?: ProgramFlow;
   description: PortableTextBlock[] | string;
   featured?: ProgramFeatured;
+  /** Resolved software publisher/brand. Null on legacy docs not yet backfilled. */
+  vendor?: VendorRef | null;
   /** Vendor-reported current version (e.g. from product page). */
   latestOfficialVersion?: string;
   seo?: {

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -169,6 +169,7 @@ export interface ProgramInformationProps {
   workingKeys: number;
   socialData?: SocialData;
   visitorHint?: VisitorHintData | null;
+  communityRating?: { ratingValue: number; ratingCount: number; successPercent: number } | null;
 }
 
 export interface ProgramPageProps {

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -123,6 +123,8 @@ export interface Program {
     affiliateProUrl?: string;
     affiliateProLabel?: string;
   };
+  /** Per-program Free vs PRO rows; falls back to vendor.freeVsProDefaults when empty. */
+  freeVsProComparison?: FreeVsProRow[] | null;
   programComments?: ProgramComment[];
   cdKeys: CDKey[];
   keyCount?: number;


### PR DESCRIPTION
## Summary

KeyAway grows into a more partner-ready hub: vendor index pages, shareable program links, a public updates feed, and richer JSON-LD across the site.

## Changelog

<!-- tags: feat, ui, api, enhance -->

### Highlights

- Vendor directory and vendor detail hubs with comparison tables
- Program social share components with click tracking
- Auto-generated /updates feed from catalog activity

### Discovery & trust

- /vendors and /vendors/[slug] hubs with vendor schema, logo tiles, and Studio program picker
- Free vs Official PRO and Giveaway key vs Official PRO comparison tables
- Breadcrumb trails, JSON-LD, dynamic robots/sitemap, report-based aggregate ratings, 404 noindex

### Sharing & activity

- Share bar on program and /programs pages, footer mini-share
- /updates auto-feed from siteNotificationFeed, paginated, linked from announcements dropdown
- Analytics skip events for logged-in admin sessions

---

## Environment Variables

None

## Testing

- Vendor hubs render tables/logos; program pages show Free vs PRO
- Share counts increment; /updates paginates
- Verify JSON-LD via Rich Results; admin sessions produce no analytics events

## Technical Details

New Sanity types: vendor, freeVsProRow, giveawayComparisonRow; extended siteNotificationFeed and program schemas.
