### PR TITLE
feat(admin): contact reply email, visitor moderation, and seo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ ADMIN_ALLOWED_EMAILS=you@example.com        # Or use Sanity Access (SANITY_ACCES
 # Optional
 CRON_SECRET=yourCronSecret                   # Cron routes (e.g. update-expired-keys)
 ANALYTICS_SALT=yourRandomSalt                # IP hashing for analytics
+
+# Outbound email (admin message replies via Resend)
+RESEND_API_KEY=re_xxxxxxxx                   # https://resend.com — verify keyaway.app domain first
+RESEND_FROM="KeyAway <support@keyaway.app>"  # Must use a verified domain
+RESEND_REPLY_TO=support@keyaway.app          # Optional — where visitor replies land
 ```
 
 **Google login (optional):** Set `AUTH_GOOGLE_ID` and `AUTH_GOOGLE_SECRET`, then in `auth.ts` uncomment the Google provider import and the `Google({ ... })` block in the `providers` array.

--- a/auth.ts
+++ b/auth.ts
@@ -5,6 +5,9 @@ import { verifyAdminMembership } from "@/src/lib/admin/verifyAdminMembership";
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   trustHost: true,
+  pages: {
+    signIn: "/admin/signin"
+  },
   providers: [
     // Google({
     //   clientId: process.env.AUTH_GOOGLE_ID!,
@@ -54,7 +57,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       const { pathname } = request.nextUrl;
       if (pathname.startsWith("/admin")) {
         if (auth) return true;
-        const signInUrl = new URL("/api/auth/signin", request.url);
+        const signInUrl = new URL("/admin/signin", request.url);
         signInUrl.searchParams.set("callbackUrl", pathname || "/admin");
         return Response.redirect(signInUrl);
       }

--- a/next.config.ts
+++ b/next.config.ts
@@ -73,7 +73,7 @@ const nextConfig: NextConfig = {
               "media-src 'self'",
               "worker-src 'self' blob:",
               "child-src 'self' blob:",
-              "form-action 'self'",
+              "form-action 'self' https://www.keyaway.app https://keyaway.app",
               "frame-ancestors 'none'",
               "upgrade-insecure-requests"
             ].join("; ")

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "19.2.6",
         "react-dom": "19.2.6",
         "react-icons": "^5.6.0",
+        "resend": "^6.17.2",
         "sanity": "^5.26.0",
         "semver": "^7.8.0",
         "styled-components": "^6.4.2"
@@ -7593,6 +7594,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -11718,6 +11725,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
@@ -15803,6 +15816,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -16460,6 +16479,27 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.17.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.17.2.tgz",
+      "integrity": "sha512-hbaXEORFIFfT2Bh03NsA/akTTTKkD1hiuJ88ke64c5dWVV6DyoLxzFve3OiZqVOQ+JKLJ5uVkPR6hlUslpJFoA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -17287,6 +17327,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-icons": "^5.6.0",
+    "resend": "^6.17.2",
     "sanity": "^5.26.0",
     "semver": "^7.8.0",
     "styled-components": "^6.4.2"

--- a/src/app/admin/comments/page.tsx
+++ b/src/app/admin/comments/page.tsx
@@ -57,34 +57,6 @@ export default function AdminCommentsPage() {
     }
   }
 
-  async function handleToggleSpammer(
-    row: AdminProgramCommentRow,
-    markSpammer: boolean
-  ): Promise<boolean> {
-    if (!row.ipHash) return false;
-    const msg = markSpammer
-      ? `Mark visitor ${row.ipHash.slice(0, 10)}… as spammer? They will not be able to post comments or negative key reports.`
-      : `Unmark spammer for ${row.ipHash.slice(0, 10)}…?`;
-    if (!confirm(msg)) return false;
-
-    setBusyId(row.id);
-    try {
-      const res = await fetch("/api/v1/admin/visitor-spammer", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ visitorHash: row.ipHash, isSpammer: markSpammer })
-      });
-      if (res.ok) {
-        await fetchRows();
-        return true;
-      }
-      console.error(await res.text());
-      return false;
-    } finally {
-      setBusyId(null);
-    }
-  }
-
   if (loading) {
     return (
       <ProtectedAdminLayout title="Comments" subtitle="Moderate program page comments">
@@ -101,7 +73,7 @@ export default function AdminCommentsPage() {
         rows={rows}
         busyId={busyId}
         onDelete={handleDelete}
-        onToggleSpammer={handleToggleSpammer}
+        onSpammerChanged={fetchRows}
       />
     </ProtectedAdminLayout>
   );

--- a/src/app/admin/key-suggestions/page.tsx
+++ b/src/app/admin/key-suggestions/page.tsx
@@ -34,6 +34,7 @@ export default function KeySuggestionsPage() {
           email,
           message,
           status,
+          ipHash,
           createdAt
         }`
       );

--- a/src/app/admin/messages/page.tsx
+++ b/src/app/admin/messages/page.tsx
@@ -3,16 +3,45 @@
 import { useState, useEffect, useMemo } from "react";
 import ProtectedAdminLayout from "@/src/components/admin/ProtectedAdminLayout";
 import MessagesTable from "@/src/components/admin/messages/MessagesTable";
+import ReplyEmailTemplatePreview from "@/src/components/admin/messages/ReplyEmailTemplatePreview";
 import SearchInput from "@/src/components/ui/SearchInput";
+import {
+  filterMessagesByQuickFilter,
+  getMessageStats,
+  MESSAGE_QUICK_FILTERS,
+  type MessageQuickFilter
+} from "@/src/lib/admin/contactMessages";
 import { ContactMessage } from "@/src/types/contact";
 import { client } from "@/src/sanity/lib/client";
 import { SortDirection } from "@/src/components/ui/SortableTableHead";
+
+const MESSAGES_QUERY = `*[_type == "contactMessage"] | order(createdAt desc) {
+  _id,
+  _createdAt,
+  title,
+  message,
+  name,
+  email,
+  ipHash,
+  status,
+  createdAt,
+  lastRepliedAt,
+  replies[]{
+    _key,
+    body,
+    subject,
+    sentTo,
+    sentBy,
+    sentAt,
+    resendId
+  }
+}`;
 
 export default function MessagesPage() {
   const [messages, setMessages] = useState<ContactMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
-  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [quickFilter, setQuickFilter] = useState<MessageQuickFilter>("all");
   const [sortColumn, setSortColumn] = useState<string>("status");
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
 
@@ -22,19 +51,7 @@ export default function MessagesPage() {
 
   const fetchMessages = async () => {
     try {
-      const result = await client.fetch<ContactMessage[]>(
-        `*[_type == "contactMessage"] | order(createdAt desc) {
-          _id,
-          _createdAt,
-          title,
-          message,
-          name,
-          email,
-          ipHash,
-          status,
-          createdAt
-        }`
-      );
+      const result = await client.fetch<ContactMessage[]>(MESSAGES_QUERY);
       setMessages(result);
     } catch (error) {
       console.error("Error fetching messages:", error);
@@ -52,20 +69,27 @@ export default function MessagesPage() {
     }
   };
 
+  const stats = useMemo(() => getMessageStats(messages), [messages]);
+
   const filteredAndSortedMessages = useMemo(() => {
-    const filtered = messages.filter(msg => {
-      const matchesSearch =
-        msg.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        msg.message.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        msg.name?.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        msg.email?.toLowerCase().includes(searchTerm.toLowerCase());
+    const search = searchTerm.toLowerCase();
 
-      const matchesStatus = statusFilter === "all" || msg.status === statusFilter;
-
-      return matchesSearch && matchesStatus;
+    const filtered = filterMessagesByQuickFilter(messages, quickFilter).filter(msg => {
+      if (!search) return true;
+      return (
+        msg.title.toLowerCase().includes(search) ||
+        msg.message.toLowerCase().includes(search) ||
+        msg.name?.toLowerCase().includes(search) ||
+        msg.email?.toLowerCase().includes(search) ||
+        msg.replies?.some(
+          reply =>
+            reply.body.toLowerCase().includes(search) ||
+            reply.sentBy.toLowerCase().includes(search) ||
+            reply.subject.toLowerCase().includes(search)
+        )
+      );
     });
 
-    // Sort (status order: new, read, replied, archived)
     const statusOrder: Record<string, number> = { new: 0, read: 1, replied: 2, archived: 3 };
     return [...filtered].sort((a, b) => {
       let cmp = 0;
@@ -84,7 +108,7 @@ export default function MessagesPage() {
       }
       return sortDirection === "asc" ? cmp : -cmp;
     });
-  }, [messages, searchTerm, statusFilter, sortColumn, sortDirection]);
+  }, [messages, searchTerm, quickFilter, sortColumn, sortDirection]);
 
   if (loading) {
     return (
@@ -98,37 +122,63 @@ export default function MessagesPage() {
 
   return (
     <ProtectedAdminLayout title="Messages" subtitle="Manage contact messages">
-      {/* Filters */}
-      <div className="mb-6">
-        <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* Search */}
-            <SearchInput
-              value={searchTerm}
-              onChange={setSearchTerm}
-              placeholder="Search messages..."
-              className="w-full"
-            />
+      <div className="mb-6 grid grid-cols-2 md:grid-cols-3 xl:grid-cols-6 gap-3">
+        {[
+          { label: "Total", value: stats.total, tone: "text-gray-900" },
+          { label: "New", value: stats.new, tone: "text-blue-700" },
+          { label: "Needs reply", value: stats.needsReply, tone: "text-amber-700" },
+          { label: "No email", value: stats.noEmail, tone: "text-red-700" },
+          { label: "Replied", value: stats.replied, tone: "text-green-700" },
+          { label: "Archived", value: stats.archived, tone: "text-purple-700" }
+        ].map(item => (
+          <div key={item.label} className="rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-soft">
+            <div className="text-xs font-medium uppercase tracking-wide text-gray-500">{item.label}</div>
+            <div className={`mt-1 text-2xl font-bold ${item.tone}`}>{item.value}</div>
+          </div>
+        ))}
+      </div>
 
-            {/* Status Filter */}
-            <div>
-              <select
-                id="status-filter"
-                value={statusFilter}
-                onChange={e => setStatusFilter(e.target.value)}
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-gray-900">
-                <option value="all">All Messages ({messages.length})</option>
-                <option value="new">New ({messages.filter(m => m.status === "new").length})</option>
-                <option value="read">Read ({messages.filter(m => m.status === "read").length})</option>
-                <option value="replied">Replied ({messages.filter(m => m.status === "replied").length})</option>
-                <option value="archived">Archived ({messages.filter(m => m.status === "archived").length})</option>
-              </select>
-            </div>
+      <div className="mb-6">
+        <div className="bg-white rounded-xl shadow-soft border border-gray-200 p-6 space-y-4">
+          <SearchInput
+            value={searchTerm}
+            onChange={setSearchTerm}
+            placeholder="Search messages, emails, or reply history..."
+            className="w-full"
+          />
+
+          <div className="flex flex-wrap gap-2">
+            {MESSAGE_QUICK_FILTERS.map(filter => {
+              const count =
+                filter.id === "all"
+                  ? stats.total
+                  : filter.id === "needs_reply"
+                    ? stats.needsReply
+                    : filter.id === "no_email"
+                      ? stats.noEmail
+                      : filter.id === "replied"
+                        ? stats.replied
+                        : stats.archived;
+              const active = quickFilter === filter.id;
+
+              return (
+                <button
+                  key={filter.id}
+                  type="button"
+                  onClick={() => setQuickFilter(filter.id)}
+                  className={`rounded-full px-3 py-1.5 text-sm font-medium transition-colors cursor-pointer ${
+                    active
+                      ? "bg-primary-600 text-white"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+                  }`}>
+                  {filter.label} ({count})
+                </button>
+              );
+            })}
           </div>
         </div>
       </div>
 
-      {/* Messages Table */}
       <MessagesTable
         messages={filteredAndSortedMessages}
         onUpdate={fetchMessages}
@@ -136,6 +186,8 @@ export default function MessagesPage() {
         sortDirection={sortDirection}
         onSort={handleSort}
       />
+
+      <ReplyEmailTemplatePreview />
     </ProtectedAdminLayout>
   );
 }

--- a/src/app/admin/signin/page.tsx
+++ b/src/app/admin/signin/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { signIn } from "next-auth/react";
+import { FaGithub } from "react-icons/fa";
+
+function AdminSignInForm() {
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") ?? "/admin";
+  const errorParam = searchParams.get("error");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSignIn(provider: string) {
+    setIsLoading(true);
+    setError(null);
+    try {
+      await signIn(provider, { callbackUrl });
+    } catch {
+      setError("Sign-in failed. Try again.");
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="w-full max-w-md rounded-xl border border-gray-200 bg-white p-8 shadow-sm">
+        <h1 className="text-2xl font-semibold text-gray-900">Admin sign in</h1>
+        <p className="mt-2 text-sm text-gray-600">Use your approved GitHub account to access the dashboard.</p>
+
+        {(errorParam || error) && (
+          <p className="mt-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error ?? "Sign-in failed. Try again or contact support."}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={() => handleSignIn("github")}
+          disabled={isLoading}
+          className="mt-6 flex w-full items-center justify-center gap-2 rounded-lg bg-[#24292f] px-4 py-3 cursor-pointer text-sm font-medium text-white transition hover:bg-[#1b1f23] disabled:cursor-not-allowed disabled:opacity-70">
+          <FaGithub className="h-5 w-5" />
+          {isLoading ? "Redirecting to GitHub..." : "Sign in with GitHub"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function AdminSignInPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+          <p className="text-gray-600">Loading sign in...</p>
+        </div>
+      }>
+      <AdminSignInForm />
+    </Suspense>
+  );
+}

--- a/src/app/api/v1/admin/comments/route.ts
+++ b/src/app/api/v1/admin/comments/route.ts
@@ -10,7 +10,7 @@ import { adminProgramsWithCommentsQuery } from "@/src/lib/sanity/queries";
 import type { AdminCommentVisitor } from "@/src/types/admin/programComments";
 import type { Program } from "@/src/types/program";
 
-const VISITOR_FIELDS = `visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, contributionScore, country, city, lastActivityAt`;
+const VISITOR_FIELDS = `visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, commentCount, contributionScore, country, city, lastActivityAt`;
 
 /** GET /api/v1/admin/comments — flattened comment rows */
 export async function GET(req: NextRequest) {

--- a/src/app/api/v1/admin/messages/[id]/reply/route.ts
+++ b/src/app/api/v1/admin/messages/[id]/reply/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminSession } from "@/src/lib/admin/adminAuth";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { MAX_REPLY_BODY_LENGTH, ReplySendError, sendContactMessageReply } from "@/src/lib/email/sendContactMessageReply";
+
+/** POST /api/v1/admin/messages/[id]/reply - Send HTML reply via Resend */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const admin = await requireAdminSession();
+  if (admin instanceof Response) return admin;
+
+  try {
+    const { id } = await params;
+    if (!id) return Errors.badRequest("id is required");
+
+    const body = await req.json().catch(() => ({}));
+    const replyText = typeof (body as { replyText?: unknown }).replyText === "string" ? body.replyText : "";
+
+    if (!replyText.trim()) {
+      return Errors.validation("Reply text is required", [{ field: "replyText", message: "Required" }]);
+    }
+    if (replyText.length > MAX_REPLY_BODY_LENGTH) {
+      return Errors.validation(`Reply too long (max ${MAX_REPLY_BODY_LENGTH})`, [
+        { field: "replyText", message: "Too long" }
+      ]);
+    }
+
+    const result = await sendContactMessageReply({
+      messageId: id,
+      replyText,
+      adminEmail: admin.email
+    });
+
+    return NextResponse.json({ data: result, meta: {} }, { status: 201 });
+  } catch (err) {
+    if (err instanceof ReplySendError) {
+      if (err.code === "NOT_CONFIGURED") {
+        return Errors.serviceUnavailable(err.message, "RESEND_NOT_CONFIGURED");
+      }
+      if (err.code === "NOT_FOUND") return Errors.notFound(err.message);
+      if (err.code === "NO_EMAIL") return Errors.validation(err.message, [{ field: "email", message: "Required" }]);
+      return Errors.validation(err.message);
+    }
+
+    console.error("[POST /api/v1/admin/messages/[id]/reply]", err);
+    return Errors.internal();
+  }
+}

--- a/src/app/api/v1/admin/messages/reply/status/route.ts
+++ b/src/app/api/v1/admin/messages/reply/status/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminSession } from "@/src/lib/admin/adminAuth";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { isResendConfigured } from "@/src/lib/email/resendClient";
+
+/** GET /api/v1/admin/messages/reply/status - Whether outbound email is configured */
+export async function GET(req: NextRequest) {
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const admin = await requireAdminSession();
+  if (admin instanceof Response) return admin;
+
+  return NextResponse.json({
+    data: { configured: isResendConfigured() },
+    meta: {}
+  });
+}

--- a/src/app/api/v1/admin/visitor-spammer/route.ts
+++ b/src/app/api/v1/admin/visitor-spammer/route.ts
@@ -40,6 +40,7 @@ export async function PATCH(req: NextRequest) {
         isSpammer,
         reportCount: resolved?.reportCount ?? 0,
         suggestionCount: resolved?.suggestionCount ?? 0,
+        commentCount: resolved?.commentCount ?? 0,
         contributionScore,
         ...(isSpammer ? { spamMarkedAt: now } : {}),
         ...(resolved?.country ? { country: resolved.country } : {}),

--- a/src/app/api/v1/admin/visitor/route.ts
+++ b/src/app/api/v1/admin/visitor/route.ts
@@ -1,0 +1,46 @@
+/** @fileoverview Admin GET: resolve visitor profile by visitorHash / ipHash. */
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdminSession } from "@/src/lib/admin/adminAuth";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
+import type { AdminCommentVisitor } from "@/src/types/admin/programComments";
+
+function toAdminVisitor(
+  v: NonNullable<Awaited<ReturnType<typeof fetchVisitorByHash>>>
+): AdminCommentVisitor {
+  return {
+    visitTier: v.visitTier,
+    isSpammer: v.isSpammer,
+    visitCount: v.visitCount,
+    reportCount: v.reportCount,
+    suggestionCount: v.suggestionCount,
+    commentCount: v.commentCount,
+    contributionScore: v.contributionScore,
+    country: v.country,
+    city: v.city,
+    lastActivityAt: v.lastActivityAt
+  };
+}
+
+export async function GET(req: NextRequest) {
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const admin = await requireAdminSession();
+  if (admin instanceof Response) return admin;
+
+  const hash = req.nextUrl.searchParams.get("hash")?.trim();
+  if (!hash) return Errors.validation("hash query parameter required");
+
+  try {
+    const resolved = await fetchVisitorByHash(hash);
+    return NextResponse.json({
+      data: resolved ? toAdminVisitor(resolved) : null,
+      meta: { visitorHash: hash, source: resolved?.source ?? null }
+    });
+  } catch (err) {
+    console.error("[GET /api/v1/admin/visitor]", err);
+    return Errors.internal();
+  }
+}

--- a/src/app/api/v1/analytics/track/route.ts
+++ b/src/app/api/v1/analytics/track/route.ts
@@ -10,6 +10,7 @@ import { isRecentDuplicateRequest } from "@/src/lib/api/shortRequestDedupe";
 import { isAutomatedAnalyticsRequest } from "@/src/lib/api/isAutomatedAnalyticsRequest";
 import { getClientIp, hashIp, getLocationFromIP } from "@/src/lib/api/requestGeo";
 import { upsertVisitorOnPageView } from "@/src/lib/visitors/upsertVisitorOnPageView";
+import { upsertVisitorContribution } from "@/src/lib/visitors/upsertVisitorContribution";
 import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
 import { isProgramSlugPublishedCached } from "@/src/lib/sanity/getCachedPublishedProgramSlugs";
 import { getAdminSession } from "@/src/lib/admin/adminAuth";
@@ -224,6 +225,14 @@ export async function POST(req: NextRequest) {
     if (location?.city) eventData.city = location.city;
 
     await client.create(eventData as { _type: string } & Record<string, unknown>);
+
+    if (isReportEvent && ipHash) {
+      try {
+        await upsertVisitorContribution(ipHash, "report");
+      } catch (e) {
+        console.error("[track] visitor contribution upsert (report)", e);
+      }
+    }
 
     if (body.event === "page_viewed") {
       try {

--- a/src/app/api/v1/contact/route.ts
+++ b/src/app/api/v1/contact/route.ts
@@ -3,6 +3,8 @@ import { client } from "@/src/sanity/lib/client";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 import { getClientIp, hashIp } from "@/src/lib/api/requestGeo";
+import { isVisitorSpammerByHash } from "@/src/lib/visitors/isVisitorSpammerByHash";
+import { touchVisitorActivity } from "@/src/lib/visitors/upsertVisitorContribution";
 
 const MAX_TITLE = 200;
 const MAX_MESSAGE = 5000;
@@ -36,6 +38,12 @@ export async function POST(req: NextRequest) {
     if (email && email.length > MAX_EMAIL)
       return Errors.validation(`Email too long (max ${MAX_EMAIL})`, [{ field: "email", message: "Too long" }]);
 
+    if (ipHash && (await isVisitorSpammerByHash(ipHash))) {
+      return Errors.validation("Contact submissions are disabled for your network.", [
+        { field: "message", message: "Submission disabled" }
+      ]);
+    }
+
     const result = await client.create({
       _type: "contactMessage",
       title,
@@ -46,6 +54,12 @@ export async function POST(req: NextRequest) {
       status: "new",
       createdAt: new Date().toISOString()
     });
+
+    try {
+      await touchVisitorActivity(ipHash);
+    } catch (e) {
+      console.error("[POST /api/v1/contact] visitor activity touch failed", e);
+    }
 
     return NextResponse.json({ data: { id: result._id }, meta: {} }, { status: 201 });
   } catch (err) {

--- a/src/app/api/v1/key-suggestions/route.ts
+++ b/src/app/api/v1/key-suggestions/route.ts
@@ -3,6 +3,7 @@ import { client } from "@/src/sanity/lib/client";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 import { getClientIp, hashIp } from "@/src/lib/api/requestGeo";
+import { isVisitorSpammerByHash } from "@/src/lib/visitors/isVisitorSpammerByHash";
 import { upsertVisitorContribution } from "@/src/lib/visitors/upsertVisitorContribution";
 
 const MAX_FIELD = 500;
@@ -37,6 +38,12 @@ export async function POST(req: NextRequest) {
 
     if (cdKey.length > MAX_FIELD || programName.length > MAX_FIELD || programVersion.length > MAX_FIELD)
       return Errors.validation("Field too long");
+
+    if (visitorHash && (await isVisitorSpammerByHash(visitorHash))) {
+      return Errors.validation("Key suggestions are disabled for your network.", [
+        { field: "cdKey", message: "Submission disabled" }
+      ]);
+    }
 
     const result = await client.create({
       _type: "keySuggestion",

--- a/src/app/api/v1/program-comments/route.ts
+++ b/src/app/api/v1/program-comments/route.ts
@@ -16,6 +16,7 @@ import {
 } from "@/src/lib/program/commentBody";
 import { isProgramSlugPublished } from "@/src/lib/sanity/programSlugExists";
 import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
+import { upsertVisitorContribution } from "@/src/lib/visitors/upsertVisitorContribution";
 import { isDevelopmentEnv } from "@/src/lib/env/isDevelopment";
 import { getAdminSession } from "@/src/lib/admin/adminAuth";
 import { STAFF_COMMENT_AUTHOR_NAME, STAFF_COMMENT_AUTHOR_ROLE } from "@/src/lib/program/staffCommentIdentity";
@@ -129,6 +130,14 @@ export async function POST(req: NextRequest) {
       ipHash,
       parentCommentKey
     });
+
+    if (!isStaffComment) {
+      try {
+        await upsertVisitorContribution(ipHash, "comment");
+      } catch (e) {
+        console.error("[POST /api/v1/program-comments] visitor contribution upsert failed", e);
+      }
+    }
 
     revalidateAfterProgramContentWrite({ slug: programSlug });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -107,9 +107,11 @@ export default async function RootLayout({
   );
 
   return (
-    <html lang="en" data-scroll-behavior="smooth">
+    <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
       <head>{renderedHeadMetaTags}</head>
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#0f1923] text-[#c6d4df]`}>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#0f1923] text-[#c6d4df]`}
+        suppressHydrationWarning>
         <SessionProvider>
           <PageViewTracker />
           <StoreDetailsProvider value={storeData}>

--- a/src/app/program/[slug]/not-found.tsx
+++ b/src/app/program/[slug]/not-found.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import NotFoundView from "@/src/components/site/NotFoundView";
 
 export const metadata: Metadata = {
-  title: "Program not found | KeyAway",
+  title: "Program Not Found — Browse All Giveaways | KeyAway",
   robots: { index: false, follow: true }
 };
 

--- a/src/app/programs/ProgramsPageClient.tsx
+++ b/src/app/programs/ProgramsPageClient.tsx
@@ -229,6 +229,8 @@ export default function ProgramsPageClient({
         )}
       </div>
 
+      <h2 className="sr-only">All Giveaway Programs</h2>
+
       {!fetchError && (
         <ProgramsGrid
           programs={showLoading ? EMPTY_PROGRAMS : programs}

--- a/src/app/vendors/[slug]/page.tsx
+++ b/src/app/vendors/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDe
 import { getCachedVendorSlugs, getVendorBySlug } from "@/src/lib/vendors/getVendors";
 import { generateVendorPageJsonLd } from "@/src/lib/seo/jsonLd";
 import { resolveVendorHubSeo } from "@/src/lib/seo/vendorSeo";
+import { buildOpenGraphWebsite } from "@/src/lib/seo/openGraph";
 import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
 
 /** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` (Next.js requires a literal). */
@@ -39,14 +40,14 @@ export async function generateMetadata({ params }: VendorPageProps): Promise<Met
   return {
     title,
     description,
-    openGraph: {
+    openGraph: buildOpenGraphWebsite({
       title,
       description,
       url,
       siteName: storeTitle,
-      type: "website",
-      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${vendor.name} on ${storeTitle}` }]
-    },
+      ogImageUrl,
+      ogImageAlt: `${vendor.name} on ${storeTitle}`
+    }),
     twitter: { card: "summary_large_image", title, description, images: [ogImageUrl] },
     alternates: { canonical: url }
   };

--- a/src/app/vendors/page.tsx
+++ b/src/app/vendors/page.tsx
@@ -6,6 +6,7 @@ import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDe
 import { getCachedVendorsWithCounts } from "@/src/lib/vendors/getVendors";
 import { generateVendorsPageJsonLd } from "@/src/lib/seo/jsonLd";
 import { resolveVendorsIndexSeo } from "@/src/lib/seo/vendorSeo";
+import { buildOpenGraphWebsite } from "@/src/lib/seo/openGraph";
 
 /** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` (Next.js requires a literal). */
 export const revalidate = 43200;
@@ -16,14 +17,14 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     title,
     description,
-    openGraph: {
+    openGraph: buildOpenGraphWebsite({
       title,
       description,
       url,
       siteName: storeTitle,
-      type: "website",
-      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: `${storeTitle} — Vendors` }]
-    },
+      ogImageUrl,
+      ogImageAlt: `${storeTitle} — Vendors`
+    }),
     twitter: { card: "summary_large_image", title, description, images: [ogImageUrl] },
     alternates: { canonical: url }
   };

--- a/src/components/admin/AdminVisitorPanel.tsx
+++ b/src/components/admin/AdminVisitorPanel.tsx
@@ -3,23 +3,31 @@
 import { visitorTierBadgeClasses } from "@/src/theme/colorSchema";
 import type { AdminCommentVisitor } from "@/src/types/admin/programComments";
 
-type CommentVisitorPanelProps = {
+type AdminVisitorPanelProps = {
   ipHash?: string;
   visitor?: AdminCommentVisitor;
 };
 
-function Stat({ label, value }: { label: string; value: string | number }) {
+function Stat({
+  label,
+  value,
+  className = ""
+}: {
+  label: string;
+  value: string | number;
+  className?: string;
+}) {
   return (
-    <div className="rounded-lg border border-gray-200 bg-white px-3 py-2">
+    <div className={`rounded-lg border border-gray-200 bg-white px-3 py-2 ${className}`.trim()}>
       <dt className="text-xs font-medium text-gray-500">{label}</dt>
       <dd className="mt-0.5 text-sm font-semibold text-gray-900">{value}</dd>
     </div>
   );
 }
 
-export default function CommentVisitorPanel({ ipHash, visitor }: CommentVisitorPanelProps) {
+export default function AdminVisitorPanel({ ipHash, visitor }: AdminVisitorPanelProps) {
   if (!ipHash?.trim()) {
-    return <p className="text-sm text-gray-500">No visitor hash recorded for this post.</p>;
+    return <p className="text-sm text-gray-500">No visitor hash recorded.</p>;
   }
 
   const tier = visitor?.visitTier ?? "new";
@@ -34,14 +42,16 @@ export default function CommentVisitorPanel({ ipHash, visitor }: CommentVisitorP
       </div>
       <p className="font-mono text-xs text-gray-500 break-all">{ipHash}</p>
       {visitor ? (
-        <dl className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-          <Stat label="Visits" value={visitor.visitCount ?? 0} />
-          <Stat label="Reports" value={visitor.reportCount ?? 0} />
-          <Stat label="Suggestions" value={visitor.suggestionCount ?? 0} />
-          <Stat label="Contribution" value={visitor.contributionScore ?? 0} />
-          <Stat label="Location" value={location || "—"} />
+        <dl className="grid grid-cols-2 gap-2 sm:grid-cols-6">
+          <Stat label="Visits" value={visitor.visitCount ?? 0} className="sm:col-span-2" />
+          <Stat label="Reports" value={visitor.reportCount ?? 0} className="sm:col-span-2" />
+          <Stat label="Comments" value={visitor.commentCount ?? 0} className="sm:col-span-2" />
+          <Stat label="Suggestions" value={visitor.suggestionCount ?? 0} className="sm:col-span-3" />
+          <Stat label="Contribution" value={visitor.contributionScore ?? 0} className="col-span-2 sm:col-span-3" />
+          <Stat label="Location" value={location || "—"} className="sm:col-span-3" />
           <Stat
             label="Last active"
+            className="sm:col-span-3"
             value={
               visitor.lastActivityAt
                 ? new Date(visitor.lastActivityAt).toLocaleString(undefined, {

--- a/src/components/admin/AdminVisitorSection.tsx
+++ b/src/components/admin/AdminVisitorSection.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import AdminVisitorPanel from "@/src/components/admin/AdminVisitorPanel";
+import MarkSpammerButton from "@/src/components/admin/MarkSpammerButton";
+import ModalSection from "@/src/components/admin/ModalSection";
+import type { AdminCommentVisitor } from "@/src/types/admin/programComments";
+
+type AdminVisitorSectionProps = {
+  ipHash?: string;
+  /** When false, only the stats panel is shown (no section wrapper / spam button). */
+  showActions?: boolean;
+  onSpammerChanged?: () => void | Promise<void>;
+  className?: string;
+};
+
+export default function AdminVisitorSection({
+  ipHash,
+  showActions = true,
+  onSpammerChanged,
+  className = ""
+}: AdminVisitorSectionProps) {
+  const [visitor, setVisitor] = useState<AdminCommentVisitor | null | undefined>(undefined);
+  const [loading, setLoading] = useState(false);
+
+  const hash = ipHash?.trim();
+
+  const fetchVisitor = useCallback(async () => {
+    if (!hash) {
+      setVisitor(undefined);
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/v1/admin/visitor?hash=${encodeURIComponent(hash)}`);
+      const json = await res.json();
+      if (res.ok) {
+        setVisitor((json.data as AdminCommentVisitor | null) ?? null);
+      } else {
+        console.error("visitor fetch", json);
+        setVisitor(null);
+      }
+    } catch (e) {
+      console.error(e);
+      setVisitor(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [hash]);
+
+  useEffect(() => {
+    fetchVisitor();
+  }, [fetchVisitor]);
+
+  async function handleSpammerChanged(nextIsSpammer: boolean) {
+    setVisitor(prev => (prev ? { ...prev, isSpammer: nextIsSpammer } : prev));
+    await fetchVisitor();
+    await onSpammerChanged?.();
+  }
+
+  const panel = loading ? (
+    <p className="text-sm text-gray-500">Loading visitor…</p>
+  ) : (
+    <AdminVisitorPanel ipHash={hash} visitor={visitor ?? undefined} />
+  );
+
+  if (!showActions) return panel;
+
+  return (
+    <ModalSection title="Visitor" color="green" className={`mb-0! ${className}`.trim()}>
+      <div className="space-y-4">
+        {panel}
+        {hash ? (
+          <div className="flex justify-end border-t border-green-200/80 pt-4">
+            <MarkSpammerButton
+              visitorHash={hash}
+              isSpammer={visitor?.isSpammer === true}
+              disabled={loading}
+              onSuccess={handleSpammerChanged}
+            />
+          </div>
+        ) : null}
+      </div>
+    </ModalSection>
+  );
+}

--- a/src/components/admin/MarkSpammerButton.tsx
+++ b/src/components/admin/MarkSpammerButton.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import MarkSpammerConfirmModal from "@/src/components/admin/MarkSpammerConfirmModal";
+import { patchVisitorSpammer } from "@/src/lib/admin/patchVisitorSpammer";
+
+type MarkSpammerButtonProps = {
+  visitorHash: string;
+  isSpammer: boolean;
+  disabled?: boolean;
+  onSuccess?: (nextIsSpammer: boolean) => void | Promise<void>;
+  variant?: "default" | "compact" | "report";
+  className?: string;
+};
+
+const variantClasses: Record<NonNullable<MarkSpammerButtonProps["variant"]>, (isSpammer: boolean) => string> = {
+  default: () =>
+    "cursor-pointer rounded border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-800 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50",
+  compact: () =>
+    "cursor-pointer rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-800 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50",
+  report: isSpammer =>
+    `h-7 px-2.5 rounded border text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+      isSpammer
+        ? "border-gray-300 bg-white text-gray-800 hover:bg-gray-50"
+        : "border-red-300 bg-red-50 text-red-800 hover:bg-red-100"
+    }`
+};
+
+export default function MarkSpammerButton({
+  visitorHash,
+  isSpammer,
+  disabled = false,
+  onSuccess,
+  variant = "default",
+  className = ""
+}: MarkSpammerButtonProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const hash = visitorHash.trim();
+  if (!hash) return null;
+
+  async function handleConfirm() {
+    const nextIsSpammer = !isSpammer;
+    setBusy(true);
+    try {
+      const ok = await patchVisitorSpammer(hash, nextIsSpammer);
+      if (ok) {
+        setConfirmOpen(false);
+        await onSuccess?.(nextIsSpammer);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const buttonClass = `${variantClasses[variant](isSpammer)} ${className}`.trim();
+
+  return (
+    <>
+      <button
+        type="button"
+        disabled={disabled || busy}
+        onClick={() => setConfirmOpen(true)}
+        className={buttonClass}>
+        {busy ? "…" : isSpammer ? "Unmark spammer" : "Mark spammer"}
+      </button>
+
+      <MarkSpammerConfirmModal
+        open={confirmOpen}
+        visitorHash={hash}
+        markingSpammer={!isSpammer}
+        busy={busy}
+        onClose={() => setConfirmOpen(false)}
+        onConfirm={() => void handleConfirm()}
+      />
+    </>
+  );
+}

--- a/src/components/admin/MarkSpammerConfirmModal.tsx
+++ b/src/components/admin/MarkSpammerConfirmModal.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { ModalCloseButton } from "@/src/components/ui/ModalCloseButton";
+
+type MarkSpammerConfirmModalProps = {
+  open: boolean;
+  visitorHash: string;
+  markingSpammer: boolean;
+  busy?: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+};
+
+export default function MarkSpammerConfirmModal({
+  open,
+  visitorHash,
+  markingSpammer,
+  busy = false,
+  onClose,
+  onConfirm
+}: MarkSpammerConfirmModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) onClose();
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [open, busy, onClose]);
+
+  if (!open) return null;
+
+  const shortHash = `${visitorHash.slice(0, 10)}…`;
+
+  return (
+    <div className="fixed inset-0 z-[210] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={busy ? undefined : onClose} />
+      <div
+        ref={modalRef}
+        role="alertdialog"
+        aria-labelledby="mark-spammer-title"
+        aria-describedby="mark-spammer-desc"
+        className="relative w-full max-w-md rounded-xl bg-white p-6 shadow-2xl text-start"
+        onClick={e => e.stopPropagation()}>
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <h3 id="mark-spammer-title" className="text-lg font-bold text-gray-900">
+            {markingSpammer ? "Mark as spammer?" : "Unmark spammer?"}
+          </h3>
+          <ModalCloseButton
+            onClick={onClose}
+            disabled={busy}
+            className="cursor-pointer rounded-lg p-1.5 text-gray-500 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-50"
+            iconClassName="h-5 w-5"
+            aria-label="Close"
+          />
+        </div>
+        <p id="mark-spammer-desc" className="text-sm leading-relaxed text-gray-600">
+          {markingSpammer ? (
+            <>
+              Are you sure you want to mark visitor <strong className="font-mono text-gray-900">{shortHash}</strong> as
+              a spammer? They will be blocked from comments, contact messages, key submissions, and negative key
+              reports.
+            </>
+          ) : (
+            <>
+              Are you sure you want to unmark visitor <strong className="font-mono text-gray-900">{shortHash}</strong>?
+              They will be able to submit again.
+            </>
+          )}
+        </p>
+        <div className="mt-6 flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onClose}
+            className="cursor-pointer rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50">
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onConfirm}
+            className={`cursor-pointer rounded-lg px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50 ${
+              markingSpammer ? "bg-red-600 hover:bg-red-700" : "bg-primary-600 hover:bg-primary-700"
+            }`}>
+            {busy ? "Saving…" : markingSpammer ? "Yes, mark spammer" : "Yes, unmark"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/ProtectedAdminLayout.tsx
+++ b/src/components/admin/ProtectedAdminLayout.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
 import AdminLayout from "./AdminLayout";
 import type { ProtectedAdminLayoutProps } from "@/src/types";
@@ -14,19 +13,18 @@ export default function ProtectedAdminLayout({
 }: ProtectedAdminLayoutProps) {
   const { data: session, status } = useSession();
   const [isChecking, setIsChecking] = useState(true);
-  const router = useRouter();
 
   useEffect(() => {
     if (status === "loading") return;
 
     const isAdmin = (session?.user as { isAdmin?: boolean })?.isAdmin === true;
     if (!isAdmin) {
-      router.push("/api/auth/signin?callbackUrl=/admin");
+      window.location.assign("/admin/signin?callbackUrl=/admin");
       return;
     }
 
     setIsChecking(false);
-  }, [session, status, router]);
+  }, [session, status]);
 
   if (status === "loading" || isChecking) {
     return (

--- a/src/components/admin/ReportDetailsModal.tsx
+++ b/src/components/admin/ReportDetailsModal.tsx
@@ -10,6 +10,7 @@ import { client } from "@/src/sanity/lib/client";
 import { fetchVisitorsByHashes } from "@/src/lib/visitors/visitorLookup";
 import { effectiveReferrerHref, extractReferrerInfo } from "@/src/lib/analytics/analyticsUtils";
 import { visitorTierBadgeClasses } from "@/src/theme/colorSchema";
+import MarkSpammerButton from "@/src/components/admin/MarkSpammerButton";
 import {
   isAccountFlow,
   isKeyLikeFlow,
@@ -105,7 +106,6 @@ export default function ReportDetailsModal({ isOpen, onClose, report }: ReportDe
   const [mounted, setMounted] = useState(false);
   const [rowEventTypes, setRowEventTypes] = useState<Record<string, KeyReportEvent>>({});
   const [savingReportId, setSavingReportId] = useState<string | null>(null);
-  const [spamBusyHash, setSpamBusyHash] = useState<string | null>(null);
   const [visitorByHash, setVisitorByHash] = useState<Record<string, { visitTier?: string; isSpammer?: boolean }>>({});
 
   useEffect(() => {
@@ -181,35 +181,6 @@ export default function ReportDetailsModal({ isOpen, onClose, report }: ReportDe
     },
     [rowEventTypes]
   );
-
-  const patchVisitorSpam = useCallback(async (visitorHash: string, isSpammer: boolean) => {
-    const ok = window.confirm(
-      isSpammer
-        ? "Mark this visitor as spammer? They can still report keys as working, but not expired or limit reached."
-        : "Unmark spammer for this visitor?"
-    );
-    if (!ok) return;
-    setSpamBusyHash(visitorHash);
-    try {
-      const res = await fetch("/api/v1/admin/visitor-spammer", {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        body: JSON.stringify({ visitorHash, isSpammer })
-      });
-      if (res.ok) {
-        setVisitorByHash(prev => ({
-          ...prev,
-          [visitorHash]: {
-            visitTier: prev[visitorHash]?.visitTier ?? "new",
-            isSpammer
-          }
-        }));
-      } else console.error("PATCH visitor-spammer", await res.text());
-    } finally {
-      setSpamBusyHash(null);
-    }
-  }, []);
 
   if (!mounted || !isOpen || !report) return null;
 
@@ -464,17 +435,20 @@ export default function ReportDetailsModal({ isOpen, onClose, report }: ReportDe
                         {reportItem.city}, {reportItem.country}
                       </span>
                       {hash ? (
-                        <button
-                          type="button"
-                          disabled={spamBusyHash === hash}
-                          onClick={() => void patchVisitorSpam(hash, !isSpam)}
-                          className={`h-7 px-2.5 rounded border text-xs font-medium transition-colors disabled:opacity-50 ${
-                            isSpam
-                              ? "border-gray-300 bg-white text-gray-800 hover:bg-gray-50"
-                              : "border-red-300 bg-red-50 text-red-800 hover:bg-red-100"
-                          }`}>
-                          {spamBusyHash === hash ? "…" : isSpam ? "Unmark spammer" : "Mark spammer"}
-                        </button>
+                        <MarkSpammerButton
+                          visitorHash={hash}
+                          isSpammer={isSpam}
+                          variant="report"
+                          onSuccess={nextIsSpammer =>
+                            setVisitorByHash(prev => ({
+                              ...prev,
+                              [hash]: {
+                                visitTier: prev[hash]?.visitTier ?? "new",
+                                isSpammer: nextIsSpammer
+                              }
+                            }))
+                          }
+                        />
                       ) : null}
                     </div>
                   </div>

--- a/src/components/admin/comments/ProgramCommentDetailsModal.tsx
+++ b/src/components/admin/comments/ProgramCommentDetailsModal.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useRef } from "react";
 import Link from "next/link";
 import { ModalCloseButton } from "@/src/components/ui/ModalCloseButton";
+import AdminVisitorSection from "@/src/components/admin/AdminVisitorSection";
 import ModalSection from "@/src/components/admin/ModalSection";
-import CommentVisitorPanel from "@/src/components/admin/comments/CommentVisitorPanel";
 import type { AdminProgramCommentRow } from "@/src/types/admin/programComments";
 
 type ProgramCommentDetailsModalProps = {
@@ -14,7 +14,7 @@ type ProgramCommentDetailsModalProps = {
   busyId: string | null;
   onClose: () => void;
   onRequestDelete: (row: AdminProgramCommentRow) => void;
-  onToggleSpammer: (row: AdminProgramCommentRow, markSpammer: boolean) => void | Promise<boolean>;
+  onSpammerChanged?: () => void | Promise<void>;
 };
 
 function formatDate(iso?: string) {
@@ -57,11 +57,10 @@ export default function ProgramCommentDetailsModal({
   busyId,
   onClose,
   onRequestDelete,
-  onToggleSpammer
+  onSpammerChanged
 }: ProgramCommentDetailsModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const busy = busyId === row.id;
-  const isSpam = row.visitor?.isSpammer === true;
   const displayRow = row.isReply && parentComment ? parentComment : row;
 
   useEffect(() => {
@@ -108,10 +107,6 @@ export default function ProgramCommentDetailsModal({
         </div>
 
         <div className="flex-1 space-y-6 overflow-y-auto p-6">
-          <ModalSection title="Visitor" color="green">
-            <CommentVisitorPanel ipHash={row.ipHash} visitor={row.visitor} />
-          </ModalSection>
-
           {row.isReply && parentComment ? (
             <ModalSection title="Parent comment" color="gray">
               <CommentBlock
@@ -158,6 +153,8 @@ export default function ProgramCommentDetailsModal({
           {!row.isReply && threadReplies.length === 0 ? (
             <p className="text-sm text-gray-500">No replies on this comment.</p>
           ) : null}
+
+          <AdminVisitorSection ipHash={row.ipHash} onSpammerChanged={onSpammerChanged} />
         </div>
 
         <div className="flex flex-wrap justify-end gap-2 border-t border-gray-200 bg-gray-50 px-6 py-4">
@@ -168,15 +165,6 @@ export default function ProgramCommentDetailsModal({
             className="cursor-pointer rounded border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50">
             Delete {row.isReply ? "reply" : "comment"}
           </button>
-          {row.ipHash ? (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => onToggleSpammer(row, !isSpam)}
-              className="cursor-pointer rounded border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-800 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50">
-              {busy ? "…" : isSpam ? "Unmark spammer" : "Mark spammer"}
-            </button>
-          ) : null}
         </div>
       </div>
     </div>

--- a/src/components/admin/comments/ProgramCommentsTable.tsx
+++ b/src/components/admin/comments/ProgramCommentsTable.tsx
@@ -22,10 +22,10 @@ type ProgramCommentsTableProps = {
   rows: AdminProgramCommentRow[];
   busyId: string | null;
   onDelete: (row: AdminProgramCommentRow) => Promise<boolean>;
-  onToggleSpammer: (row: AdminProgramCommentRow, markSpammer: boolean) => Promise<boolean>;
+  onSpammerChanged?: () => void | Promise<void>;
 };
 
-export default function ProgramCommentsTable({ rows, busyId, onDelete, onToggleSpammer }: ProgramCommentsTableProps) {
+export default function ProgramCommentsTable({ rows, busyId, onDelete, onSpammerChanged }: ProgramCommentsTableProps) {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<"all" | "comments" | "replies" | "spam">("all");
   const [sortColumn, setSortColumn] = useState("createdAt");
@@ -270,15 +270,6 @@ export default function ProgramCommentsTable({ rows, busyId, onDelete, onToggleS
                             <FaTrash className="h-4 w-4" />
                           </button>
                         </div>
-                        {row.ipHash ? (
-                          <button
-                            type="button"
-                            disabled={busy}
-                            onClick={() => onToggleSpammer(row, !isSpam)}
-                            className="cursor-pointer rounded border border-gray-300 bg-white px-2 py-1 text-xs font-semibold text-gray-800 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50">
-                            {busy ? "…" : isSpam ? "Unmark spammer" : "Mark spammer"}
-                          </button>
-                        ) : null}
                       </div>
                     </td>
                   </tr>
@@ -306,7 +297,7 @@ export default function ProgramCommentsTable({ rows, busyId, onDelete, onToggleS
           busyId={busyId}
           onClose={() => setDetailsRow(null)}
           onRequestDelete={row => setDeleteTarget(row)}
-          onToggleSpammer={onToggleSpammer}
+          onSpammerChanged={onSpammerChanged}
         />
       ) : null}
 

--- a/src/components/admin/key-suggestions/SuggestionDetailsModal.tsx
+++ b/src/components/admin/key-suggestions/SuggestionDetailsModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { FaExternalLinkAlt, FaCopy } from "react-icons/fa";
 import { ModalCloseButton } from "@/src/components/ui/ModalCloseButton";
+import AdminVisitorSection from "@/src/components/admin/AdminVisitorSection";
 import { KeySuggestion } from "@/src/types/contact";
 import type { SuggestionUpdatePayload } from "./KeySuggestionsTable";
 
@@ -217,6 +218,8 @@ export default function SuggestionDetailsModal({
               </select>
             </div>
           </div>
+
+          <AdminVisitorSection ipHash={suggestion.ipHash} />
         </div>
 
         {/* Footer */}

--- a/src/components/admin/layout/AdminHeader.tsx
+++ b/src/components/admin/layout/AdminHeader.tsx
@@ -49,12 +49,9 @@ export default function AdminHeader() {
               <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-sm">A</span>
               </div>
-              <div className="hidden sm:block">
+              <div className="block">
                 <h1 className="text-xl font-bold text-gray-900">Admin Dashboard</h1>
                 <p className="text-sm text-gray-500">KeyAway Analytics</p>
-              </div>
-              <div className="sm:hidden">
-                <h1 className="text-lg font-bold text-gray-900">Admin</h1>
               </div>
             </Link>
           </div>

--- a/src/components/admin/messages/MessageDetailsModal.tsx
+++ b/src/components/admin/messages/MessageDetailsModal.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { useStoreDetails } from "@/src/components/providers/StoreDetailsProvider";
+import Toast from "@/src/components/ui/Toast";
 import { ModalCloseButton } from "@/src/components/ui/ModalCloseButton";
+import AdminVisitorSection from "@/src/components/admin/AdminVisitorSection";
+import { openAdminReplyEmail } from "@/src/lib/email/openAdminReplyEmail";
+import { resolveEmailFooterLinks } from "@/src/lib/email/resolveEmailFooterLinks";
+import { MAX_REPLY_BODY_LENGTH } from "@/src/lib/email/sendContactMessageReply";
+import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
+import { NOTIFICATION_DURATION } from "@/src/lib/notifications/notificationUtils";
 import { ContactMessage } from "@/src/types/contact";
 import type { MessageUpdatePayload } from "./MessagesTable";
 
@@ -9,15 +18,70 @@ interface MessageDetailsModalProps {
   message: ContactMessage;
   onClose: () => void;
   onUpdateMessage: (updates: MessageUpdatePayload) => void;
+  onReplySent: () => void;
   updating?: boolean;
 }
 
-export default function MessageDetailsModal({ message, onClose, onUpdateMessage, updating }: MessageDetailsModalProps) {
+export default function MessageDetailsModal({
+  message,
+  onClose,
+  onUpdateMessage,
+  onReplySent,
+  updating
+}: MessageDetailsModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
+  const markedReadRef = useRef<string | null>(null);
+  const storeData = useStoreDetails();
   const [emailInput, setEmailInput] = useState(message.email ?? "");
   const [emailSaved, setEmailSaved] = useState(false);
+  const [replyText, setReplyText] = useState("");
+  const [sending, setSending] = useState(false);
+  const [resendConfigured, setResendConfigured] = useState<boolean | null>(null);
+  const [toast, setToast] = useState<{ message: string; type: "success" | "error" | "info" } | null>(null);
 
-  // Sync email input when message changes (e.g. after refetch)
+  const replyEmailOptions = useMemo(() => {
+    const to = message.email?.trim();
+    if (!to) return null;
+
+    return {
+      to,
+      subject: message.title ?? "",
+      originalMessage: message.message,
+      adminReply: replyText.trim() || undefined,
+      recipientName: message.name,
+      siteBaseUrl: resolveSiteBaseUrl(storeData?.seo),
+      storeTitle: storeData?.title,
+      footerLinks: resolveEmailFooterLinks(storeData)
+    };
+  }, [
+    message.email,
+    message.message,
+    message.name,
+    message.title,
+    replyText,
+    storeData?.seo,
+    storeData?.socialLinks,
+    storeData?.otherLinks,
+    storeData?.title
+  ]);
+
+  const replies = message.replies ?? [];
+  const canSendReply = Boolean(message.email?.trim()) && replyText.trim().length > 0 && !sending && !updating;
+
+  useEffect(() => {
+    fetch("/api/v1/admin/messages/reply/status")
+      .then(res => res.json())
+      .then(data => setResendConfigured(Boolean(data?.data?.configured)))
+      .catch(() => setResendConfigured(false));
+  }, []);
+
+  useEffect(() => {
+    if (message.status !== "new") return;
+    if (markedReadRef.current === message._id) return;
+    markedReadRef.current = message._id;
+    onUpdateMessage({ status: "read" });
+  }, [message._id, message.status, onUpdateMessage]);
+
   useEffect(() => {
     setEmailInput(message.email ?? "");
   }, [message._id, message.email]);
@@ -29,6 +93,47 @@ export default function MessageDetailsModal({ message, onClose, onUpdateMessage,
     setEmailSaved(true);
     setTimeout(() => setEmailSaved(false), 2000);
   }, [emailInput, message.email, onUpdateMessage]);
+
+  const handleSendViaResend = useCallback(async () => {
+    if (!canSendReply) return;
+
+    setSending(true);
+    try {
+      const res = await fetch(`/api/v1/admin/messages/${message._id}/reply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ replyText: replyText.trim() })
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const msg = data?.error?.message ?? "Failed to send reply";
+        throw new Error(msg);
+      }
+
+      setReplyText("");
+      setToast({ message: "Reply sent — status updated to Replied.", type: "success" });
+      onReplySent();
+    } catch (error) {
+      setToast({
+        message: error instanceof Error ? error.message : "Failed to send reply",
+        type: "error"
+      });
+    } finally {
+      setSending(false);
+    }
+  }, [canSendReply, message._id, onReplySent, replyText]);
+
+  const handleOpenMailApp = useCallback(async () => {
+    if (!replyEmailOptions) return;
+
+    const copied = await openAdminReplyEmail(replyEmailOptions);
+    setToast({
+      message: copied
+        ? "Opening mail app — formatted reply copied. Paste into the body (Ctrl+V) for styling."
+        : "Opening mail app — plain-text body was prefilled.",
+      type: "info"
+    });
+  }, [replyEmailOptions]);
 
   useEffect(() => {
     const handleEscape = (e: KeyboardEvent) => {
@@ -60,7 +165,6 @@ export default function MessageDetailsModal({ message, onClose, onUpdateMessage,
         ref={modalRef}
         className="relative bg-white rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-hidden"
         style={{ animation: "slideDown 0.3s ease-out" }}>
-        {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 bg-gray-50">
           <h2 className="text-2xl font-bold text-gray-900">Message Details</h2>
           <ModalCloseButton
@@ -71,15 +175,12 @@ export default function MessageDetailsModal({ message, onClose, onUpdateMessage,
           />
         </div>
 
-        {/* Content */}
         <div className="p-6 overflow-y-auto max-h-[calc(90vh-140px)] space-y-6">
-          {/* Title */}
           <div>
             <label className="block text-sm font-medium text-gray-500 mb-1">Subject</label>
             <p className="text-lg font-semibold text-gray-900">{message.title ?? "-"}</p>
           </div>
 
-          {/* Message */}
           <div>
             <label className="block text-sm font-medium text-gray-500 mb-1">Message</label>
             <p className="text-gray-700 whitespace-pre-wrap bg-gray-50 p-4 rounded-lg border border-gray-200">
@@ -87,7 +188,6 @@ export default function MessageDetailsModal({ message, onClose, onUpdateMessage,
             </p>
           </div>
 
-          {/* Contact Information */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-500 mb-1">Name</label>
@@ -103,38 +203,104 @@ export default function MessageDetailsModal({ message, onClose, onUpdateMessage,
                   onKeyDown={e => e.key === "Enter" && handleSaveEmail()}
                   placeholder="Add or edit email..."
                   className="flex-1 min-w-0 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-gray-900 text-sm"
-                  disabled={updating}
+                  disabled={updating || sending}
                 />
                 <button
                   type="button"
                   onClick={handleSaveEmail}
-                  disabled={updating || emailInput.trim() === (message.email ?? "").trim()}
+                  disabled={updating || sending || emailInput.trim() === (message.email ?? "").trim()}
                   className="shrink-0 px-3 py-2 text-sm font-medium rounded-lg bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
                   {emailSaved ? "Saved" : "Save"}
                 </button>
               </div>
-              {message.email?.trim() && (
-                <a
-                  href={`mailto:${message.email}`}
-                  className="mt-1 inline-block text-sm text-primary-600 hover:text-primary-700">
-                  Send mail
-                </a>
-              )}
+              {!message.email?.trim() && !emailInput.trim() ? (
+                <p className="mt-1 text-xs text-amber-600">Add an email address to send a reply.</p>
+              ) : null}
             </div>
           </div>
 
-          {/* Metadata */}
+          <div className="pt-4 border-t border-gray-200 space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <label htmlFor="admin-reply-text" className="block text-sm font-medium text-gray-700">
+                Your reply
+              </label>
+              {resendConfigured === false ? (
+                <span className="text-xs text-amber-600">Resend not configured — use mail app fallback</span>
+              ) : resendConfigured ? (
+                <span className="text-xs text-green-600">HTML email via Resend</span>
+              ) : null}
+            </div>
+            <textarea
+              id="admin-reply-text"
+              value={replyText}
+              onChange={e => setReplyText(e.target.value)}
+              rows={5}
+              maxLength={MAX_REPLY_BODY_LENGTH}
+              placeholder="Write your reply here. The original message and KeyAway footer are added automatically."
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-gray-900 text-sm resize-y min-h-[120px]"
+              disabled={sending || updating}
+            />
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={handleSendViaResend}
+                disabled={!canSendReply || resendConfigured === false}
+                className="px-4 py-2 text-sm font-medium rounded-lg bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                {sending ? "Sending…" : "Send HTML reply"}
+              </button>
+              {replyEmailOptions ? (
+                <button
+                  type="button"
+                  onClick={handleOpenMailApp}
+                  disabled={sending || updating}
+                  className="px-4 py-2 text-sm font-medium rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                  Open in mail app
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          {replies.length > 0 ? (
+            <div className="pt-4 border-t border-gray-200 space-y-3">
+              <h3 className="text-sm font-semibold text-gray-900">
+                Reply history ({replies.length})
+              </h3>
+              <ul className="space-y-3">
+                {[...replies].reverse().map(reply => (
+                  <li
+                    key={reply._key ?? `${reply.sentAt}-${reply.sentBy}`}
+                    className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 mb-2">
+                      <span>{reply.sentBy}</span>
+                      <span>→ {reply.sentTo}</span>
+                      <span>{reply.sentAt ? new Date(reply.sentAt).toLocaleString() : ""}</span>
+                      {reply.resendId ? <span className="font-mono">#{reply.resendId.slice(0, 8)}</span> : null}
+                    </div>
+                    <p className="text-sm font-medium text-gray-700 mb-1">{reply.subject}</p>
+                    <p className="text-sm text-gray-700 whitespace-pre-wrap">{reply.body}</p>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-4 border-t border-gray-200">
             <div>
               <label className="block text-sm font-medium text-gray-500 mb-1">Received</label>
               <p className="text-gray-900">{message.createdAt ? new Date(message.createdAt).toLocaleString() : "-"}</p>
             </div>
             <div>
+              <label className="block text-sm font-medium text-gray-500 mb-1">Last replied</label>
+              <p className="text-gray-900">
+                {message.lastRepliedAt ? new Date(message.lastRepliedAt).toLocaleString() : "-"}
+              </p>
+            </div>
+            <div>
               <label className="block text-sm font-medium text-gray-500 mb-1">Status</label>
               <select
                 value={message.status ?? "new"}
                 onChange={e => onUpdateMessage({ status: e.target.value as ContactMessage["status"] })}
-                disabled={updating}
+                disabled={updating || sending}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent cursor-pointer text-gray-900 disabled:opacity-50">
                 <option value="new">New</option>
                 <option value="read">Read</option>
@@ -143,9 +309,10 @@ export default function MessageDetailsModal({ message, onClose, onUpdateMessage,
               </select>
             </div>
           </div>
+
+          <AdminVisitorSection ipHash={message.ipHash} />
         </div>
 
-        {/* Footer */}
         <div className="px-6 py-4 border-t border-gray-200 bg-gray-50 flex justify-end">
           <button
             onClick={onClose}
@@ -154,6 +321,18 @@ export default function MessageDetailsModal({ message, onClose, onUpdateMessage,
           </button>
         </div>
       </div>
+
+      {toast && typeof document !== "undefined"
+        ? createPortal(
+            <Toast
+              message={toast.message}
+              type={toast.type}
+              duration={NOTIFICATION_DURATION.MEDIUM}
+              onClose={() => setToast(null)}
+            />,
+            document.body
+          )
+        : null}
     </div>
   );
 }

--- a/src/components/admin/messages/MessagesTable.tsx
+++ b/src/components/admin/messages/MessagesTable.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { ContactMessage } from "@/src/types/contact";
+import { messageHasNoEmail, messageNeedsReply } from "@/src/lib/admin/contactMessages";
 import MessageDetailsModal from "./MessageDetailsModal";
 import SortableTableHead, { SortableColumn, SortDirection } from "@/src/components/ui/SortableTableHead";
 
@@ -31,6 +32,7 @@ export default function MessagesTable({ messages, onUpdate, sortColumn, sortDire
     { key: "title", label: "Title", sortable: true, className: "text-left" },
     { key: "contact", label: "Contact", sortable: false, className: "text-left" },
     { key: "status", label: "Status", sortable: true, className: "text-center" },
+    { key: "replies", label: "Replies", sortable: false, className: "text-center" },
     { key: "createdAt", label: "Date", sortable: true, className: "text-center" },
     { key: "actions", label: "Actions", sortable: false, className: "text-center" }
   ];
@@ -90,11 +92,12 @@ export default function MessagesTable({ messages, onUpdate, sortColumn, sortDire
         <div className="overflow-x-auto">
           <table className="w-full table-fixed">
             <colgroup>
-              <col className="w-[28%]" />
-              <col className="w-[22%]" />
+              <col className="w-[24%]" />
+              <col className="w-[20%]" />
+              <col className="w-[12%]" />
+              <col className="w-[10%]" />
               <col className="w-[14%]" />
-              <col className="w-[14%]" />
-              <col className="w-[22%]" />
+              <col className="w-[20%]" />
             </colgroup>
             <SortableTableHead
               columns={tableColumns}
@@ -112,7 +115,13 @@ export default function MessagesTable({ messages, onUpdate, sortColumn, sortDire
                 const contactName = message.name ?? "-";
                 const contactEmail = message.email ?? "-";
                 const hasContact = (message.name ?? "").trim() || (message.email ?? "").trim();
+                const replyCount = message.replies?.length ?? 0;
+                const needsReply = messageNeedsReply(message);
+                const noEmail = messageHasNoEmail(message);
                 const dateStr = message.createdAt ? new Date(message.createdAt).toLocaleDateString() : "-";
+                const lastReplyStr = message.lastRepliedAt
+                  ? new Date(message.lastRepliedAt).toLocaleDateString()
+                  : null;
                 return (
                   <tr key={message._id} className={`hover:bg-gray-50 ${isArchived ? "bg-gray-50 opacity-75" : ""}`}>
                     <td className="px-6 py-4 align-top text-left">
@@ -126,7 +135,19 @@ export default function MessagesTable({ messages, onUpdate, sortColumn, sortDire
                     <td className="px-6 py-4 align-top text-left">
                       {hasContact ? (
                         <div className="text-sm">
-                          <div className={isArchived ? "text-gray-500" : "text-gray-900"}>{contactName}</div>
+                          <div className={`flex flex-wrap items-center gap-2 ${isArchived ? "text-gray-500" : "text-gray-900"}`}>
+                            <span>{contactName}</span>
+                            {needsReply ? (
+                              <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-800">
+                                Needs reply
+                              </span>
+                            ) : null}
+                            {noEmail ? (
+                              <span className="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-red-700">
+                                No email
+                              </span>
+                            ) : null}
+                          </div>
                           <div className={isArchived ? "text-gray-400" : "text-gray-500"}>{contactEmail}</div>
                         </div>
                       ) : (
@@ -148,6 +169,16 @@ export default function MessagesTable({ messages, onUpdate, sortColumn, sortDire
                           <option value="archived">Archived</option>
                         </select>
                       </div>
+                    </td>
+                    <td className="px-6 py-4 align-top text-center text-sm text-gray-500">
+                      {replyCount > 0 ? (
+                        <div>
+                          <div className="font-medium text-gray-900">{replyCount}</div>
+                          {lastReplyStr ? <div className="text-xs text-gray-400">{lastReplyStr}</div> : null}
+                        </div>
+                      ) : (
+                        "-"
+                      )}
                     </td>
                     <td className="px-6 py-4 align-top text-center text-sm text-gray-500">{dateStr}</td>
                     <td className="px-6 py-4 align-top text-center">
@@ -173,6 +204,7 @@ export default function MessagesTable({ messages, onUpdate, sortColumn, sortDire
           message={selectedMessage}
           onClose={() => setSelectedMessage(null)}
           onUpdateMessage={updates => handleUpdateMessage(selectedMessage._id, updates)}
+          onReplySent={onUpdate}
           updating={updating === selectedMessage._id}
         />
       )}

--- a/src/components/admin/messages/ReplyEmailTemplatePreview.tsx
+++ b/src/components/admin/messages/ReplyEmailTemplatePreview.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useMemo } from "react";
+import { useStoreDetails } from "@/src/components/providers/StoreDetailsProvider";
+import { buildAdminReplyHtmlBody, buildReplySubject } from "@/src/lib/email/adminReplyMailto";
+import { resolveEmailFooterLinks } from "@/src/lib/email/resolveEmailFooterLinks";
+import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
+
+const SAMPLE = {
+  recipientName: "Alex",
+  subject: "Example program",
+  adminReply: "Here is the info you asked for — let us know if you need anything else.",
+  originalMessage: "Do you have a working key for Example Pro?"
+};
+
+export default function ReplyEmailTemplatePreview() {
+  const storeData = useStoreDetails();
+
+  const subject = useMemo(() => buildReplySubject(SAMPLE.subject), []);
+  const htmlBody = useMemo(
+    () =>
+      buildAdminReplyHtmlBody({
+        subject: SAMPLE.subject,
+        recipientName: SAMPLE.recipientName,
+        adminReply: SAMPLE.adminReply,
+        originalMessage: SAMPLE.originalMessage,
+        siteBaseUrl: resolveSiteBaseUrl(storeData?.seo),
+        storeTitle: storeData?.title,
+        footerLinks: resolveEmailFooterLinks(storeData)
+      }),
+    [storeData]
+  );
+
+  return (
+    <section className="mt-8 md:mt-12">
+      <div className="mb-4">
+        <h3 className="text-xl font-semibold text-gray-900">Reply email preview</h3>
+        <p className="mt-1 text-sm text-gray-500">
+          Sample of the HTML visitors receive when you send a reply. Footer buttons pull from Sanity store settings.
+        </p>
+        <p className="mt-2 text-sm text-gray-600">
+          <span className="font-medium text-gray-700">Subject:</span> {subject}
+        </p>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-soft">
+        <div className="border-b border-gray-200 bg-gray-50 px-4 py-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+          Email body preview
+        </div>
+        <iframe
+          title="Reply email template preview"
+          srcDoc={htmlBody}
+          className="block w-full min-h-[440px] border-0 bg-white"
+          sandbox="allow-popups allow-popups-to-escape-sandbox"
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/HomeVendorBrowse.tsx
+++ b/src/components/home/HomeVendorBrowse.tsx
@@ -16,9 +16,9 @@ export default function HomeVendorBrowse({ vendors, position = "bottom" }: HomeV
 
   return (
     <div className={`text-center ${position === "top" ? "mb-10" : "mt-10"}`}>
-      <h3 className="mb-5 text-xl font-semibold text-[#c6d4df] sm:mb-6 sm:text-2xl">
+      <h2 className="mb-5 text-xl font-semibold text-[#c6d4df] sm:mb-6 sm:text-2xl">
         Browse by <span className="text-gradient-pro">Vendor</span>
-      </h3>
+      </h2>
 
       <ul className="flex flex-wrap items-stretch justify-center gap-2.5 sm:gap-3">
         {items.map(vendor => (
@@ -34,9 +34,9 @@ export default function HomeVendorBrowse({ vendors, position = "bottom" }: HomeV
                 displayMaxSize={64}
                 frameClassName="mb-2 flex h-12 w-12 shrink-0 items-center justify-center rounded-sm border border-[#2a475e] sm:h-16 sm:w-16"
               />
-              <span className="line-clamp-2 min-h-8 text-center text-xs font-semibold leading-tight text-[#c6d4df] group-hover:text-white sm:min-h-9 sm:text-xs">
+              <h3 className="line-clamp-2 min-h-8 text-center text-xs font-semibold leading-tight text-[#c6d4df] group-hover:text-white sm:min-h-9 sm:text-xs">
                 {vendor.name}
-              </span>
+              </h3>
               <span className="mt-0.5 text-xs text-[#8f98a0] group-hover:text-neutral-100">
                 {vendor.programCount} {vendor.programCount === 1 ? "program" : "programs"}
               </span>

--- a/src/components/home/ProgramCard.tsx
+++ b/src/components/home/ProgramCard.tsx
@@ -57,9 +57,9 @@ export default function ProgramCard({ program, stats, badges, showStats = true }
       </Link>
 
       <div className="flex grow flex-col p-4 pt-0">
-        <h2 className="mb-1 line-clamp-2 text-base font-bold leading-tight text-white transition-colors group-hover:text-white sm:text-lg lg:text-xl">
+        <h3 className="mb-1 line-clamp-2 text-base font-bold leading-tight text-white transition-colors group-hover:text-white sm:text-lg lg:text-xl">
           {program.title}
-        </h2>
+        </h3>
 
         {program.descriptionPlain ? (
           <p className="mb-2 line-clamp-3 text-xs leading-relaxed text-neutral-100 sm:line-clamp-4 sm:text-sm">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -57,9 +57,12 @@ export default function Footer({ logoData, socialData, siteBaseUrl }: FooterProp
           <div className="col-span-1 xs:col-span-2 flex flex-col gap-4">
             <Link href="/" className="inline-block w-fit pr-4">
               {isLogo ? (
-                <IdealImageClient {...logoData} className="h-12 w-auto" />
+                <>
+                  <h2 className="sr-only">{storeData.title}</h2>
+                  <IdealImageClient {...logoData} className="h-12 w-auto" />
+                </>
               ) : (
-                <h3 className="text-2xl font-bold text-white">{storeData.title}</h3>
+                <h2 className="text-2xl font-bold text-white">{storeData.title}</h2>
               )}
             </Link>
             <p className="mb-2 max-w-md section-text">
@@ -89,7 +92,7 @@ export default function Footer({ logoData, socialData, siteBaseUrl }: FooterProp
 
           {/* Navigation */}
           <div>
-            <h4 className="section-label mb-4 text-neutral-50">Navigate</h4>
+            <h3 className="section-label mb-4 text-neutral-50">Navigate</h3>
             <ul className="space-y-2">
               <li>
                 <Link
@@ -135,7 +138,7 @@ export default function Footer({ logoData, socialData, siteBaseUrl }: FooterProp
 
           {/* Trust */}
           <div>
-            <h4 className="section-label mb-4 text-neutral-50">Trust</h4>
+            <h3 className="section-label mb-4 text-neutral-50">Trust</h3>
             <ul className="mb-6 space-y-2">
               {TRUST_FOOTER_LINKS.map(({ href, label }) => (
                 <li key={href}>
@@ -153,7 +156,7 @@ export default function Footer({ logoData, socialData, siteBaseUrl }: FooterProp
 
           {/* Contribute Section */}
           <div className="xs:col-span-2 xl:col-span-1">
-            <h4 className="section-label mb-4 text-neutral-50">Contribute</h4>
+            <h3 className="section-label mb-4 text-neutral-50">Contribute</h3>
             <div className="space-y-3">
               {/* Suggest a Key Button */}
               <ContactModalTrigger

--- a/src/components/program/AboutSectionBlock.tsx
+++ b/src/components/program/AboutSectionBlock.tsx
@@ -37,7 +37,7 @@ export default function AboutSectionBlock({ section }: { section: ProgramAboutSe
                       .width(64)
                       .height(64)
                       .url()}
-                    alt=""
+                    alt={sectionTitle + " - bullet point icon"}
                     width={28}
                     height={28}
                     className="h-full w-full object-contain p-0.5"

--- a/src/components/site/EnumeratedSectionHeading.tsx
+++ b/src/components/site/EnumeratedSectionHeading.tsx
@@ -20,13 +20,13 @@ export default function EnumeratedSectionHeading({
   const Heading = Tag as ElementType;
 
   return (
-    <Heading className={`section-title mb-4 flex items-center gap-3 ${className}`.trim()}>
+    <div className={`section-title mb-4 flex items-center gap-3 ${className}`.trim()}>
       <span
         aria-hidden
         className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm border border-[#4a90c4] bg-[#1a2f45] text-sm font-bold text-[#66c0f4]">
         {index}
       </span>
-      <span className="flex min-w-0 flex-wrap items-baseline gap-x-2">{children}</span>
-    </Heading>
+      <Heading className="section-title flex min-w-0 flex-wrap items-baseline gap-x-2">{children}</Heading>
+    </div>
   );
 }

--- a/src/components/vendors/VendorLogoFrame.tsx
+++ b/src/components/vendors/VendorLogoFrame.tsx
@@ -60,6 +60,7 @@ export default function VendorLogoFrame({
   const intrinsic = getImageDimensions(logo as SanityImageSource);
   const boxMax = displayMaxSize ?? Math.round(imageSize / 2);
   const display = fitInsideBox(intrinsic.width, intrinsic.height, boxMax, boxMax);
+  const imageAlt = alt ?? name;
 
   return (
     <div className={frameClassName} style={backgroundColor ? { backgroundColor } : undefined}>
@@ -70,12 +71,12 @@ export default function VendorLogoFrame({
             .fit("max")
             .auto("format")
             .url()}
-          alt={alt ?? ""}
+          alt={imageAlt ?? ""}
           width={display.width}
           height={display.height}
           className={imageClassName}
           sizes={`${imageSize}px`}
-          aria-hidden={alt === "" || alt === undefined}
+          aria-hidden={imageAlt === "" || imageAlt === undefined}
         />
       </div>
     </div>

--- a/src/components/visitors/VisitorTierHint.tsx
+++ b/src/components/visitors/VisitorTierHint.tsx
@@ -6,6 +6,7 @@ import {
   FaCheckCircle,
   FaCircle,
   FaClock,
+  FaComment,
   FaKey,
   FaMedal,
   FaStar,
@@ -63,9 +64,10 @@ export default function VisitorTierHint({ hint, variant = "pill" }: VisitorTierH
     () => [
       { icon: <FaClock size={11} aria-hidden="true" />, label: "visits", value: hint.visitCount },
       { icon: <FaCheckCircle size={11} aria-hidden="true" />, label: "reports", value: hint.reportCount },
+      { icon: <FaComment size={11} aria-hidden="true" />, label: "comments", value: hint.commentCount },
       { icon: <FaKey size={11} aria-hidden="true" />, label: "suggestions", value: hint.suggestionCount }
     ],
-    [hint.reportCount, hint.suggestionCount, hint.visitCount]
+    [hint.commentCount, hint.reportCount, hint.suggestionCount, hint.visitCount]
   );
 
   const shell = variant === "feature" ? tierFeatureShell(hint.tier) : null;

--- a/src/lib/admin/contactMessages.ts
+++ b/src/lib/admin/contactMessages.ts
@@ -1,0 +1,49 @@
+import type { ContactMessage } from "@/src/types/contact";
+
+export type MessageQuickFilter = "all" | "needs_reply" | "no_email" | "replied" | "archived";
+
+export function messageNeedsReply(message: ContactMessage): boolean {
+  const hasEmail = Boolean(message.email?.trim());
+  return hasEmail && (message.status === "new" || message.status === "read");
+}
+
+export function messageHasNoEmail(message: ContactMessage): boolean {
+  return !message.email?.trim();
+}
+
+export function filterMessagesByQuickFilter(
+  messages: ContactMessage[],
+  filter: MessageQuickFilter
+): ContactMessage[] {
+  switch (filter) {
+    case "needs_reply":
+      return messages.filter(messageNeedsReply);
+    case "no_email":
+      return messages.filter(messageHasNoEmail);
+    case "replied":
+      return messages.filter(m => m.status === "replied");
+    case "archived":
+      return messages.filter(m => m.status === "archived");
+    default:
+      return messages;
+  }
+}
+
+export function getMessageStats(messages: ContactMessage[]) {
+  return {
+    total: messages.length,
+    new: messages.filter(m => m.status === "new").length,
+    needsReply: messages.filter(messageNeedsReply).length,
+    noEmail: messages.filter(messageHasNoEmail).length,
+    replied: messages.filter(m => m.status === "replied").length,
+    archived: messages.filter(m => m.status === "archived").length
+  };
+}
+
+export const MESSAGE_QUICK_FILTERS: Array<{ id: MessageQuickFilter; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "needs_reply", label: "Needs reply" },
+  { id: "no_email", label: "No email" },
+  { id: "replied", label: "Replied" },
+  { id: "archived", label: "Archived" }
+];

--- a/src/lib/admin/patchVisitorSpammer.ts
+++ b/src/lib/admin/patchVisitorSpammer.ts
@@ -1,0 +1,14 @@
+/** @fileoverview Admin PATCH helper for visitor spammer flag. */
+export async function patchVisitorSpammer(visitorHash: string, isSpammer: boolean): Promise<boolean> {
+  const res = await fetch("/api/v1/admin/visitor-spammer", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ visitorHash, isSpammer })
+  });
+  if (!res.ok) {
+    console.error("PATCH visitor-spammer", await res.text());
+    return false;
+  }
+  return true;
+}

--- a/src/lib/api/errors.ts
+++ b/src/lib/api/errors.ts
@@ -20,5 +20,7 @@ export const Errors = {
   validation: (message: string, details?: ApiError["details"]) =>
     errorResponse({ code: "VALIDATION_ERROR", message, details }, 422),
   tooManyRequests: (message = "Too many requests") => errorResponse({ code: "RATE_LIMIT_EXCEEDED", message }, 429),
+  serviceUnavailable: (message = "Service unavailable", code = "SERVICE_UNAVAILABLE") =>
+    errorResponse({ code, message }, 503),
   internal: (message = "Internal server error") => errorResponse({ code: "INTERNAL_ERROR", message }, 500)
 } as const;

--- a/src/lib/email/adminReplyMailto.ts
+++ b/src/lib/email/adminReplyMailto.ts
@@ -1,0 +1,372 @@
+import { DEFAULT_SITE_URL } from "@/src/lib/seo/storeSeoResolve";
+import type { EmailFooterLinks } from "@/src/lib/email/resolveEmailFooterLinks";
+
+const LOGO_PATH = "/images/KeyAway_Logo_White.png";
+const TRUSTPILOT_LOGO_PATH = "/images/Trustpilot_Logo.png";
+const DEFAULT_STORE_TITLE = "KeyAway";
+const PLAIN_LINE_BREAK = "\r\n";
+const FACEBOOK_TAGLINE = "Get notified about new programs & CD keys";
+const OPENING_THANKS = "Thanks for reaching out!";
+const FOOTER_BG = "#0E141B";
+const FOOTER_GRADIENT = "linear-gradient(180deg,#1b2838 0%,#0E141B 100%)";
+const FOOTER_BG_STYLE = `background-color:${FOOTER_BG};background-image:${FOOTER_GRADIENT};`;
+
+const EMAIL_HEAD_STYLES = `<style type="text/css">
+  .footer-shell { width: 100%; max-width: 420px; margin: 0 auto; text-align: center; }
+</style>`;
+
+const FOOTER_CTA_MAX_WIDTH = 300;
+
+export interface AdminReplyMailtoOptions {
+  to: string;
+  subject: string;
+  originalMessage?: string | null;
+  adminReply?: string | null;
+  recipientName?: string | null;
+  siteBaseUrl?: string;
+  storeTitle?: string | null;
+  footerLinks?: EmailFooterLinks | null;
+}
+
+export interface AdminReplyTemplate {
+  subject: string;
+  htmlBody: string;
+  plainTextBody: string;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+export function buildReplySubject(originalTitle: string | undefined | null): string {
+  const title = originalTitle?.trim() || "Your message";
+  if (/^re:\s*/i.test(title)) return title;
+  return `RE: ${title}`;
+}
+
+function buildGreetingPlain(recipientName?: string | null): string {
+  const name = recipientName?.trim();
+  return name ? `Hi ${name},` : "Hi there,";
+}
+
+function buildGreetingHtml(recipientName?: string | null): string {
+  return escapeHtml(buildGreetingPlain(recipientName));
+}
+
+function buildSignOffPlain(storeTitle: string): string[] {
+  return ["", "Kind regards,", `${storeTitle} Support`];
+}
+
+function buildSignOffHtml(storeTitle: string): string {
+  return `<p style="font-family:Segoe UI,Arial,sans-serif;font-size:14px;color:#333;margin:0 0 16px;line-height:1.5;">Kind regards,<br />${escapeHtml(storeTitle)} Support</p>`;
+}
+
+function buildOpeningPlain(recipientName?: string | null): string[] {
+  return [buildGreetingPlain(recipientName), "", OPENING_THANKS, ""];
+}
+
+function buildOpeningHtml(recipientName?: string | null): string {
+  return [
+    `<p style="font-family:Segoe UI,Arial,sans-serif;font-size:14px;color:#333;margin:0 0 12px;">${buildGreetingHtml(recipientName)}</p>`,
+    `<p style="font-family:Segoe UI,Arial,sans-serif;font-size:14px;color:#333;margin:0 0 16px;line-height:1.5;">${escapeHtml(OPENING_THANKS)}</p>`
+  ].join("");
+}
+
+function normalizeBaseUrl(siteBaseUrl?: string): string {
+  const raw = siteBaseUrl?.trim() || DEFAULT_SITE_URL;
+  return raw.replace(/\/$/, "");
+}
+
+function formatMultilineHtml(value: string): string {
+  return escapeHtml(value).replace(/\r?\n/g, "<br />");
+}
+
+function quotePlainLines(message: string): string {
+  return message
+    .split(/\r?\n/)
+    .map(line => `> ${line}`)
+    .join(PLAIN_LINE_BREAK);
+}
+
+function buildQuotedMessagePlain(originalMessage?: string | null, recipientName?: string | null): string {
+  const message = originalMessage?.trim();
+  if (!message) return "";
+
+  const name = recipientName?.trim();
+  const attribution = name ? `${name} wrote:${PLAIN_LINE_BREAK}` : "";
+  return `${attribution}${quotePlainLines(message)}`;
+}
+
+function buildQuotedMessageHtml(originalMessage?: string | null, recipientName?: string | null): string {
+  const message = originalMessage?.trim();
+  if (!message) return "";
+
+  const name = recipientName?.trim();
+  const attribution = name
+    ? `<p style="margin:0 0 8px;font-family:Segoe UI,Arial,sans-serif;font-size:12px;color:#8f98a0;">${escapeHtml(name)} wrote:</p>`
+    : "";
+
+  return [
+    `<div style="margin:0 0 24px;">`,
+    attribution,
+    `<blockquote style="margin:0;padding:12px 16px;border-left:4px solid #2a475e;background-color:#f3f4f6;font-family:Segoe UI,Arial,sans-serif;font-size:13px;line-height:1.5;color:#4b5563;">`,
+    formatMultilineHtml(message),
+    `</blockquote>`,
+    `</div>`
+  ].join("");
+}
+
+function buildAdminReplyContentPlain(adminReply: string | null | undefined, storeTitle: string): string[] {
+  const reply = adminReply?.trim();
+  if (reply) {
+    return [reply, ...buildSignOffPlain(storeTitle)];
+  }
+  return ["", "", ...buildSignOffPlain(storeTitle)];
+}
+
+function buildAdminReplyContentHtml(adminReply: string | null | undefined, storeTitle: string): string {
+  const reply = adminReply?.trim();
+  const signOffHtml = buildSignOffHtml(storeTitle);
+
+  if (reply) {
+    return [
+      `<p style="font-family:Segoe UI,Arial,sans-serif;font-size:14px;color:#333;margin:0 0 16px;line-height:1.5;">${formatMultilineHtml(reply)}</p>`,
+      signOffHtml
+    ].join("");
+  }
+
+  return [
+    `<p style="font-family:Segoe UI,Arial,sans-serif;font-size:14px;color:#333;margin:0 0 12px;">&nbsp;</p>`,
+    `<p style="font-family:Segoe UI,Arial,sans-serif;font-size:14px;color:#333;margin:0 0 12px;">&nbsp;</p>`,
+    signOffHtml
+  ].join("");
+}
+
+function footerCtaSlot(content: string, marginTop = 10): string {
+  return [
+    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="${FOOTER_CTA_MAX_WIDTH}" align="center"`,
+    ` style="width:100%;max-width:${FOOTER_CTA_MAX_WIDTH}px;margin:${marginTop}px auto 0;">`,
+    `<tr><td align="center" style="padding:0;">`,
+    content,
+    `</td></tr>`,
+    `</table>`
+  ].join("");
+}
+
+function footerBlockLink(
+  href: string,
+  innerHtml: string,
+  bg: string,
+  color: string,
+  border: string,
+  compact = false
+): string {
+  const pad = compact ? "9px 10px" : "11px 16px";
+  const size = compact ? "12px" : "13px";
+  return [
+    `<a href="${escapeHtml(href)}" style="display:block;width:100%;padding:${pad};background-color:${bg};color:${color};`,
+    `text-decoration:none;font-family:Segoe UI,Arial,sans-serif;font-size:${size};font-weight:600;border-radius:4px;`,
+    `border:1px solid ${border};line-height:1.35;text-align:center;box-sizing:border-box;">`,
+    innerHtml,
+    `</a>`
+  ].join("");
+}
+
+function facebookJoinGroupLink(url: string): string {
+  const inner = [
+    `<table cellpadding="0" cellspacing="0" border="0" role="presentation" align="center" style="margin:0 auto;">`,
+    `<tr>`,
+    `<td style="padding:0 8px 0 0;vertical-align:middle;line-height:0;">`,
+    `<span style="display:inline-block;width:18px;height:18px;line-height:18px;background:#ffffff;color:#2563eb;border-radius:4px;font-family:Helvetica,Arial,sans-serif;font-size:14px;font-weight:700;text-align:center;">f</span>`,
+    `</td>`,
+    `<td style="vertical-align:middle;font-family:Segoe UI,Arial,sans-serif;font-size:13px;font-weight:600;color:#ffffff;white-space:nowrap;">Join Group</td>`,
+    `</tr>`,
+    `</table>`
+  ].join("");
+  return footerBlockLink(url, inner, "#2563eb", "#ffffff", "#3b82f6");
+}
+
+function trustpilotReviewLink(url: string, trustpilotLogoUrl: string): string {
+  const inner = [
+    `<span style="vertical-align:middle;">Leave a review on</span>`,
+    ` <img src="${escapeHtml(trustpilotLogoUrl)}" alt="Trustpilot" width="72" height="18"`,
+    ` style="vertical-align:middle;border:0;display:inline-block;margin-left:4px;" />`
+  ].join("");
+  return footerBlockLink(url, inner, "#f3f4f6", "#111827", "#d1d5db");
+}
+
+function footerDivider(): string {
+  return [
+    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="${FOOTER_CTA_MAX_WIDTH}" align="center"`,
+    ` style="width:100%;max-width:${FOOTER_CTA_MAX_WIDTH}px;margin:16px auto;">`,
+    `<tr><td style="border-top:1px solid #2a475e;font-size:0;line-height:0;">&nbsp;</td></tr>`,
+    `</table>`
+  ].join("");
+}
+
+function footerSupportRow(githubUrl: string | null | undefined, buyMeACoffeeUrl: string | null | undefined): string {
+  if (!githubUrl && !buyMeACoffeeUrl) return "";
+
+  const cells: string[] = [];
+  if (githubUrl) {
+    cells.push(
+      footerBlockLink(githubUrl, "&#11088; on GitHub", "#213246", "#f3f4f6", "#2a475e", true)
+    );
+  }
+  if (buyMeACoffeeUrl) {
+    cells.push(
+      footerBlockLink(buyMeACoffeeUrl, "&#129365; Carrot Juice", "#7d3315", "#ffffff", "#a3421b", true)
+    );
+  }
+
+  if (cells.length === 1) {
+    return footerCtaSlot(cells[0]!, 10);
+  }
+
+  return [
+    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="${FOOTER_CTA_MAX_WIDTH}" align="center"`,
+    ` style="width:100%;max-width:${FOOTER_CTA_MAX_WIDTH}px;margin:10px auto 0;">`,
+    `<tr>`,
+    cells
+      .map(
+        (cell, i) =>
+          `<td width="50%" align="center" valign="top" style="padding:${i === 0 ? "0 4px 0 0" : "0 0 0 4px"};">${cell}</td>`
+      )
+      .join(""),
+    `</tr>`,
+    `</table>`
+  ].join("");
+}
+
+function buildFooterLinksPlain(links: EmailFooterLinks): string[] {
+  const lines: string[] = [];
+
+  if (links.facebookGroupUrl) {
+    lines.push(`Join our Facebook group: ${links.facebookGroupUrl}`);
+    lines.push(FACEBOOK_TAGLINE);
+  }
+  if (links.trustpilotUrl) {
+    lines.push(`Leave a review on Trustpilot: ${links.trustpilotUrl}`);
+  }
+  if (links.githubRepoUrl) {
+    lines.push(`Star on GitHub: ${links.githubRepoUrl}`);
+  }
+  if (links.buyMeACoffeeUrl) {
+    lines.push(`Buy us carrot juice: ${links.buyMeACoffeeUrl}`);
+  }
+
+  return lines;
+}
+
+/** Branded footer — included on every outbound reply (Resend + mailto plain-text). */
+function buildEmailFooterHtml(
+  baseUrl: string,
+  storeTitle: string,
+  programsUrl: string,
+  logoUrl: string,
+  trustpilotLogoUrl: string,
+  links: EmailFooterLinks
+): string {
+  const blocks: string[] = [
+    `<table role="presentation" cellpadding="0" cellspacing="0" border="0" width="100%" style="width:100%;${FOOTER_BG_STYLE}border-collapse:collapse;">`,
+    `<tr><td style="padding:20px 16px;${FOOTER_BG_STYLE}">`,
+    `<div class="footer-shell">`,
+    `<a href="${escapeHtml(baseUrl)}" style="text-decoration:none;">`,
+    `<img src="${escapeHtml(logoUrl)}" alt="${escapeHtml(storeTitle)}" width="112" style="display:block;margin:0 auto 8px;border:0;max-width:112px;height:auto;" />`,
+    `</a>`,
+    `<p style="margin:0 auto 4px;max-width:320px;font-family:Segoe UI,Arial,sans-serif;font-size:13px;line-height:1.45;color:#8f98a0;">Free giveaway CD keys for your favorite software.</p>`,
+    footerDivider(),
+    footerCtaSlot(footerBlockLink(programsUrl, "View all programs", "#1a3a5c", "#c6d4df", "#4a90c4"), 0)
+  ];
+
+  if (links.facebookGroupUrl) {
+    blocks.push(
+      footerCtaSlot(facebookJoinGroupLink(links.facebookGroupUrl)),
+      `<p style="margin:6px auto 0;max-width:${FOOTER_CTA_MAX_WIDTH}px;font-family:Segoe UI,Arial,sans-serif;font-size:11px;line-height:1.35;color:#8f98a0;">${escapeHtml(FACEBOOK_TAGLINE)}</p>`
+    );
+  }
+
+  if (links.trustpilotUrl) {
+    blocks.push(footerCtaSlot(trustpilotReviewLink(links.trustpilotUrl, trustpilotLogoUrl)));
+  }
+
+  blocks.push(
+    footerSupportRow(links.githubRepoUrl, links.buyMeACoffeeUrl),
+    `<p style="margin:14px 0 0;font-family:Segoe UI,Arial,sans-serif;font-size:11px;line-height:1.3;color:#8f98a0;">&copy; ${new Date().getFullYear()} ${escapeHtml(storeTitle)}</p>`,
+    `</div>`,
+    `</td></tr></table>`
+  );
+
+  return blocks.join("");
+}
+
+export function buildAdminReplyPlainTextBody(options: Omit<AdminReplyMailtoOptions, "to">): string {
+  const baseUrl = normalizeBaseUrl(options.siteBaseUrl);
+  const storeTitle = options.storeTitle?.trim() || DEFAULT_STORE_TITLE;
+  const programsUrl = `${baseUrl}/programs`;
+  const footerLinks = options.footerLinks ?? {};
+  const opening = buildOpeningPlain(options.recipientName);
+  const adminContent = buildAdminReplyContentPlain(options.adminReply, storeTitle);
+  const quotedMessage = buildQuotedMessagePlain(options.originalMessage, options.recipientName);
+  const footerLinkLines = buildFooterLinksPlain(footerLinks);
+
+  const lines = [
+    ...opening,
+    ...adminContent,
+    quotedMessage,
+    quotedMessage ? "" : null,
+    "--",
+    storeTitle,
+    "Free giveaway CD keys for your favorite software.",
+    "",
+    `View all programs: ${programsUrl}`,
+    footerLinkLines.length > 0 ? "" : null,
+    ...footerLinkLines,
+    "",
+    `${storeTitle} · ${baseUrl}`
+  ].filter((line): line is string => line != null);
+
+  return lines.join(PLAIN_LINE_BREAK);
+}
+
+export function buildAdminReplyHtmlBody(options: Omit<AdminReplyMailtoOptions, "to">): string {
+  const baseUrl = normalizeBaseUrl(options.siteBaseUrl);
+  const storeTitle = options.storeTitle?.trim() || DEFAULT_STORE_TITLE;
+  const programsUrl = `${baseUrl}/programs`;
+  const logoUrl = `${baseUrl}${LOGO_PATH}`;
+  const trustpilotLogoUrl = `${baseUrl}${TRUSTPILOT_LOGO_PATH}`;
+  const footerLinks = options.footerLinks ?? {};
+  const openingHtml = buildOpeningHtml(options.recipientName);
+  const adminContentHtml = buildAdminReplyContentHtml(options.adminReply, storeTitle);
+  const quotedMessageHtml = buildQuotedMessageHtml(options.originalMessage, options.recipientName);
+  const footerHtml = buildEmailFooterHtml(baseUrl, storeTitle, programsUrl, logoUrl, trustpilotLogoUrl, footerLinks);
+
+  const inner = [
+    `<div style="padding:16px 20px;max-width:640px;margin:0 auto;">`,
+    openingHtml,
+    adminContentHtml,
+    quotedMessageHtml,
+    `</div>`,
+    footerHtml
+  ].join("");
+
+  return `<!DOCTYPE html><html><head><meta name="viewport" content="width=device-width, initial-scale=1.0" />${EMAIL_HEAD_STYLES}</head><body style="margin:0;padding:0;width:100%;background:#ffffff;">${inner}</body></html>`;
+}
+
+export function buildAdminReplyTemplate(options: Omit<AdminReplyMailtoOptions, "to">): AdminReplyTemplate {
+  return {
+    subject: buildReplySubject(options.subject),
+    htmlBody: buildAdminReplyHtmlBody(options),
+    plainTextBody: buildAdminReplyPlainTextBody(options)
+  };
+}
+
+/** Plain-text mailto only — HTML is not supported by the mailto spec. */
+export function buildAdminReplyMailto(options: AdminReplyMailtoOptions): string {
+  const to = encodeURIComponent(options.to.trim());
+  const template = buildAdminReplyTemplate(options);
+  const subject = encodeURIComponent(template.subject);
+  const body = encodeURIComponent(template.plainTextBody);
+
+  return `mailto:${to}?subject=${subject}&body=${body}`;
+}

--- a/src/lib/email/openAdminReplyEmail.ts
+++ b/src/lib/email/openAdminReplyEmail.ts
@@ -1,0 +1,45 @@
+import {
+  type AdminReplyMailtoOptions,
+  buildAdminReplyMailto,
+  buildAdminReplyTemplate
+} from "@/src/lib/email/adminReplyMailto";
+
+export async function copyAdminReplyTemplate(htmlBody: string, plainTextBody: string): Promise<boolean> {
+  if (typeof navigator === "undefined" || !navigator.clipboard) return false;
+
+  try {
+    if (typeof ClipboardItem !== "undefined") {
+      await navigator.clipboard.write([
+        new ClipboardItem({
+          "text/html": new Blob([htmlBody], { type: "text/html" }),
+          "text/plain": new Blob([plainTextBody], { type: "text/plain" })
+        })
+      ]);
+      return true;
+    }
+
+    await navigator.clipboard.writeText(plainTextBody);
+    return true;
+  } catch {
+    try {
+      await navigator.clipboard.writeText(plainTextBody);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * Copies the rich HTML reply to clipboard, then opens the default mail client.
+ * mailto: only supports plain text — paste (Ctrl+V) in the compose window for formatting.
+ */
+export async function openAdminReplyEmail(options: AdminReplyMailtoOptions): Promise<boolean> {
+  const template = buildAdminReplyTemplate(options);
+  const copied = await copyAdminReplyTemplate(template.htmlBody, template.plainTextBody);
+
+  const mailtoUrl = buildAdminReplyMailto(options);
+  window.open(mailtoUrl, "_blank", "noopener,noreferrer");
+
+  return copied;
+}

--- a/src/lib/email/resendClient.ts
+++ b/src/lib/email/resendClient.ts
@@ -1,0 +1,32 @@
+import { Resend } from "resend";
+
+let resendClient: Resend | null | undefined;
+
+export function getResendClient(): Resend | null {
+  if (resendClient !== undefined) return resendClient;
+
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  if (!apiKey) {
+    resendClient = null;
+    return resendClient;
+  }
+
+  resendClient = new Resend(apiKey);
+  return resendClient;
+}
+
+export function getResendFromAddress(): string | null {
+  const from = process.env.RESEND_FROM?.trim();
+  return from || null;
+}
+
+export function getResendReplyToAddress(fallback?: string): string | null {
+  const replyTo = process.env.RESEND_REPLY_TO?.trim();
+  if (replyTo) return replyTo;
+  const fallbackTrimmed = fallback?.trim();
+  return fallbackTrimmed && fallbackTrimmed.includes("@") ? fallbackTrimmed : null;
+}
+
+export function isResendConfigured(): boolean {
+  return Boolean(getResendClient() && getResendFromAddress());
+}

--- a/src/lib/email/resolveEmailFooterLinks.ts
+++ b/src/lib/email/resolveEmailFooterLinks.ts
@@ -1,0 +1,31 @@
+import { getFacebookSocialLink, getTrustpilotReviewUrl } from "@/src/lib/social/socialUtils";
+
+export type EmailFooterLinks = {
+  facebookGroupUrl?: string | null;
+  trustpilotUrl?: string | null;
+  buyMeACoffeeUrl?: string | null;
+  githubRepoUrl?: string | null;
+};
+
+type StoreForEmailFooter = {
+  socialLinks?: Array<{ platform: string; url: string }>;
+  otherLinks?: Array<{ kind: string; url?: string }>;
+};
+
+export function resolveEmailFooterLinks(store: StoreForEmailFooter | null | undefined): EmailFooterLinks {
+  const socialData = { socialLinks: store?.socialLinks ?? [] };
+  const other = store?.otherLinks ?? [];
+
+  return {
+    facebookGroupUrl: getFacebookSocialLink(socialData),
+    trustpilotUrl: getTrustpilotReviewUrl(socialData),
+    buyMeACoffeeUrl: other.find(e => e.kind === "buymeacoffee" && e.url?.trim())?.url?.trim() ?? null,
+    githubRepoUrl: other.find(e => e.kind === "githubRepository" && e.url?.trim())?.url?.trim() ?? null
+  };
+}
+
+export function emailFooterHasLinks(links: EmailFooterLinks): boolean {
+  return Boolean(
+    links.facebookGroupUrl || links.trustpilotUrl || links.buyMeACoffeeUrl || links.githubRepoUrl
+  );
+}

--- a/src/lib/email/sendContactMessageReply.ts
+++ b/src/lib/email/sendContactMessageReply.ts
@@ -1,0 +1,144 @@
+import { client } from "@/src/sanity/lib/client";
+import { buildAdminReplyTemplate, type AdminReplyMailtoOptions } from "@/src/lib/email/adminReplyMailto";
+import {
+  getResendClient,
+  getResendFromAddress,
+  getResendReplyToAddress,
+  isResendConfigured
+} from "@/src/lib/email/resendClient";
+import { resolveSiteBaseUrl } from "@/src/lib/seo/storeSeoResolve";
+import { resolveSupportEmail } from "@/src/lib/site/supportEmail";
+import { resolveEmailFooterLinks } from "@/src/lib/email/resolveEmailFooterLinks";
+import type { ContactMessage, ContactMessageReply } from "@/src/types/contact";
+
+const STORE_FOR_REPLY_QUERY = `*[_type=="storeDetails"][0]{
+  title,
+  supportEmail,
+  seo{ siteUrl },
+  socialLinks[]{ platform, url },
+  otherLinks[]{ kind, url }
+}`;
+
+const MESSAGE_FOR_REPLY_QUERY = `*[_type == "contactMessage" && _id == $id][0]{
+  _id,
+  title,
+  message,
+  name,
+  email,
+  status
+}`;
+
+export const MAX_REPLY_BODY_LENGTH = 10000;
+
+type StoreForReply = {
+  title?: string;
+  supportEmail?: string;
+  seo?: { siteUrl?: string };
+  socialLinks?: Array<{ platform: string; url: string }>;
+  otherLinks?: Array<{ kind: string; url?: string }>;
+};
+
+export class ReplySendError extends Error {
+  constructor(
+    message: string,
+    public readonly code: "NOT_CONFIGURED" | "NOT_FOUND" | "NO_EMAIL" | "SEND_FAILED"
+  ) {
+    super(message);
+    this.name = "ReplySendError";
+  }
+}
+
+export function buildReplyTemplateOptions(
+  message: Pick<ContactMessage, "title" | "message" | "name">,
+  store: StoreForReply | null | undefined,
+  adminReply: string
+): Omit<AdminReplyMailtoOptions, "to"> {
+  return {
+    subject: message.title ?? "",
+    originalMessage: message.message,
+    recipientName: message.name,
+    adminReply,
+    siteBaseUrl: resolveSiteBaseUrl(store?.seo),
+    storeTitle: store?.title,
+    footerLinks: resolveEmailFooterLinks(store)
+  };
+}
+
+export async function sendContactMessageReply(opts: {
+  messageId: string;
+  replyText: string;
+  adminEmail: string;
+}): Promise<{ reply: ContactMessageReply; message: ContactMessage }> {
+  if (!isResendConfigured()) {
+    throw new ReplySendError(
+      "Email sending is not configured. Set RESEND_API_KEY and RESEND_FROM in your environment.",
+      "NOT_CONFIGURED"
+    );
+  }
+
+  const replyBody = opts.replyText.trim();
+  if (!replyBody) {
+    throw new ReplySendError("Reply text is required.", "SEND_FAILED");
+  }
+  if (replyBody.length > MAX_REPLY_BODY_LENGTH) {
+    throw new ReplySendError(`Reply too long (max ${MAX_REPLY_BODY_LENGTH} characters).`, "SEND_FAILED");
+  }
+
+  const [message, store] = await Promise.all([
+    client.fetch<ContactMessage | null>(MESSAGE_FOR_REPLY_QUERY, { id: opts.messageId }),
+    client.fetch<StoreForReply | null>(STORE_FOR_REPLY_QUERY)
+  ]);
+
+  if (!message?._id) {
+    throw new ReplySendError("Message not found.", "NOT_FOUND");
+  }
+
+  const to = message.email?.trim();
+  if (!to) {
+    throw new ReplySendError("This message has no email address. Add one before sending a reply.", "NO_EMAIL");
+  }
+
+  const templateOptions = buildReplyTemplateOptions(message, store, replyBody);
+  const template = buildAdminReplyTemplate(templateOptions);
+  const from = getResendFromAddress()!;
+  const replyTo = getResendReplyToAddress(resolveSupportEmail(store));
+
+  const resend = getResendClient()!;
+  const { data, error } = await resend.emails.send({
+    from,
+    to,
+    ...(replyTo ? { replyTo } : {}),
+    subject: template.subject,
+    html: template.htmlBody,
+    text: template.plainTextBody
+  });
+
+  if (error) {
+    console.error("[sendContactMessageReply] Resend error:", error);
+    throw new ReplySendError(error.message || "Failed to send email.", "SEND_FAILED");
+  }
+
+  const sentAt = new Date().toISOString();
+  const replyKey = crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+  const replyRecord: ContactMessageReply = {
+    _key: replyKey,
+    body: replyBody,
+    subject: template.subject,
+    sentTo: to,
+    sentBy: opts.adminEmail,
+    sentAt,
+    ...(data?.id ? { resendId: data.id } : {})
+  };
+
+  const updated = await client
+    .patch(message._id)
+    .set({ status: "replied", lastRepliedAt: sentAt })
+    .setIfMissing({ replies: [] })
+    .append("replies", [{ ...replyRecord, _type: "contactMessageReply" }])
+    .commit({ returnDocuments: true });
+
+  return {
+    reply: replyRecord,
+    message: updated as unknown as ContactMessage
+  };
+}

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -16,13 +16,13 @@ import {
 } from "@/src/lib/seo/storeSeoResolve";
 import { programT } from "@/src/lib/program/programCopy";
 import { normalizeProgramFlow } from "@/src/lib/program/activationEntry";
+import { buildOpenGraphWebsite } from "@/src/lib/seo/openGraph";
 
 const defaultData = {
   store: DEFAULT_STORE_NAME,
   description:
     "Get free CD keys for popular software like IOBIT, iTop and more. Download premium programs with working activation keys from our giveaway collection.",
-  programTitle: (displayName: string, storeTitle: string) =>
-    `${displayName}: free CD keys & giveaway activation | ${storeTitle}`,
+  programTitle: (displayName: string, storeTitle: string) => `${displayName} CD Keys & Giveaways | ${storeTitle}`,
   programDescription: (programTitle: string, workingKeys: number, totalKeys: number) =>
     `Free ${programTitle} giveaway CD keys for Windows. ${workingKeys} working keys out of ${totalKeys} — copy a license and activate in-app. Official download recommended.`
 };
@@ -45,20 +45,14 @@ export async function generateHomePageMetadata(): Promise<Metadata> {
     title,
     description,
     ...(keywords ? { keywords } : {}),
-    openGraph: {
+    openGraph: buildOpenGraphWebsite({
       title,
       description,
-      type: "website",
       url: siteUrl,
-      images: [
-        {
-          url: ogImageUrl,
-          width: 1200,
-          height: 630,
-          alt: storeTitle
-        }
-      ]
-    },
+      siteName: storeTitle,
+      ogImageUrl,
+      ogImageAlt: storeTitle
+    }),
     twitter: {
       card: "summary_large_image",
       title,
@@ -90,7 +84,7 @@ export async function generateProgramMetadata(slug: string): Promise<Metadata> {
 
     if (!program) {
       return {
-        title: `Program Not Found - ${storeTitle}`,
+        title: `Program Not Found — Browse All Giveaways | ${storeTitle}`,
         description: "The requested program could not be found."
       };
     }
@@ -115,20 +109,14 @@ export async function generateProgramMetadata(slug: string): Promise<Metadata> {
       title,
       description,
       ...(programKeywords ? { keywords: programKeywords } : {}),
-      openGraph: {
+      openGraph: buildOpenGraphWebsite({
         title,
         description,
-        type: "website",
         url,
-        images: [
-          {
-            url: ogImageUrl,
-            width: 1200,
-            height: 630,
-            alt: program.title
-          }
-        ]
-      },
+        siteName: storeTitle,
+        ogImageUrl,
+        ogImageAlt: program.title
+      }),
       twitter: {
         card: "summary_large_image",
         title,
@@ -151,17 +139,21 @@ export async function generateProgramMetadata(slug: string): Promise<Metadata> {
 export async function generatePrivacyMetadata(): Promise<Metadata> {
   const storeData = await getCachedStoreDetailsDocument();
   const { title, description, pageUrl: url, keywords } = resolvePrivacyPageSeo(storeData);
+  const storeTitle = storeData?.title?.trim() || DEFAULT_STORE_NAME;
+  const ogImageUrl = resolveDefaultOgImageUrl(storeData?.seo);
 
   return {
     title,
     description,
     ...(keywords ? { keywords } : {}),
-    openGraph: {
+    openGraph: buildOpenGraphWebsite({
       title,
       description,
-      type: "website",
-      url
-    },
+      url,
+      siteName: storeTitle,
+      ogImageUrl,
+      ogImageAlt: title
+    }),
     twitter: {
       card: "summary",
       title,
@@ -176,17 +168,21 @@ export async function generatePrivacyMetadata(): Promise<Metadata> {
 export async function generateTermsMetadata(): Promise<Metadata> {
   const storeData = await getCachedStoreDetailsDocument();
   const { title, description, pageUrl: url, keywords } = resolveTermsPageSeo(storeData);
+  const storeTitle = storeData?.title?.trim() || DEFAULT_STORE_NAME;
+  const ogImageUrl = resolveDefaultOgImageUrl(storeData?.seo);
 
   return {
     title,
     description,
     ...(keywords ? { keywords } : {}),
-    openGraph: {
+    openGraph: buildOpenGraphWebsite({
       title,
       description,
-      type: "website",
-      url
-    },
+      url,
+      siteName: storeTitle,
+      ogImageUrl,
+      ogImageAlt: title
+    }),
     twitter: {
       card: "summary",
       title,
@@ -207,11 +203,20 @@ async function generateTrustRouteMetadata(
 ): Promise<Metadata> {
   const storeData = await getCachedStoreDetailsDocument();
   const { title, description, pageUrl: url } = resolve(storeData);
+  const storeTitle = storeData?.title?.trim() || DEFAULT_STORE_NAME;
+  const ogImageUrl = resolveDefaultOgImageUrl(storeData?.seo);
 
   return {
     title,
     description,
-    openGraph: { title, description, type: "website", url },
+    openGraph: buildOpenGraphWebsite({
+      title,
+      description,
+      url,
+      siteName: storeTitle,
+      ogImageUrl,
+      ogImageAlt: title
+    }),
     twitter: { card: "summary", title, description },
     alternates: { canonical: url }
   };
@@ -254,28 +259,20 @@ export async function generateUpdatesMetadata(): Promise<Metadata> {
 
 export async function generateProgramsPageMetadata(): Promise<Metadata> {
   const storeData = await getCachedStoreDetailsDocument();
-  const { title, description, pageUrl: url, ogImageUrl, storeTitle, keywords } =
-    resolveProgramsPageSeo(storeData);
+  const { title, description, pageUrl: url, ogImageUrl, storeTitle, keywords } = resolveProgramsPageSeo(storeData);
 
   return {
     title,
     description,
     keywords: keywords ?? defaultProgramsKeywords,
-    openGraph: {
+    openGraph: buildOpenGraphWebsite({
       title,
       description,
       url,
       siteName: storeTitle,
-      type: "website",
-      images: [
-        {
-          url: ogImageUrl,
-          width: 1200,
-          height: 630,
-          alt: `${storeTitle} - All Programs`
-        }
-      ]
-    },
+      ogImageUrl,
+      ogImageAlt: `${storeTitle} - All Programs`
+    }),
     twitter: {
       card: "summary_large_image",
       title,

--- a/src/lib/seo/openGraph.ts
+++ b/src/lib/seo/openGraph.ts
@@ -3,7 +3,13 @@ import type { Metadata } from "next";
 const OG_IMAGE_WIDTH = 1200;
 const OG_IMAGE_HEIGHT = 630;
 
-type OpenGraphImage = NonNullable<NonNullable<Metadata["openGraph"]>["images"]>[number];
+type OpenGraphImage = {
+  url: string;
+  secureUrl?: string;
+  width?: number;
+  height?: number;
+  alt?: string;
+};
 
 export function buildOpenGraphImage(url: string, alt: string): OpenGraphImage {
   return {

--- a/src/lib/seo/openGraph.ts
+++ b/src/lib/seo/openGraph.ts
@@ -1,0 +1,34 @@
+import type { Metadata } from "next";
+
+const OG_IMAGE_WIDTH = 1200;
+const OG_IMAGE_HEIGHT = 630;
+
+type OpenGraphImage = NonNullable<NonNullable<Metadata["openGraph"]>["images"]>[number];
+
+export function buildOpenGraphImage(url: string, alt: string): OpenGraphImage {
+  return {
+    url,
+    ...(url.startsWith("https://") ? { secureUrl: url } : {}),
+    width: OG_IMAGE_WIDTH,
+    height: OG_IMAGE_HEIGHT,
+    alt
+  };
+}
+
+export function buildOpenGraphWebsite(params: {
+  title: string;
+  description: string;
+  url: string;
+  siteName: string;
+  ogImageUrl: string;
+  ogImageAlt: string;
+}): NonNullable<Metadata["openGraph"]> {
+  return {
+    title: params.title,
+    description: params.description,
+    url: params.url,
+    siteName: params.siteName,
+    type: "website",
+    images: [buildOpenGraphImage(params.ogImageUrl, params.ogImageAlt)]
+  };
+}

--- a/src/lib/seo/storeSeoResolve.ts
+++ b/src/lib/seo/storeSeoResolve.ts
@@ -18,10 +18,7 @@ export function buildStoreSeoVariableMap(store: StoreDetailsForSeo): Record<stri
   return { title };
 }
 
-export function applyStoreSeoTemplate(
-  template: string | undefined | null,
-  vars: Record<string, string>
-): string {
+export function applyStoreSeoTemplate(template: string | undefined | null, vars: Record<string, string>): string {
   if (template == null) return "";
   return String(template).replace(/\[([a-zA-Z0-9_]+)\]/g, (_, key: string) =>
     Object.prototype.hasOwnProperty.call(vars, key) ? vars[key]! : `[${key}]`
@@ -101,7 +98,7 @@ export function resolveProgramsPageSeo(store: StoreDetailsForSeo | null | undefi
   const storeTitle = vars.title;
 
   const titleFromTemplate = trimmedNonEmpty(applyStoreSeoTemplate(s.seo?.programsMetaTitle, vars));
-  const title = titleFromTemplate ?? `All Programs - ${storeTitle}`;
+  const title = titleFromTemplate ?? `All Giveaway Programs - Free PRO Software CD Keys | ${storeTitle}`;
 
   const descFromTemplate = trimmedNonEmpty(applyStoreSeoTemplate(s.seo?.programsMetaDescription, vars));
   const description =
@@ -122,7 +119,7 @@ export function resolvePrivacyPageSeo(store: StoreDetailsForSeo | null | undefin
   const storeTitle = vars.title;
 
   const titleFromTemplate = trimmedNonEmpty(applyStoreSeoTemplate(s.seo?.privacyMetaTitle, vars));
-  const title = titleFromTemplate ?? `Privacy Policy | ${storeTitle}`;
+  const title = titleFromTemplate ?? `Privacy Policy & Data Practices | ${storeTitle}`;
 
   const descFromTemplate = trimmedNonEmpty(applyStoreSeoTemplate(s.seo?.privacyMetaDescription, vars));
   const description =
@@ -142,7 +139,7 @@ export function resolveTermsPageSeo(store: StoreDetailsForSeo | null | undefined
   const storeTitle = vars.title;
 
   const titleFromTemplate = trimmedNonEmpty(applyStoreSeoTemplate(s.seo?.termsMetaTitle, vars));
-  const title = titleFromTemplate ?? `Terms of Service | ${storeTitle}`;
+  const title = titleFromTemplate ?? `Terms of Service & Site Usage | ${storeTitle}`;
 
   const descFromTemplate = trimmedNonEmpty(applyStoreSeoTemplate(s.seo?.termsMetaDescription, vars));
   const description =

--- a/src/lib/seo/trustPageSeo.ts
+++ b/src/lib/seo/trustPageSeo.ts
@@ -20,7 +20,7 @@ export function resolveHowItWorksPageSeo(store: StoreDetailsForSeo | null | unde
   return resolveTrustPageSeo(
     store,
     "/how-it-works",
-    "How It Works | [title]",
+    "How Giveaway Keys & Reports Work | [title]",
     "Learn how [title] lists official promotional CD keys, how community reports work, and what we never host."
   );
 }
@@ -29,7 +29,7 @@ export function resolveAboutPageSeo(store: StoreDetailsForSeo | null | undefined
   return resolveTrustPageSeo(
     store,
     "/about",
-    "About | [title]",
+    "About & Our Story | Who We Are at [title]",
     "What [title] is, how we help you find legal software giveaway keys, and how to reach us."
   );
 }
@@ -38,7 +38,7 @@ export function resolveAffiliateDisclosurePageSeo(store: StoreDetailsForSeo | nu
   return resolveTrustPageSeo(
     store,
     "/affiliate-disclosure",
-    "Affiliate Disclosure | [title]",
+    "Affiliate Links & Disclosure Policy | [title]",
     "How [title] uses affiliate links, outbound vendor links, and how that supports free giveaway listings."
   );
 }
@@ -47,7 +47,7 @@ export function resolveVerificationPolicyPageSeo(store: StoreDetailsForSeo | nul
   return resolveTrustPageSeo(
     store,
     "/verification-policy",
-    "Verification Policy | [title]",
+    "Key Verification & Listing Policy | [title]",
     "How [title] handles community key reports, listings review, and giveaway accuracy."
   );
 }
@@ -56,7 +56,7 @@ export function resolveDmcaPageSeo(store: StoreDetailsForSeo | null | undefined)
   return resolveTrustPageSeo(
     store,
     "/dmca",
-    "Report Content | [title]",
+    "Report Content or Copyright Issues | [title]",
     "How to report copyright or content issues on [title]."
   );
 }
@@ -65,7 +65,7 @@ export function resolvePartnersPageSeo(store: StoreDetailsForSeo | null | undefi
   return resolveTrustPageSeo(
     store,
     "/partners",
-    "Partners & Vendors | [title]",
+    "Software Partners & Vendor Deals | [title]",
     "Work with [title] on official software giveaways and promotional listings."
   );
 }
@@ -74,7 +74,7 @@ export function resolveUpdatesPageSeo(store: StoreDetailsForSeo | null | undefin
   return resolveTrustPageSeo(
     store,
     "/updates",
-    "Latest Updates | [title]",
+    "Latest Giveaway Keys & New Programs | [title]",
     "New programs and fresh giveaway keys added to [title] in the last 90 days — auto-updated from our catalog."
   );
 }

--- a/src/lib/seo/vendorSeo.ts
+++ b/src/lib/seo/vendorSeo.ts
@@ -14,7 +14,7 @@ export function resolveVendorsIndexSeo(store: StoreDetailsForSeo | null | undefi
   const vars = buildStoreSeoVariableMap(s);
   const siteUrl = resolveSiteBaseUrl(s.seo);
   return {
-    title: `Software Vendors | ${vars.title}`,
+    title: `Software Vendors & Publishers | ${vars.title}`,
     description: `Browse software publishers on ${vars.title} — free promotional CD keys, giveaways, and PRO upgrade deals grouped by vendor.`,
     pageUrl: `${siteUrl}/vendors`,
     ogImageUrl: resolveDefaultOgImageUrl(s.seo),
@@ -31,7 +31,7 @@ export function resolveVendorHubSeo(store: StoreDetailsForSeo | null | undefined
   const count = vendor.programCount ?? 0;
   const countLabel = count > 0 ? `${count} program${count === 1 ? "" : "s"}` : "programs";
 
-  const title = vendor.seo?.metaTitle?.trim() || `${vendor.name} — Free CD Keys & Giveaways | ${vars.title}`;
+  const title = vendor.seo?.metaTitle?.trim() || `${vendor.name} CD Keys & Giveaways | ${vars.title}`;
   const description =
     vendor.seo?.metaDescription?.trim() ||
     `Free ${vendor.name} promotional CD keys and giveaways on ${vars.title}. Browse ${countLabel}, verified community reports, and official PRO upgrade deals.`;

--- a/src/lib/visitors/buildVisitorHintData.ts
+++ b/src/lib/visitors/buildVisitorHintData.ts
@@ -29,8 +29,11 @@ export function lineForTier(tier: VisitTier, contributionType: ContributionType)
       if (contributionType === "suggestions_only") {
         return "Your suggestions shaped the list — thank you.";
       }
+      if (contributionType === "comments_only") {
+        return "Your comments help the community — thank you.";
+      }
       if (contributionType === "mixed") {
-        return "Your reports and suggestions both helped — thank you.";
+        return "Your contributions helped the community — thank you.";
       }
       return "Thanks for sticking with the community.";
     case "star":
@@ -40,7 +43,10 @@ export function lineForTier(tier: VisitTier, contributionType: ContributionType)
       if (contributionType === "suggestions_only") {
         return "Your suggestions mattered — thank you.";
       }
-      return "Thanks for both reports and suggestions.";
+      if (contributionType === "comments_only") {
+        return "Your comments made a real difference — thank you.";
+      }
+      return "Thanks for supporting the community.";
     default:
       return null;
   }
@@ -52,12 +58,16 @@ export function buildVisitorHintData(doc: {
   visitCount: number;
   reportCount: number;
   suggestionCount: number;
+  commentCount?: number;
+  contributionScore?: number;
 }): VisitorHintData | null {
   const { visitTier: tier } = doc;
   const visitCount = Math.max(0, doc.visitCount ?? 0);
   const reportCount = Math.max(0, doc.reportCount ?? 0);
   const suggestionCount = Math.max(0, doc.suggestionCount ?? 0);
-  const contributionType = contributionTypeFromCounts(reportCount, suggestionCount);
+  const commentCount = Math.max(0, doc.commentCount ?? 0);
+  const contributionScore = Math.max(0, doc.contributionScore ?? reportCount + suggestionCount + commentCount);
+  const contributionType = contributionTypeFromCounts(reportCount, suggestionCount, commentCount);
   const message = lineForTier(tier, contributionType);
   if (!message) return null;
   return {
@@ -67,6 +77,8 @@ export function buildVisitorHintData(doc: {
     contributionType,
     visitCount,
     reportCount,
-    suggestionCount
+    suggestionCount,
+    commentCount,
+    contributionScore
   };
 }

--- a/src/lib/visitors/bundleVisitors.ts
+++ b/src/lib/visitors/bundleVisitors.ts
@@ -8,7 +8,7 @@ import {
 import { client } from "@/src/sanity/lib/client";
 
 const VISITOR_FIELDS =
-  "visitorHash, visitCount, lastActivityAt, visitTier, isSpammer, reportCount, suggestionCount, contributionScore, spamMarkedAt, country, city, geoUpdatedAt, createdAt, updatedAt";
+  "visitorHash, visitCount, lastActivityAt, visitTier, isSpammer, reportCount, suggestionCount, commentCount, contributionScore, spamMarkedAt, country, city, geoUpdatedAt, createdAt, updatedAt";
 
 function toBundledVisitor(doc: Record<string, unknown> & { _id?: string }) {
   return {
@@ -21,6 +21,7 @@ function toBundledVisitor(doc: Record<string, unknown> & { _id?: string }) {
     isSpammer: doc.isSpammer,
     reportCount: doc.reportCount,
     suggestionCount: doc.suggestionCount,
+    commentCount: doc.commentCount,
     contributionScore: doc.contributionScore,
     spamMarkedAt: doc.spamMarkedAt,
     country: doc.country,

--- a/src/lib/visitors/publicVisitorContext.ts
+++ b/src/lib/visitors/publicVisitorContext.ts
@@ -8,6 +8,8 @@ export interface VisitorHintData {
   visitCount: number;
   reportCount: number;
   suggestionCount: number;
+  commentCount: number;
+  contributionScore: number;
 }
 
 export interface PublicVisitorContext {

--- a/src/lib/visitors/serverVisitorContext.ts
+++ b/src/lib/visitors/serverVisitorContext.ts
@@ -29,7 +29,9 @@ export async function getVisitorContextForPublicPage(headersList: Headers): Prom
     visitTier: doc.visitTier as VisitTier,
     visitCount: doc.visitCount ?? 0,
     reportCount: doc.reportCount ?? 0,
-    suggestionCount: doc.suggestionCount ?? 0
+    suggestionCount: doc.suggestionCount ?? 0,
+    commentCount: doc.commentCount ?? 0,
+    contributionScore: doc.contributionScore ?? 0
   });
 
   return {

--- a/src/lib/visitors/upsertVisitorContribution.ts
+++ b/src/lib/visitors/upsertVisitorContribution.ts
@@ -2,7 +2,7 @@ import { client } from "@/src/sanity/lib/client";
 import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
 import { resolveVisitTier } from "@/src/lib/visitors/visitTier";
 
-export type VisitorContributionKind = "report" | "suggestion";
+export type VisitorContributionKind = "report" | "suggestion" | "comment";
 
 type VisitorContributionDoc = {
   _id: string;
@@ -10,12 +10,13 @@ type VisitorContributionDoc = {
   isSpammer?: boolean;
   reportCount?: number;
   suggestionCount?: number;
+  commentCount?: number;
   contributionScore?: number;
 };
 
 /**
  * Increments contribution counters for a visitor and recomputes tier.
- * Used for successful key reports and key suggestions.
+ * Used for successful key reports, key suggestions, and program comments.
  */
 export async function upsertVisitorContribution(
   visitorHash: string | undefined,
@@ -31,6 +32,7 @@ export async function upsertVisitorContribution(
       isSpammer,
       reportCount,
       suggestionCount,
+      commentCount,
       contributionScore
     }`,
     { h: visitorHash }
@@ -39,11 +41,13 @@ export async function upsertVisitorContribution(
   const prevVisitCount = existing?.visitCount ?? 0;
   const prevReportCount = existing?.reportCount ?? 0;
   const prevSuggestionCount = existing?.suggestionCount ?? 0;
+  const prevCommentCount = existing?.commentCount ?? 0;
   const prevContributionScore = existing?.contributionScore ?? 0;
   const isSpammer = existing?.isSpammer === true;
 
   const nextReportCount = kind === "report" ? prevReportCount + 1 : prevReportCount;
   const nextSuggestionCount = kind === "suggestion" ? prevSuggestionCount + 1 : prevSuggestionCount;
+  const nextCommentCount = kind === "comment" ? prevCommentCount + 1 : prevCommentCount;
   const nextContributionScore = prevContributionScore + 1;
   const nextVisitTier = resolveVisitTier(prevVisitCount, nextContributionScore, isSpammer);
 
@@ -52,10 +56,12 @@ export async function upsertVisitorContribution(
     const visitCount = archived?.visitCount ?? 0;
     const restoredReport = archived?.reportCount ?? 0;
     const restoredSuggestion = archived?.suggestionCount ?? 0;
+    const restoredComment = archived?.commentCount ?? 0;
     const restoredScore = archived?.contributionScore ?? 0;
     const isSpammer = archived?.isSpammer === true;
     const reportCount = kind === "report" ? restoredReport + 1 : restoredReport;
     const suggestionCount = kind === "suggestion" ? restoredSuggestion + 1 : restoredSuggestion;
+    const commentCount = kind === "comment" ? restoredComment + 1 : restoredComment;
     const contributionScore = restoredScore + 1;
     await client.create({
       _type: "visitor",
@@ -66,6 +72,7 @@ export async function upsertVisitorContribution(
       isSpammer,
       reportCount,
       suggestionCount,
+      commentCount,
       contributionScore,
       createdAt: now,
       updatedAt: now
@@ -78,9 +85,57 @@ export async function upsertVisitorContribution(
     .set({
       reportCount: nextReportCount,
       suggestionCount: nextSuggestionCount,
+      commentCount: nextCommentCount,
       contributionScore: nextContributionScore,
       visitTier: nextVisitTier,
+      lastActivityAt: now,
       updatedAt: now
     })
     .commit();
+}
+
+/** Ensures a visitor doc exists and bumps lastActivityAt (no contribution increment). */
+export async function touchVisitorActivity(visitorHash: string | undefined): Promise<void> {
+  if (!visitorHash) return;
+
+  const now = new Date().toISOString();
+  const existing = await client.fetch<VisitorContributionDoc | null>(
+    `*[_type == "visitor" && visitorHash == $h][0]{
+      _id,
+      visitCount,
+      isSpammer,
+      reportCount,
+      suggestionCount,
+      commentCount,
+      contributionScore
+    }`,
+    { h: visitorHash }
+  );
+
+  if (existing?._id) {
+    await client.patch(existing._id).set({ lastActivityAt: now, updatedAt: now }).commit();
+    return;
+  }
+
+  const archived = await fetchVisitorByHash(visitorHash);
+  const visitCount = archived?.visitCount ?? 0;
+  const contributionScore = archived?.contributionScore ?? 0;
+  const isSpammer = archived?.isSpammer === true;
+
+  await client.create({
+    _type: "visitor",
+    visitorHash,
+    visitCount,
+    lastActivityAt: now,
+    visitTier: resolveVisitTier(visitCount, contributionScore, isSpammer),
+    isSpammer,
+    reportCount: archived?.reportCount ?? 0,
+    suggestionCount: archived?.suggestionCount ?? 0,
+    commentCount: archived?.commentCount ?? 0,
+    contributionScore,
+    ...(archived?.country ? { country: archived.country } : {}),
+    ...(archived?.city ? { city: archived.city } : {}),
+    createdAt: now,
+    updatedAt: now
+  });
 }

--- a/src/lib/visitors/upsertVisitorOnPageView.ts
+++ b/src/lib/visitors/upsertVisitorOnPageView.ts
@@ -40,6 +40,7 @@ export async function upsertVisitorOnPageView(
       isSpammer,
       reportCount: archived?.reportCount ?? 0,
       suggestionCount: archived?.suggestionCount ?? 0,
+      commentCount: archived?.commentCount ?? 0,
       contributionScore,
       ...(location?.country ? { country: location.country } : {}),
       ...(location?.city ? { city: location.city } : {}),

--- a/src/lib/visitors/visitTier.ts
+++ b/src/lib/visitors/visitTier.ts
@@ -1,5 +1,5 @@
 export type VisitTier = "new" | "returning" | "regular" | "star";
-export type ContributionType = "none" | "reports_only" | "suggestions_only" | "mixed";
+export type ContributionType = "none" | "reports_only" | "suggestions_only" | "comments_only" | "mixed";
 
 /** Maps session count to baseline tier: ≤1 new, ≤5 returning, else regular. */
 export function visitTierFromSessionCount(n: number): VisitTier {
@@ -15,11 +15,19 @@ export function resolveVisitTier(visitCount: number, contributionScore: number, 
 }
 
 /** Derives contribution type for accurate, evidence-based messaging. */
-export function contributionTypeFromCounts(reportCount: number, suggestionCount: number): ContributionType {
-  const hasReports = reportCount > 0;
-  const hasSuggestions = suggestionCount > 0;
-  if (hasReports && hasSuggestions) return "mixed";
-  if (hasReports) return "reports_only";
-  if (hasSuggestions) return "suggestions_only";
-  return "none";
+export function contributionTypeFromCounts(
+  reportCount: number,
+  suggestionCount: number,
+  commentCount = 0
+): ContributionType {
+  const kinds = [
+    reportCount > 0,
+    suggestionCount > 0,
+    commentCount > 0
+  ].filter(Boolean).length;
+  if (kinds === 0) return "none";
+  if (kinds > 1) return "mixed";
+  if (reportCount > 0) return "reports_only";
+  if (suggestionCount > 0) return "suggestions_only";
+  return "comments_only";
 }

--- a/src/lib/visitors/visitorLookup.ts
+++ b/src/lib/visitors/visitorLookup.ts
@@ -10,6 +10,7 @@ export type ResolvedVisitor = {
   visitCount?: number;
   reportCount?: number;
   suggestionCount?: number;
+  commentCount?: number;
   contributionScore?: number;
   country?: string;
   city?: string;
@@ -43,10 +44,10 @@ export async function fetchVisitorByHash(visitorHash: string): Promise<ResolvedV
   }>(
     `{
       "live": *[_type == "visitor" && visitorHash == $h][0]{
-        _id, visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, contributionScore, country, city, lastActivityAt
+        _id, visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, commentCount, contributionScore, country, city, lastActivityAt
       },
       "archived": *[_type == "visitorBundle"].visitors[visitorHash == $h]{
-        visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, contributionScore, country, city, lastActivityAt
+        visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, commentCount, contributionScore, country, city, lastActivityAt
       }
     }`,
     { h: visitorHash }
@@ -67,10 +68,10 @@ export async function fetchVisitorsByHashes(
   }>(
     `{
       "live": *[_type == "visitor" && visitorHash in $hashes]{
-        _id, visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, contributionScore, country, city, lastActivityAt
+        _id, visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, commentCount, contributionScore, country, city, lastActivityAt
       },
       "archived": *[_type == "visitorBundle"].visitors[visitorHash in $hashes]{
-        visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, contributionScore, country, city, lastActivityAt
+        visitorHash, isSpammer, visitTier, visitCount, reportCount, suggestionCount, commentCount, contributionScore, country, city, lastActivityAt
       }
     }`,
     { hashes: unique }

--- a/src/sanity/schemaTypes/analytics/bundledVisitor.ts
+++ b/src/sanity/schemaTypes/analytics/bundledVisitor.ts
@@ -25,6 +25,7 @@ export const bundledVisitor = defineType({
     defineField({ name: "isSpammer", title: "Spammer", type: "boolean" }),
     defineField({ name: "reportCount", title: "Key reports", type: "number" }),
     defineField({ name: "suggestionCount", title: "Key suggestions", type: "number" }),
+    defineField({ name: "commentCount", title: "Program comments", type: "number" }),
     defineField({ name: "contributionScore", title: "Contribution score", type: "number" }),
     defineField({ name: "spamMarkedAt", title: "Marked spam at", type: "datetime" }),
     defineField({ name: "country", title: "Country", type: "string" }),

--- a/src/sanity/schemaTypes/analytics/visitor.ts
+++ b/src/sanity/schemaTypes/analytics/visitor.ts
@@ -62,10 +62,17 @@ export const visitor = defineType({
       validation: Rule => Rule.required().min(0)
     }),
     defineField({
+      name: "commentCount",
+      title: "Program comments posted",
+      type: "number",
+      initialValue: 0,
+      validation: Rule => Rule.required().min(0)
+    }),
+    defineField({
       name: "contributionScore",
       title: "Contribution score",
       type: "number",
-      description: "Incremented for each valid key report and key suggestion.",
+      description: "Incremented for each valid key report, key suggestion, and program comment.",
       initialValue: 0,
       validation: Rule => Rule.required().min(0)
     }),

--- a/src/sanity/schemaTypes/contact/contactMessage.ts
+++ b/src/sanity/schemaTypes/contact/contactMessage.ts
@@ -48,6 +48,19 @@ export default defineType({
       initialValue: () => new Date().toISOString()
     }),
     defineField({
+      name: "lastRepliedAt",
+      title: "Last replied at",
+      type: "datetime",
+      readOnly: true
+    }),
+    defineField({
+      name: "replies",
+      title: "Replies",
+      type: "array",
+      of: [{ type: "contactMessageReply" }],
+      readOnly: true
+    }),
+    defineField({
       name: "ipHash",
       title: "Visitor Hash",
       type: "string",
@@ -58,12 +71,25 @@ export default defineType({
     select: {
       title: "title",
       subtitle: "message",
-      status: "status"
+      status: "status",
+      replyCount: "replies"
     },
-    prepare({ title, subtitle, status }: { title?: string; subtitle?: string; status?: string }) {
+    prepare({
+      title,
+      subtitle,
+      status,
+      replyCount
+    }: {
+      title?: string;
+      subtitle?: string;
+      status?: string;
+      replyCount?: unknown[];
+    }) {
+      const replies = Array.isArray(replyCount) ? replyCount.length : 0;
+      const replyLabel = replies > 0 ? ` · ${replies} repl${replies === 1 ? "y" : "ies"}` : "";
       return {
         title: title || "Untitled Message",
-        subtitle: `${status} - ${subtitle?.slice(0, 60)}...`
+        subtitle: `${status}${replyLabel} - ${subtitle?.slice(0, 60)}...`
       };
     }
   }

--- a/src/sanity/schemaTypes/contact/contactMessageReply.ts
+++ b/src/sanity/schemaTypes/contact/contactMessageReply.ts
@@ -1,0 +1,61 @@
+import { defineField, defineType } from "sanity";
+
+export const contactMessageReply = defineType({
+  name: "contactMessageReply",
+  title: "Message reply",
+  type: "object",
+  fields: [
+    defineField({
+      name: "body",
+      title: "Reply body",
+      type: "text",
+      rows: 4,
+      validation: Rule => Rule.required().max(10000)
+    }),
+    defineField({
+      name: "subject",
+      title: "Email subject",
+      type: "string",
+      validation: Rule => Rule.required().max(300)
+    }),
+    defineField({
+      name: "sentTo",
+      title: "Sent to",
+      type: "string",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "sentBy",
+      title: "Sent by (admin)",
+      type: "string",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "sentAt",
+      title: "Sent at",
+      type: "datetime",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "resendId",
+      title: "Resend message ID",
+      type: "string",
+      description: "Provider ID for delivery tracking."
+    })
+  ],
+  preview: {
+    select: { sentBy: "sentBy", body: "body", sentAt: "sentAt" },
+    prepare({ sentBy, body, sentAt }) {
+      const preview =
+        typeof body === "string" && body.trim()
+          ? body.trim().length > 60
+            ? `${body.trim().slice(0, 60)}…`
+            : body.trim()
+          : "Reply";
+      return {
+        title: typeof sentBy === "string" && sentBy.trim() ? sentBy.trim() : "Admin reply",
+        subtitle: sentAt ? `${preview} · ${sentAt}` : preview
+      };
+    }
+  }
+});

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -11,6 +11,7 @@ import { visitor } from "./analytics/visitor";
 import { cronRun } from "./system/cronRun";
 import { siteNotificationFeed } from "./system/siteNotificationFeed";
 import contactMessage from "./contact/contactMessage";
+import { contactMessageReply } from "./contact/contactMessageReply";
 import keySuggestion from "./contact/keySuggestion";
 
 import { storeDetails } from "./store/storeDetails";
@@ -39,6 +40,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     cronRun,
     siteNotificationFeed,
     contactMessage,
+    contactMessageReply,
     keySuggestion,
     link,
     storeSocialEntry,

--- a/src/sanity/schemaTypes/store/storeDetails.ts
+++ b/src/sanity/schemaTypes/store/storeDetails.ts
@@ -80,7 +80,7 @@ export const storeDetails = defineType({
           name: "programsMetaTitle",
           title: "Programs listing meta title",
           type: "string",
-          description: 'Example: "All Programs - [title]"'
+          description: 'Example: "All Giveaway Programs - Free PRO Software CD Keys | [title]"'
         }),
         defineField({
           name: "programsMetaDescription",

--- a/src/types/admin/programComments.ts
+++ b/src/types/admin/programComments.ts
@@ -4,6 +4,7 @@ export type AdminCommentVisitor = {
   visitCount?: number;
   reportCount?: number;
   suggestionCount?: number;
+  commentCount?: number;
   contributionScore?: number;
   country?: string;
   city?: string;

--- a/src/types/contact/index.ts
+++ b/src/types/contact/index.ts
@@ -1,3 +1,13 @@
+export interface ContactMessageReply {
+  _key?: string;
+  body: string;
+  subject: string;
+  sentTo: string;
+  sentBy: string;
+  sentAt: string;
+  resendId?: string;
+}
+
 export interface ContactMessage {
   _id: string;
   _createdAt: string;
@@ -8,6 +18,8 @@ export interface ContactMessage {
   ipHash?: string;
   status: "new" | "read" | "replied" | "archived";
   createdAt: string;
+  lastRepliedAt?: string;
+  replies?: ContactMessageReply[];
 }
 
 export interface ContactFormData {
@@ -27,6 +39,7 @@ export interface KeySuggestion {
   name?: string;
   email?: string;
   message?: string;
+  ipHash?: string;
   status: "new" | "reviewing" | "added" | "rejected";
   createdAt: string;
 }


### PR DESCRIPTION
## Summary

Admins can reply to contact messages by email from the dashboard, visitor-tier moderation tools expand across admin surfaces, and several SEO metadata and accessibility gaps close.

## Changelog

<!-- tags: feat, fix, ui, api -->

### Highlights

- Reply-to-visitor email flow from admin messages (Resend + mailto fallback)
- Shared visitor moderation panel and spammer marking across admin modals
- Stronger Open Graph metadata and meta title lengths on trust and program routes

### Admin

- Reply to contact messages with template preview, send via Resend, mailto draft, and reply history on the thread
- Shared AdminVisitorPanel / AdminVisitorSection and MarkSpammerButton on messages, comments, suggestions, and key reports
- Visitor upserts track comments and contributions; spammers blocked on contact, comments, and suggestions
- Custom /admin/signin page for GitHub sign-in across browsers (CSP form-action relaxed for prod domains)

### SEO & accessibility

- Open Graph helper adds og:site_name and og:image:secure_url across routes; fallback meta titles tuned to 32–60 chars
- Footer, home, and programs heading hierarchy fixes
- Vendor and about image alt text improvements

---

## Environment Variables

New optional Resend vars: RESEND_API_KEY, RESEND_FROM, RESEND_REPLY_TO. Existing auth vars unchanged.

## Testing

- Sign in to /admin in a fresh browser (Brave/Vivaldi) via GitHub
- Open a contact message → preview reply template → send via Resend and via mailto
- Mark a visitor as spammer from a message/comment modal; confirm blocked submissions
- Inspect page source on home, programs, trust pages for og:site_name, og:image:secure_url, and title length
- Spot-check footer/programs heading order and vendor logo alt text in devtools accessibility tree

## Technical Details

Sanity: new contactMessageReply type; contactMessage gains replies and lastRepliedAt; visitor gains commentCount and markedSpamAt; bundled visitor schema aligned.
