### PR TITLE
feat(program): community comments, taxonomy, and program discovery

### DIFF
--- a/src/app/api/v1/program-comments/ownership/route.ts
+++ b/src/app/api/v1/program-comments/ownership/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { client } from "@/src/sanity/lib/client";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { isLikelyBotUserAgent } from "@/src/lib/api/botUserAgent";
+import { getClientIp, hashIp } from "@/src/lib/api/requestGeo";
+import { isDevelopmentEnv } from "@/src/lib/env/isDevelopment";
+import { isProgramSlugPublished } from "@/src/lib/sanity/programSlugExists";
+import { fetchProgramCommentOwnership } from "@/src/lib/program/programCommentOwnership";
+
+async function resolveProgramId(slug: string): Promise<string | null> {
+  const program = await client.fetch<{ _id: string } | null>(
+    `*[_type == "program" && slug.current == $slug][0]{ _id }`,
+    { slug }
+  );
+  return program?._id ?? null;
+}
+
+/** GET /api/v1/program-comments/ownership?programSlug= — comment/reply keys owned by this visitor */
+export async function GET(req: NextRequest) {
+  const isDev = isDevelopmentEnv();
+  if (!isDev && isLikelyBotUserAgent(req.headers.get("user-agent"))) {
+    return Errors.badRequest("Automated requests are not allowed");
+  }
+
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const programSlug = req.nextUrl.searchParams.get("programSlug")?.trim() ?? "";
+  if (!programSlug) {
+    return Errors.validation("programSlug is required", [{ field: "programSlug", message: "Required" }]);
+  }
+
+  const ipHash = hashIp(getClientIp(req)) ?? (isDev ? "dev-local" : undefined);
+  if (!ipHash) return Errors.badRequest("Unable to process request");
+
+  const published = await isProgramSlugPublished(programSlug);
+  if (!published) return Errors.notFound("Program not found");
+
+  const programId = await resolveProgramId(programSlug);
+  if (!programId) return Errors.notFound("Program not found");
+
+  const data = await fetchProgramCommentOwnership(programId, ipHash);
+
+  return NextResponse.json({ data, meta: {} });
+}

--- a/src/app/api/v1/program-comments/reactions/route.ts
+++ b/src/app/api/v1/program-comments/reactions/route.ts
@@ -1,0 +1,157 @@
+import { NextRequest, NextResponse } from "next/server";
+import { client } from "@/src/sanity/lib/client";
+import { Errors } from "@/src/lib/api/errors";
+import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
+import { isLikelyBotUserAgent } from "@/src/lib/api/botUserAgent";
+import { getClientIp, hashIp } from "@/src/lib/api/requestGeo";
+import { isDevelopmentEnv } from "@/src/lib/env/isDevelopment";
+import { isProgramSlugPublished } from "@/src/lib/sanity/programSlugExists";
+import { fetchVisitorByHash } from "@/src/lib/visitors/visitorLookup";
+import { MAX_REACTIONS_PER_VISITOR, sanitizeReactionEmoji } from "@/src/lib/program/commentReactions";
+import {
+  fetchProgramReactionSummaryMap,
+  toggleCommentReaction,
+  type ReactionTarget
+} from "@/src/lib/program/toggleCommentReaction";
+
+async function resolveProgramId(slug: string): Promise<string | null> {
+  const program = await client.fetch<{ _id: string } | null>(
+    `*[_type == "program" && slug.current == $slug][0]{ _id }`,
+    { slug }
+  );
+  return program?._id ?? null;
+}
+
+/** GET /api/v1/program-comments/reactions?programSlug= — full summaries + reacted flags for this visitor */
+export async function GET(req: NextRequest) {
+  const isDev = isDevelopmentEnv();
+  if (!isDev && isLikelyBotUserAgent(req.headers.get("user-agent"))) {
+    return Errors.badRequest("Automated requests are not allowed");
+  }
+
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  const programSlug = req.nextUrl.searchParams.get("programSlug")?.trim() ?? "";
+  if (!programSlug) {
+    return Errors.validation("programSlug is required", [{ field: "programSlug", message: "Required" }]);
+  }
+
+  const ipHash = hashIp(getClientIp(req)) ?? (isDev ? "dev-local" : undefined);
+  if (!ipHash) return Errors.badRequest("Unable to process request");
+
+  const published = await isProgramSlugPublished(programSlug);
+  if (!published) return Errors.notFound("Program not found");
+
+  const programId = await resolveProgramId(programSlug);
+  if (!programId) return Errors.notFound("Program not found");
+
+  const data = await fetchProgramReactionSummaryMap(programId, ipHash);
+
+  return NextResponse.json({ data, meta: {} });
+}
+
+/** POST /api/v1/program-comments/reactions — toggle emoji on a comment or reply */
+export async function POST(req: NextRequest) {
+  const isDev = isDevelopmentEnv();
+
+  if (!isDev && isLikelyBotUserAgent(req.headers.get("user-agent"))) {
+    return Errors.badRequest("Automated requests are not allowed");
+  }
+
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  try {
+    const ipHash = hashIp(getClientIp(req)) ?? (isDev ? "dev-local" : undefined);
+    if (!ipHash) return Errors.badRequest("Unable to process request");
+
+    const body = await req.json().catch(() => ({}));
+    if (!body || typeof body !== "object") return Errors.badRequest("Request body is required");
+
+    const b = body as Record<string, unknown>;
+    const programSlug = typeof b.programSlug === "string" ? b.programSlug.trim() : "";
+    const commentKey = typeof b.commentKey === "string" ? b.commentKey.trim() : "";
+    const replyKeyRaw = typeof b.replyKey === "string" ? b.replyKey.trim() : "";
+    const replyKey = replyKeyRaw || undefined;
+    const emoji = sanitizeReactionEmoji(b.emoji);
+
+    if (!programSlug) {
+      return Errors.validation("programSlug is required", [{ field: "programSlug", message: "Required" }]);
+    }
+    if (!commentKey) {
+      return Errors.validation("commentKey is required", [{ field: "commentKey", message: "Required" }]);
+    }
+    if (!emoji) {
+      return Errors.validation("emoji is required", [{ field: "emoji", message: "Invalid emoji" }]);
+    }
+
+    if (!isDev) {
+      const visitor = await fetchVisitorByHash(ipHash);
+      if (visitor?.isSpammer) {
+        return Errors.validation("Reacting is disabled for your network.", [
+          { field: "emoji", message: "Reacting disabled" }
+        ]);
+      }
+    }
+
+    const published = await isProgramSlugPublished(programSlug);
+    if (!published) return Errors.notFound("Program not found");
+
+    const programId = await resolveProgramId(programSlug);
+    if (!programId) return Errors.notFound("Program not found");
+
+    if (replyKey) {
+      const replyExists = await client.fetch<boolean>(
+        `defined(*[_id == $id][0].programComments[_key == $commentKey][0].replies[_key == $replyKey][0])`,
+        { id: programId, commentKey, replyKey }
+      );
+      if (!replyExists) {
+        return Errors.validation("replyKey is invalid", [{ field: "replyKey", message: "Reply not found" }]);
+      }
+    } else {
+      const commentExists = await client.fetch<boolean>(
+        `defined(*[_id == $id][0].programComments[_key == $key][0])`,
+        { id: programId, key: commentKey }
+      );
+      if (!commentExists) {
+        return Errors.validation("commentKey is invalid", [{ field: "commentKey", message: "Comment not found" }]);
+      }
+    }
+
+    const target: ReactionTarget = replyKey
+      ? { kind: "reply", commentKey, replyKey }
+      : { kind: "comment", commentKey };
+
+    const result = await toggleCommentReaction({
+      programId,
+      target,
+      emoji,
+      ipHash
+    });
+
+    return NextResponse.json({
+      data: {
+        commentKey,
+        replyKey: replyKey ?? null,
+        storageKey: result.storageKey,
+        action: result.action,
+        reactions: result.reactions
+      },
+      meta: {}
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message === "REACTION_LIMIT") {
+      return Errors.validation("This thread has reached the maximum number of reactions.");
+    }
+    if (err instanceof Error && err.message === "VISITOR_EMOJI_LIMIT") {
+      return Errors.validation(
+        `You can react with at most ${MAX_REACTIONS_PER_VISITOR} different emojis on one comment.`,
+        [{ field: "emoji", message: "Too many emojis" }]
+      );
+    }
+    console.error("[POST /api/v1/program-comments/reactions]", err);
+    return Errors.internal();
+  }
+}
+

--- a/src/app/api/v1/program-comments/route.ts
+++ b/src/app/api/v1/program-comments/route.ts
@@ -8,6 +8,7 @@ import { getClientIp, hashIp } from "@/src/lib/api/requestGeo";
 import { revalidateAfterProgramContentWrite } from "@/src/lib/cache/revalidateProgramContent";
 import { appendProgramComment } from "@/src/lib/program/appendProgramComment";
 import { moderateCommentInput } from "@/src/lib/program/moderateComment";
+import { updateProgramCommentBody, type CommentTarget } from "@/src/lib/program/updateProgramComment";
 import {
   MAX_COMMENT_AUTHOR,
   MAX_COMMENT_BODY,
@@ -147,6 +148,110 @@ export async function POST(req: NextRequest) {
       return Errors.validation("This program has reached the maximum number of comments.");
     }
     console.error("[POST /api/v1/program-comments]", err);
+    return Errors.internal();
+  }
+}
+
+/** PATCH /api/v1/program-comments — edit own comment or reply body */
+export async function PATCH(req: NextRequest) {
+  const isDev = isDevelopmentEnv();
+
+  if (!isDev && isLikelyBotUserAgent(req.headers.get("user-agent"))) {
+    return Errors.badRequest("Automated requests are not allowed");
+  }
+
+  const { ok: rateOk } = rateLimitMiddleware(req);
+  if (!rateOk) return Errors.tooManyRequests();
+
+  try {
+    const ipHash = hashIp(getClientIp(req)) ?? (isDev ? "dev-local" : undefined);
+    if (!ipHash) return Errors.badRequest("Unable to process request");
+
+    const body = await req.json().catch(() => ({}));
+    if (!body || typeof body !== "object") return Errors.badRequest("Request body is required");
+
+    const b = body as Record<string, unknown>;
+    const programSlug = typeof b.programSlug === "string" ? b.programSlug.trim() : "";
+    const commentKey = typeof b.commentKey === "string" ? b.commentKey.trim() : "";
+    const replyKeyRaw = typeof b.replyKey === "string" ? b.replyKey.trim() : "";
+    const replyKey = replyKeyRaw || undefined;
+    const commentBody = sanitizeCommentBody(typeof b.body === "string" ? b.body : "");
+
+    if (!programSlug) {
+      return Errors.validation("programSlug is required", [{ field: "programSlug", message: "Required" }]);
+    }
+    if (!commentKey) {
+      return Errors.validation("commentKey is required", [{ field: "commentKey", message: "Required" }]);
+    }
+    if (!commentBody) {
+      return Errors.validation("body is required", [{ field: "body", message: "Required" }]);
+    }
+
+    const moderation = moderateCommentInput({ authorName: "edit", body: commentBody, honeypot: "" });
+    if (!moderation.ok) {
+      return Errors.validation(moderation.message, [
+        { field: moderation.field ?? "body", message: moderation.message }
+      ]);
+    }
+
+    if (!isDev) {
+      const visitor = await fetchVisitorByHash(ipHash);
+      if (visitor?.isSpammer) {
+        return Errors.validation("Editing is disabled for your network.", [
+          { field: "body", message: "Editing disabled" }
+        ]);
+      }
+    }
+
+    const published = await isProgramSlugPublished(programSlug);
+    if (!published) return Errors.notFound("Program not found");
+
+    const program = await client.fetch<{ _id: string } | null>(
+      `*[_type == "program" && slug.current == $slug][0]{ _id }`,
+      { slug: programSlug }
+    );
+    if (!program?._id) return Errors.notFound("Program not found");
+
+    if (replyKey) {
+      const replyExists = await client.fetch<boolean>(
+        `defined(*[_id == $id][0].programComments[_key == $commentKey][0].replies[_key == $replyKey][0])`,
+        { id: program._id, commentKey, replyKey }
+      );
+      if (!replyExists) {
+        return Errors.validation("replyKey is invalid", [{ field: "replyKey", message: "Reply not found" }]);
+      }
+    } else {
+      const commentExists = await client.fetch<boolean>(
+        `defined(*[_id == $id][0].programComments[_key == $key][0])`,
+        { id: program._id, key: commentKey }
+      );
+      if (!commentExists) {
+        return Errors.validation("commentKey is invalid", [{ field: "commentKey", message: "Comment not found" }]);
+      }
+    }
+
+    const target: CommentTarget = replyKey
+      ? { kind: "reply", commentKey, replyKey }
+      : { kind: "comment", commentKey };
+
+    const result = await updateProgramCommentBody({
+      programId: program._id,
+      target,
+      body: commentBody,
+      ipHash
+    });
+
+    revalidateAfterProgramContentWrite({ slug: programSlug });
+
+    return NextResponse.json({
+      data: { commentKey, replyKey: replyKey ?? null, body: commentBody, editedAt: result.editedAt },
+      meta: {}
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message === "FORBIDDEN") {
+      return Errors.forbidden("You can only edit your own comments.");
+    }
+    console.error("[PATCH /api/v1/program-comments]", err);
     return Errors.internal();
   }
 }

--- a/src/app/api/v1/programs/list/route.ts
+++ b/src/app/api/v1/programs/list/route.ts
@@ -16,7 +16,9 @@ export async function GET(req: NextRequest) {
       sp.get("search") ?? undefined,
       sp.get("filter") ?? undefined,
       sp.get("sort") ?? undefined,
-      sp.get("page") ?? undefined
+      sp.get("page") ?? undefined,
+      sp.get("category") ?? undefined,
+      sp.get("platform") ?? undefined
     );
 
     return NextResponse.json(

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -128,7 +128,7 @@
 body {
   background: var(--background);
   color: var(--text-primary);
-  font-family: var(--font-geist-sans), "Noto Sans", Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans), "Noto Color Emoji", "Noto Sans", Arial, Helvetica, sans-serif;
 }
 
 @layer utilities {
@@ -137,6 +137,13 @@ body {
   }
   .static-bg {
     background: #0f1923;
+  }
+  /** Color emoji stack — avoids Geist/Noto Sans empty glyphs on pictographs (e.g. 🫡). */
+  .font-emoji {
+    font-family: "Noto Color Emoji", emoji, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif;
+    font-style: normal;
+    font-weight: normal;
+    line-height: 1;
   }
   /* Eyebrow / kicker above section titles — matches Featured + Hero chips */
   .section-label {
@@ -213,7 +220,7 @@ body {
       transform 0.15s;
   }
 
-  .card-base:hover {
+  .card-base:not(.no-hover):hover {
     background: var(--surface-raised);
     border-color: var(--border-strong);
     transform: translateY(-2px);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -108,7 +108,15 @@ export default async function RootLayout({
 
   return (
     <html lang="en" data-scroll-behavior="smooth" suppressHydrationWarning>
-      <head>{renderedHeadMetaTags}</head>
+      <head>
+        {renderedHeadMetaTags}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#0f1923] text-[#c6d4df]`}
         suppressHydrationWarning>

--- a/src/app/program/[slug]/page.tsx
+++ b/src/app/program/[slug]/page.tsx
@@ -82,8 +82,12 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
   const introVersionConfirmation = getCdKeyTableIntroVersionConfirmation(program, highestKeyVersion);
   const versionSummaryLine = formatVersionSummaryLine(program, highestKeyVersion);
 
-  const [allPrograms, store, communityRating, shareCounts] = await Promise.all([
-    getCachedRelatedPrograms(),
+  const [relatedPrograms, store, communityRating, shareCounts] = await Promise.all([
+    getCachedRelatedPrograms({
+      slug,
+      categories: program.categories,
+      vendor: program.vendor
+    }),
     getCachedStoreDetailsDocument(),
     getProgramAggregateRating(slug),
     getProgramShareCounts(slug)
@@ -96,10 +100,7 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
     socialLinks: store?.socialLinks ?? []
   };
 
-  const relatedPrograms = allPrograms
-    .filter(p => p.slug.current !== slug)
-    .slice(0, 5)
-    .map(p => ({ ...p, cdKeys: p.cdKeys ?? [] }));
+  const relatedProgramsWithKeys = relatedPrograms.map(p => ({ ...p, cdKeys: p.cdKeys ?? [] }));
 
   const faqItems =
     program.faq?.filter((f: ProgramFaqItem) => f.question?.trim() && portableTextHasContent(f.answer)) ?? [];
@@ -149,7 +150,7 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
         <ProgramAboutSection program={program} />
         <ContributeBanner />
         <ProgramFaqSection programTitle={program.title} items={faqItems} />
-        <RelatedPrograms programs={relatedPrograms} />
+        <RelatedPrograms programs={relatedProgramsWithKeys} />
         <CommentsSection program={program} />
       </I18nShell>
     </>

--- a/src/app/programs/ProgramsPageClient.tsx
+++ b/src/app/programs/ProgramsPageClient.tsx
@@ -7,8 +7,9 @@ import type { ProgramsListData } from "@/src/lib/programs/getProgramsPageData";
 import { FilterType, SortType } from "@/src/types/programs";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { scrollToSectionWithHeaderOffset } from "@/src/lib/dom/scrollToSection";
-import { normalizeFilterType, normalizeSortType } from "@/src/lib/program/programUtils";
+import { normalizeFilterType, normalizeSortType, normalizeCategoryFilter, normalizePlatformFilter } from "@/src/lib/program/programUtils";
 import type { ProgramWithStats } from "@/src/types/home";
+import type { PlatformFilterType, ProgramCategoryOption } from "@/src/types/programs";
 import HomeVendorBrowse from "@/src/components/home/HomeVendorBrowse";
 import type { VendorListItem } from "@/src/lib/vendors/getVendors";
 
@@ -20,20 +21,31 @@ function readListParams(searchParams: URLSearchParams) {
     searchTerm: (searchParams.get("search") || "").trim(),
     filter: normalizeFilterType(searchParams.get("filter") ?? undefined),
     sortBy: normalizeSortType(searchParams.get("sort") ?? undefined),
+    category: normalizeCategoryFilter(searchParams.get("category")),
+    platform: normalizePlatformFilter(searchParams.get("platform")),
     page: Math.max(1, Number.parseInt(searchParams.get("page") || "1", 10) || 1)
   };
 }
 
-function listParamsKey(p: { searchTerm: string; filter: FilterType; sortBy: SortType; page: number }): string {
-  return `${p.searchTerm}|${p.filter}|${p.sortBy}|${p.page}`;
+function listParamsKey(p: {
+  searchTerm: string;
+  filter: FilterType;
+  sortBy: SortType;
+  category: string;
+  platform: PlatformFilterType;
+  page: number;
+}): string {
+  return `${p.searchTerm}|${p.filter}|${p.sortBy}|${p.category}|${p.platform}|${p.page}`;
 }
 
 export default function ProgramsPageClient({
   initialListData,
-  vendors = []
+  vendors = [],
+  categoryOptions = []
 }: {
   initialListData: ProgramsListData;
   vendors?: VendorListItem[];
+  categoryOptions?: ProgramCategoryOption[];
 }) {
   const router = useRouter();
   const pathname = usePathname();
@@ -56,13 +68,15 @@ export default function ProgramsPageClient({
       searchTerm: initialListData.searchTerm,
       filter: initialListData.filter,
       sortBy: initialListData.sortBy,
+      category: initialListData.category,
+      platform: initialListData.platform,
       page: initialListData.page
     })
   );
   const skipInitialFetchRef = useRef(true);
 
   const params = readListParams(searchParams);
-  const { searchTerm, filter, sortBy, page } = params;
+  const { searchTerm, filter, sortBy, category, platform, page } = params;
   const [localSearch, setLocalSearch] = useState(searchTerm);
   const localSearchRef = useRef(searchTerm);
 
@@ -139,11 +153,22 @@ export default function ProgramsPageClient({
     return localSearchRef.current.trim();
   };
 
-  const updateQuery = (updates: Partial<{ search: string; filter: FilterType; sort: SortType; page: number }>) => {
+  const updateQuery = (
+    updates: Partial<{
+      search: string;
+      filter: FilterType;
+      sort: SortType;
+      category: string;
+      platform: PlatformFilterType;
+      page: number;
+    }>
+  ) => {
     const next = new URLSearchParams(searchParamsRef.current.toString());
     const nextSearch = resolveSearchForUrl(updates);
     const nextFilter = updates.filter ?? filter;
     const nextSort = updates.sort ?? sortBy;
+    const nextCategory = updates.category ?? category;
+    const nextPlatform = updates.platform ?? platform;
     const nextPage = updates.page ?? currentPage;
 
     if (nextSearch) next.set("search", nextSearch);
@@ -152,6 +177,10 @@ export default function ProgramsPageClient({
     else next.delete("filter");
     if (nextSort !== "popular") next.set("sort", nextSort);
     else next.delete("sort");
+    if (nextCategory !== "all") next.set("category", nextCategory);
+    else next.delete("category");
+    if (nextPlatform !== "all") next.set("platform", nextPlatform);
+    else next.delete("platform");
     if (nextPage > 1) next.set("page", String(nextPage));
     else next.delete("page");
 
@@ -189,6 +218,16 @@ export default function ProgramsPageClient({
     updateQuery({ sort: newSort, page: 1 });
   };
 
+  const handleCategoryChange = (categorySlug: string) => {
+    clearSearchDebounce();
+    updateQuery({ category: normalizeCategoryFilter(categorySlug), page: 1 });
+  };
+
+  const handlePlatformChange = (newPlatform: PlatformFilterType) => {
+    clearSearchDebounce();
+    updateQuery({ platform: newPlatform, page: 1 });
+  };
+
   const handleSearchInputChange = (value: string) => {
     localSearchRef.current = value;
     setLocalSearch(value);
@@ -209,10 +248,15 @@ export default function ProgramsPageClient({
         searchTerm={localSearch}
         filter={filter}
         sortBy={sortBy}
+        category={category}
+        platform={platform}
+        categories={categoryOptions}
         onSearchChange={handleSearchInputChange}
         onSearchCommit={commitSearchNow}
         onFilterChange={handleFilterChange}
         onSortChange={handleSortChange}
+        onCategoryChange={handleCategoryChange}
+        onPlatformChange={handlePlatformChange}
       />
 
       <div className="mb-4 sm:mb-6">

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -13,6 +13,7 @@ import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDe
 import { getFeaturedProgram } from "@/src/lib/sanity/sanityActions";
 import { getCachedVendorsWithCounts } from "@/src/lib/vendors/getVendors";
 import {
+  getCachedProgramCategoryOptions,
   getCachedProgramsForJsonLd,
   getCachedProgramsHeroTotals,
   getProgramsListData
@@ -26,20 +27,28 @@ export async function generateMetadata() {
 }
 
 interface ProgramsPageProps {
-  searchParams: Promise<{ search?: string; filter?: string; sort?: string; page?: string }>;
+  searchParams: Promise<{
+    search?: string;
+    filter?: string;
+    sort?: string;
+    page?: string;
+    category?: string;
+    platform?: string;
+  }>;
 }
 
 /** SSR first page for crawlers; client hydrates for filter/sort/pagination via cached `/api/v1/programs/list`. */
 export default async function ProgramsPage({ searchParams }: ProgramsPageProps) {
   const sp = await searchParams;
-  const [storeRow, featuredProgram, heroTotals, jsonLdPrograms, initialListData, vendors, shareCounts] =
+  const [storeRow, featuredProgram, heroTotals, jsonLdPrograms, initialListData, vendors, categoryOptions, shareCounts] =
     await Promise.all([
       getCachedStoreDetailsDocument(),
       getFeaturedProgram(),
       getCachedProgramsHeroTotals(),
       getCachedProgramsForJsonLd(),
-      getProgramsListData(sp.search, sp.filter, sp.sort, sp.page),
+      getProgramsListData(sp.search, sp.filter, sp.sort, sp.page, sp.category, sp.platform),
       getCachedVendorsWithCounts(),
+      getCachedProgramCategoryOptions(),
       getPageShareCounts("/programs")
     ]);
 
@@ -76,7 +85,11 @@ export default async function ProgramsPage({ searchParams }: ProgramsPageProps) 
             <p className="text-sm text-neutral-100">Loading programs…</p>
           </div>
         }>
-        <ProgramsPageClient initialListData={initialListData} vendors={vendors} />
+        <ProgramsPageClient
+          initialListData={initialListData}
+          vendors={vendors}
+          categoryOptions={categoryOptions}
+        />
       </Suspense>
 
       <ContributeSection />

--- a/src/components/home/ProgramCard.tsx
+++ b/src/components/home/ProgramCard.tsx
@@ -3,6 +3,7 @@ import { IdealImage } from "@/src/components/general/IdealImage";
 import { FaEye, FaDownload, FaKey, FaChevronRight } from "react-icons/fa";
 import { ProgramCardProps } from "@/src/types/home";
 import { portableTextHasContent, portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
+import ProgramCategoryChips from "@/src/components/program/ProgramCategoryChips";
 
 export default function ProgramCard({ program, stats, badges, showStats = true }: ProgramCardProps) {
   const viewKeysLabel = `View keys for ${program.title}`;
@@ -60,6 +61,8 @@ export default function ProgramCard({ program, stats, badges, showStats = true }
         <h3 className="mb-1 line-clamp-2 text-base font-bold leading-tight text-white transition-colors group-hover:text-white sm:text-lg lg:text-xl">
           {program.title}
         </h3>
+
+        <ProgramCategoryChips categories={program.categories} maxVisible={2} className="mb-2" />
 
         {program.descriptionPlain ? (
           <p className="mb-2 line-clamp-3 text-xs leading-relaxed text-neutral-100 sm:line-clamp-4 sm:text-sm">

--- a/src/components/program/ProgramCategoryChips.tsx
+++ b/src/components/program/ProgramCategoryChips.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import type { ProgramCategoryRef } from "@/src/types/program";
+
+type ProgramCategoryChipsProps = {
+  categories?: ProgramCategoryRef[] | null;
+  /** Max chips before "+N" (cards). Program page shows all. */
+  maxVisible?: number;
+  linkToProgramsFilter?: boolean;
+  className?: string;
+};
+
+export default function ProgramCategoryChips({
+  categories,
+  maxVisible,
+  linkToProgramsFilter = true,
+  className = ""
+}: ProgramCategoryChipsProps) {
+  const items = (categories ?? []).filter(c => c.title?.trim() && c.slug?.trim());
+  if (items.length === 0) return null;
+
+  const limit = maxVisible && maxVisible > 0 ? maxVisible : items.length;
+  const visible = items.slice(0, limit);
+  const overflow = items.length - visible.length;
+
+  const chipClass =
+    "inline-flex items-center rounded-sm border border-[#2a475e] bg-[#1b2838] px-2 py-0.5 text-xs font-medium text-[#8f98a0] transition-colors hover:border-[#4a90c4] hover:text-[#c6d4df]";
+
+  return (
+    <div className={`flex flex-wrap items-center gap-1.5 ${className}`.trim()}>
+      {visible.map(cat => {
+        const label = cat.title.trim();
+        const slug = cat.slug!.trim();
+        if (linkToProgramsFilter) {
+          return (
+            <Link
+              key={cat._id ?? slug}
+              href={`/programs?category=${encodeURIComponent(slug)}`}
+              className={chipClass}>
+              {label}
+            </Link>
+          );
+        }
+        return (
+          <span key={cat._id ?? slug} className={chipClass}>
+            {label}
+          </span>
+        );
+      })}
+      {overflow > 0 ? (
+        <span className="text-xs font-medium text-[#556772]">+{overflow}</span>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/program/ProgramInformation.tsx
+++ b/src/components/program/ProgramInformation.tsx
@@ -18,6 +18,7 @@ import RichText from "@/src/components/portableText/RichText";
 import { portableTextHasContent } from "@/src/lib/portableText/toPlainText";
 import { useI18n } from "@/src/contexts/i18n";
 import ProgramCommentsJumpLink from "@/src/components/program/comments/ProgramCommentsJumpLink";
+import ProgramCategoryChips from "@/src/components/program/ProgramCategoryChips";
 import { countProgramDiscussionPosts } from "@/src/lib/program/countProgramComments";
 
 const PROGRAM_HERO_IMAGE_SIZES = "(max-width: 1023px) 98vw, (max-width: 1450px) 48vw, 680px" as const;
@@ -78,6 +79,7 @@ export default function ProgramInformation({
                 <h1 className="section-title h2 min-w-0 flex-1 max-w-[540px]">{formatProgramDisplayTitle(program)}</h1>
                 <ProgramCommentsJumpLink count={commentCount} className="mt-0.5" />
               </div>
+              <ProgramCategoryChips categories={program.categories} className="mb-3" />
               <p className="text-base leading-relaxed text-neutral-100 sm:text-lg">{heroSubtitle}</p>
             </div>
           </div>

--- a/src/components/program/RelatedPrograms.tsx
+++ b/src/components/program/RelatedPrograms.tsx
@@ -4,7 +4,7 @@ import { useState, useLayoutEffect, useMemo } from "react";
 import Link from "next/link";
 import { FaChevronLeft, FaChevronRight, FaDesktop } from "react-icons/fa";
 import { IdealImage } from "@/src/components/general/IdealImage";
-import { Program } from "@/src/types";
+import { Program, ProgramPlatform } from "@/src/types";
 
 interface RelatedProgramsProps {
   programs: Program[];
@@ -53,6 +53,28 @@ function WindowsGlyph({ className }: { className?: string }) {
   );
 }
 
+/** Apple mark for macOS platform row. */
+function MacGlyph({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" className={className} aria-hidden>
+      <path
+        fill="currentColor"
+        d="M12.07 8.44c-.03-1.86 1.52-2.75 1.59-2.8-0.87-1.27-2.22-1.44-2.7-1.46-1.15-.12-2.25.68-2.83.68-.59 0-1.5-.66-2.47-.64-1.27.02-2.44.74-3.09 1.88-1.32 2.29-.34 5.68.95 7.54.63.91 1.38 1.93 2.37 1.89.95-.04 1.31-.61 2.46-.61 1.15 0 1.47.61 2.48.59 1.03-.02 1.68-.93 2.3-1.84.72-1.05 1.02-2.07 1.04-2.12-.02-.01-2-.77-2.02-3.05zm-1.9-5.5c.53-.64.89-1.53.79-2.42-.76.03-1.68.51-2.22 1.15-.49.57-.92 1.48-.8 2.35.85.07 1.71-.43 2.23-1.08z"
+      />
+    </svg>
+  );
+}
+
+const glyphClass = "h-3.5 w-3.5 shrink-0 text-[#7a8799] sm:h-4 sm:w-4";
+
+function programPlatforms(program: Program): ProgramPlatform[] {
+  const raw = program.platforms;
+  if (Array.isArray(raw) && raw.length > 0) {
+    return raw.filter((p): p is ProgramPlatform => p === "windows" || p === "mac");
+  }
+  return ["windows"];
+}
+
 const navBtn =
   "flex shrink-0 cursor-pointer items-center justify-center self-center border-0 bg-transparent p-2 text-xl leading-none text-[#8fa3b8] transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#66c0f4] focus-visible:ring-offset-2 focus-visible:ring-offset-[#1D2634] disabled:cursor-pointer disabled:opacity-35 sm:p-2.5 sm:text-2xl";
 
@@ -63,6 +85,8 @@ const paginationBtn =
   "flex min-h-11 min-w-9 cursor-pointer items-center justify-center rounded-sm py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#66c0f4] focus-visible:ring-offset-2 focus-visible:ring-offset-[#202B3B]";
 
 function ProgramTile({ program }: { program: Program }) {
+  const platforms = programPlatforms(program);
+
   return (
     <Link href={`/program/${program.slug.current}`} className="group block h-full min-w-0 cursor-pointer">
       <article className="flex h-full flex-col gap-3 overflow-hidden rounded-sm bg-[#0E141B] ring-1 ring-black/25 transition-shadow duration-200 hover:shadow-[0_6px_20px_rgba(0,0,0,0.35)] p-4">
@@ -83,7 +107,10 @@ function ProgramTile({ program }: { program: Program }) {
         <h3 className="line-clamp-2 text-lg font-semibold leading-snug text-white">{program.title}</h3>
 
         <div className="flex items-center gap-2">
-          <WindowsGlyph className="h-3.5 w-3.5 shrink-0 text-[#7a8799] sm:h-4 sm:w-4" />
+          <span className="flex shrink-0 items-center gap-1">
+            {platforms.includes("windows") ? <WindowsGlyph className={glyphClass} /> : null}
+            {platforms.includes("mac") ? <MacGlyph className={glyphClass} /> : null}
+          </span>
           <span className="grow text-sm text-[#8b9aad]">Free</span>
           <span className="shrink-0 rounded-sm bg-[#bef571] px-3 py-1.5 text-center text-xs font-bold text-black sm:px-3.5 sm:text-sm">
             Get keys

--- a/src/components/program/comments/CommentReactions.tsx
+++ b/src/components/program/comments/CommentReactions.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FaRegSmile } from "react-icons/fa";
+import EmojiPickerPopover from "@/src/components/program/comments/EmojiPickerPopover";
+import {
+  aggregateCommentReactions,
+  applyOptimisticReactionToggle,
+  canVisitorAddReaction,
+  countVisitorReactionTypes,
+  MAX_REACTIONS_PER_VISITOR,
+  orderReactionsForDisplay
+} from "@/src/lib/program/commentReactions";
+import type { ProgramCommentReaction, ProgramCommentReactionSummary } from "@/src/types/program";
+
+type CommentReactionsProps = {
+  programSlug: string;
+  commentKey: string;
+  replyKey?: string;
+  initialReactions?: ProgramCommentReaction[];
+  /** Full summaries with counts + `reacted` (from GET). Display applies visibility rules. */
+  summaries?: ProgramCommentReactionSummary[] | null;
+  disabled?: boolean;
+};
+
+export default function CommentReactions({
+  programSlug,
+  commentKey,
+  replyKey,
+  initialReactions,
+  summaries,
+  disabled = false
+}: CommentReactionsProps) {
+  const [allSummaries, setAllSummaries] = useState<ProgramCommentReactionSummary[]>(() =>
+    summaries ?? aggregateCommentReactions(initialReactions)
+  );
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showPicker, setShowPicker] = useState(false);
+  const emojiButtonRef = useRef<HTMLButtonElement>(null);
+  const allSummariesRef = useRef(allSummaries);
+  allSummariesRef.current = allSummaries;
+
+  useEffect(() => {
+    if (summaries) setAllSummaries(summaries);
+  }, [summaries]);
+
+  const visibleItems = useMemo(() => orderReactionsForDisplay(allSummaries), [allSummaries]);
+
+  const atVisitorEmojiLimit = countVisitorReactionTypes(allSummaries) >= MAX_REACTIONS_PER_VISITOR;
+
+  const toggleEmoji = useCallback(
+    async (emoji: string) => {
+      if (disabled || busy || !emoji) return;
+
+      const prev = allSummariesRef.current;
+      const row = prev.find(r => r.emoji === emoji);
+      const isRemoving = Boolean(row?.reacted);
+
+      if (!isRemoving && !canVisitorAddReaction(prev, emoji)) {
+        setError(`You can react with at most ${MAX_REACTIONS_PER_VISITOR} different emojis here.`);
+        return;
+      }
+
+      setBusy(true);
+      setError(null);
+      setAllSummaries(applyOptimisticReactionToggle(prev, emoji));
+
+      try {
+        const res = await fetch("/api/v1/program-comments/reactions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            programSlug,
+            commentKey,
+            ...(replyKey ? { replyKey } : {}),
+            emoji
+          })
+        });
+        const json = (await res.json().catch(() => ({}))) as {
+          data?: { reactions?: ProgramCommentReactionSummary[] };
+          error?: { message?: string };
+        };
+        if (!res.ok) {
+          setAllSummaries(prev);
+          setError(json.error?.message ?? "Could not update reaction.");
+          return;
+        }
+        if (json.data?.reactions) setAllSummaries(json.data.reactions);
+      } catch {
+        setAllSummaries(prev);
+        setError("Could not update reaction.");
+      } finally {
+        setBusy(false);
+      }
+    },
+    [busy, commentKey, disabled, programSlug, replyKey]
+  );
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {visibleItems.map(item => (
+        <button
+          key={item.emoji}
+          type="button"
+          disabled={disabled || busy}
+          onClick={() => toggleEmoji(item.emoji)}
+          className={`inline-flex items-center gap-1 rounded-sm border px-2 py-1 text-xs transition-colors cursor-pointer disabled:opacity-60 ${
+            item.reacted
+              ? "border-[#4a90c4] bg-[#1a3a5c] text-white"
+              : "border-[#2a475e] bg-[#1b2838] text-[#c6d4df] hover:border-[#4a90c4]"
+          }`}
+          aria-pressed={item.reacted}
+          aria-label={`React with ${item.emoji}, ${item.count} ${item.count === 1 ? "person" : "people"}`}>
+          <span className="font-emoji text-base" aria-hidden>
+            {item.emoji}
+          </span>
+          <span className="font-semibold tabular-nums">{item.count}</span>
+        </button>
+      ))}
+
+      <button
+        ref={emojiButtonRef}
+        type="button"
+        disabled={disabled || busy || atVisitorEmojiLimit}
+        title={
+          atVisitorEmojiLimit
+            ? `You can use up to ${MAX_REACTIONS_PER_VISITOR} different emojis (remove one to add another)`
+            : undefined
+        }
+        onClick={() => setShowPicker(v => !v)}
+        className="inline-flex items-center gap-1.5 rounded-sm border border-[#2a475e] bg-[#1b2838] px-2 py-1 text-xs font-medium text-[#c6d4df] hover:border-[#4a90c4] cursor-pointer disabled:opacity-60"
+        aria-expanded={showPicker}
+        aria-label="Add reaction">
+        <FaRegSmile className="text-[#66c0f4]" />
+        React
+      </button>
+
+      <EmojiPickerPopover
+        open={showPicker}
+        onClose={() => setShowPicker(false)}
+        anchorRef={emojiButtonRef}
+        onSelect={emoji => {
+          setShowPicker(false);
+          void toggleEmoji(emoji);
+        }}
+      />
+
+      {error ? <span className="w-full text-xs text-[#e8632a]">{error}</span> : null}
+    </div>
+  );
+}
+

--- a/src/components/program/comments/CommentsSection.tsx
+++ b/src/components/program/comments/CommentsSection.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import type { Program } from "@/src/types/program";
+import type { Program, ProgramCommentReactionSummary } from "@/src/types/program";
 import ProgramCommentsList from "@/src/components/program/comments/ProgramCommentsList";
 import ProgramCommentForm from "@/src/components/program/comments/ProgramCommentForm";
 import { scrollToSectionWithHeaderOffset } from "@/src/lib/dom/scrollToSection";
@@ -10,6 +10,7 @@ import {
   PROGRAM_COMMENTS_SECTION_ID,
   PROGRAM_COMMENTS_SECTION_SELECTOR
 } from "@/src/lib/program/programCommentsSection";
+import { useProgramVisitor } from "@/src/components/visitors/ProgramVisitorProvider";
 
 type CommentsSectionProps = {
   program: Program;
@@ -18,7 +19,11 @@ type CommentsSectionProps = {
 export default function CommentsSection({ program }: CommentsSectionProps) {
   const router = useRouter();
   const slug = program.slug?.current ?? "";
+  const { isSpammer } = useProgramVisitor();
   const [replyTo, setReplyTo] = useState<{ commentKey: string; authorName: string } | null>(null);
+  const [reactionSummaries, setReactionSummaries] = useState<
+    Record<string, ProgramCommentReactionSummary[]> | undefined
+  >(undefined);
 
   const comments = program.programComments ?? [];
 
@@ -29,6 +34,29 @@ export default function CommentsSection({ program }: CommentsSectionProps) {
       scrollToSectionWithHeaderOffset(PROGRAM_COMMENTS_SECTION_SELECTOR);
     });
   }, []);
+
+  useEffect(() => {
+    if (!slug) return;
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/v1/program-comments/reactions?programSlug=${encodeURIComponent(slug)}`, {
+          credentials: "same-origin"
+        });
+        if (!res.ok) return;
+        const json = (await res.json()) as { data?: Record<string, ProgramCommentReactionSummary[]> };
+        if (!cancelled && json.data) setReactionSummaries(json.data);
+      } catch {
+        /* keep count-only fallback from program payload */
+      }
+    };
+
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
 
   function handlePosted() {
     router.refresh();
@@ -49,9 +77,12 @@ export default function CommentsSection({ program }: CommentsSectionProps) {
           </p>
         </div>
 
-        <div className="card-base overflow-visible rounded-sm p-4 sm:p-5 lg:p-6 space-y-8">
+        <div className="card-base no-hover overflow-visible rounded-sm p-4 sm:p-5 lg:p-6 space-y-8">
           <ProgramCommentsList
             comments={comments}
+            programSlug={slug}
+            reactionSummaries={reactionSummaries}
+            reactionsDisabled={isSpammer}
             onReply={c => (c._key ? setReplyTo({ commentKey: c._key, authorName: c.authorName }) : undefined)}
           />
 

--- a/src/components/program/comments/CommentsSection.tsx
+++ b/src/components/program/comments/CommentsSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { Program, ProgramCommentReactionSummary } from "@/src/types/program";
 import ProgramCommentsList from "@/src/components/program/comments/ProgramCommentsList";
 import ProgramCommentForm from "@/src/components/program/comments/ProgramCommentForm";
@@ -11,6 +11,8 @@ import {
   PROGRAM_COMMENTS_SECTION_SELECTOR
 } from "@/src/lib/program/programCommentsSection";
 import { useProgramVisitor } from "@/src/components/visitors/ProgramVisitorProvider";
+import type { ProgramCommentOwnership } from "@/src/lib/program/programCommentOwnership";
+import { replyOwnershipKey } from "@/src/lib/program/programCommentOwnership";
 
 type CommentsSectionProps = {
   program: Program;
@@ -24,6 +26,16 @@ export default function CommentsSection({ program }: CommentsSectionProps) {
   const [reactionSummaries, setReactionSummaries] = useState<
     Record<string, ProgramCommentReactionSummary[]> | undefined
   >(undefined);
+  const [ownership, setOwnership] = useState<ProgramCommentOwnership | null>(null);
+
+  const ownedCommentKeys = useMemo(
+    () => new Set(ownership?.commentKeys ?? []),
+    [ownership?.commentKeys]
+  );
+  const ownedReplyKeys = useMemo(
+    () => new Set((ownership?.replies ?? []).map(r => replyOwnershipKey(r.commentKey, r.replyKey))),
+    [ownership?.replies]
+  );
 
   const comments = program.programComments ?? [];
 
@@ -41,12 +53,24 @@ export default function CommentsSection({ program }: CommentsSectionProps) {
 
     const load = async () => {
       try {
-        const res = await fetch(`/api/v1/program-comments/reactions?programSlug=${encodeURIComponent(slug)}`, {
-          credentials: "same-origin"
-        });
-        if (!res.ok) return;
-        const json = (await res.json()) as { data?: Record<string, ProgramCommentReactionSummary[]> };
-        if (!cancelled && json.data) setReactionSummaries(json.data);
+        const [reactionsRes, ownershipRes] = await Promise.all([
+          fetch(`/api/v1/program-comments/reactions?programSlug=${encodeURIComponent(slug)}`, {
+            credentials: "same-origin"
+          }),
+          fetch(`/api/v1/program-comments/ownership?programSlug=${encodeURIComponent(slug)}`, {
+            credentials: "same-origin"
+          })
+        ]);
+
+        if (!cancelled && reactionsRes.ok) {
+          const json = (await reactionsRes.json()) as { data?: Record<string, ProgramCommentReactionSummary[]> };
+          if (json.data) setReactionSummaries(json.data);
+        }
+
+        if (!cancelled && ownershipRes.ok) {
+          const json = (await ownershipRes.json()) as { data?: ProgramCommentOwnership };
+          if (json.data) setOwnership(json.data);
+        }
       } catch {
         /* keep count-only fallback from program payload */
       }
@@ -83,6 +107,10 @@ export default function CommentsSection({ program }: CommentsSectionProps) {
             programSlug={slug}
             reactionSummaries={reactionSummaries}
             reactionsDisabled={isSpammer}
+            ownedCommentKeys={ownedCommentKeys}
+            ownedReplyKeys={ownedReplyKeys}
+            editDisabled={isSpammer}
+            onEdited={handlePosted}
             onReply={c => (c._key ? setReplyTo({ commentKey: c._key, authorName: c.authorName }) : undefined)}
           />
 

--- a/src/components/program/comments/ProgramCommentEditInline.tsx
+++ b/src/components/program/comments/ProgramCommentEditInline.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState } from "react";
+import { commentBodyToPlain, MAX_COMMENT_BODY } from "@/src/lib/program/commentBody";
+import type { ProgramComment, ProgramCommentReply } from "@/src/types/program";
+
+type ProgramCommentEditInlineProps = {
+  programSlug: string;
+  commentKey: string;
+  replyKey?: string;
+  body: ProgramComment["body"] | ProgramCommentReply["body"];
+  onSaved: () => void;
+  onCancel: () => void;
+};
+
+export default function ProgramCommentEditInline({
+  programSlug,
+  commentKey,
+  replyKey,
+  body,
+  onSaved,
+  onCancel
+}: ProgramCommentEditInlineProps) {
+  const [text, setText] = useState(() => commentBodyToPlain(body));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = text.trim();
+    if (!trimmed) {
+      setError("Comment cannot be empty.");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/v1/program-comments", {
+        method: "PATCH",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          programSlug,
+          commentKey,
+          ...(replyKey ? { replyKey } : {}),
+          body: trimmed
+        })
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const msg =
+          typeof json?.error?.message === "string" ? json.error.message : "Could not save changes.";
+        setError(msg);
+        return;
+      }
+      onSaved();
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSave} className="mt-2 space-y-2">
+      <textarea
+        value={text}
+        onChange={e => setText(e.target.value.slice(0, MAX_COMMENT_BODY))}
+        maxLength={MAX_COMMENT_BODY}
+        rows={4}
+        autoFocus
+        className="w-full resize-y rounded-sm border border-[#4a90c4] bg-[#16202d] px-3 py-2 text-sm text-[#c6d4df] focus:border-[#66c0f4] focus:outline-none"
+        aria-label="Edit comment"
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-sm border border-[#5c8529] bg-[#4c6b22] px-3 py-1.5 text-xs font-bold text-[#c6d4df] hover:bg-[#5c8529] hover:text-white disabled:opacity-60 cursor-pointer">
+          {submitting ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={onCancel}
+          className="text-xs font-semibold text-[#66c0f4] hover:text-white cursor-pointer disabled:opacity-60">
+          Cancel
+        </button>
+        <span className="text-xs text-[#8f98a0]">
+          {text.length}/{MAX_COMMENT_BODY}
+        </span>
+      </div>
+      {error ? <p className="text-xs text-[#e8632a]">{error}</p> : null}
+    </form>
+  );
+}

--- a/src/components/program/comments/ProgramCommentForm.tsx
+++ b/src/components/program/comments/ProgramCommentForm.tsx
@@ -172,7 +172,7 @@ export default function ProgramCommentForm({
             ref={emojiButtonRef}
             type="button"
             onClick={() => setShowEmoji(v => !v)}
-            className="inline-flex items-center gap-2 rounded-sm border border-[#2a475e] bg-[#1b2838] px-3 py-1.5 text-xs font-medium text-[#c6d4df] hover:border-[#4a90c4]"
+            className="inline-flex items-center gap-2 rounded-sm border border-[#2a475e] bg-[#1b2838] px-3 py-1.5 text-xs font-medium text-[#c6d4df] hover:border-[#4a90c4] cursor-pointer"
             aria-expanded={showEmoji}
             aria-label="Insert emoji">
             <FaRegSmile className="text-[#66c0f4]" />
@@ -195,7 +195,7 @@ export default function ProgramCommentForm({
       <button
         type="submit"
         disabled={submitting}
-        className="inline-flex items-center justify-center rounded-sm border border-[#5c8529] bg-[#4c6b22] px-5 py-2.5 text-sm font-bold text-[#c6d4df] transition-colors hover:bg-[#5c8529] hover:text-white disabled:opacity-60">
+        className="inline-flex items-center justify-center rounded-sm border border-[#5c8529] bg-[#4c6b22] px-5 py-2.5 text-sm font-bold text-[#c6d4df] transition-colors hover:bg-[#5c8529] hover:text-white disabled:opacity-60 cursor-pointer">
         {submitting ? "Posting…" : replyTo ? "Post reply" : "Post comment"}
       </button>
 

--- a/src/components/program/comments/ProgramCommentsList.tsx
+++ b/src/components/program/comments/ProgramCommentsList.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import CommentBodyText from "@/src/components/program/comments/CommentBodyText";
+import CommentReactions from "@/src/components/program/comments/CommentReactions";
 import { hasCommentBody } from "@/src/lib/program/commentBody";
-import type { ProgramComment } from "@/src/types/program";
+import { reactionStorageKey } from "@/src/lib/program/commentReactions";
+import type { ProgramComment, ProgramCommentReactionSummary } from "@/src/types/program";
 import { STAFF_COMMENT_AUTHOR_ROLE } from "@/src/lib/program/staffCommentIdentity";
 
 function roleBadgeClass(role: string): string {
@@ -31,10 +33,19 @@ function sortComments(comments: ProgramComment[]): ProgramComment[] {
 
 type ProgramCommentsListProps = {
   comments: ProgramComment[];
+  programSlug: string;
+  reactionSummaries?: Record<string, ProgramCommentReactionSummary[]>;
+  reactionsDisabled?: boolean;
   onReply?: (comment: ProgramComment) => void;
 };
 
-export default function ProgramCommentsList({ comments, onReply }: ProgramCommentsListProps) {
+export default function ProgramCommentsList({
+  comments,
+  programSlug,
+  reactionSummaries,
+  reactionsDisabled = false,
+  onReply
+}: ProgramCommentsListProps) {
   const visible = sortComments(comments.filter(c => c.authorName?.trim() && hasCommentBody(c.body)));
 
   if (visible.length === 0) {
@@ -65,13 +76,24 @@ export default function ProgramCommentsList({ comments, onReply }: ProgramCommen
               {date ? <span className="text-xs text-[#8f98a0]">{date}</span> : null}
             </div>
             <CommentBodyText body={comment.body} className="text-sm leading-relaxed text-[#c6d4df]" />
-            {onReply && comment._key ? (
-              <button
-                type="button"
-                onClick={() => onReply(comment)}
-                className="mt-3 text-xs font-semibold text-[#66c0f4] hover:text-white">
-                Reply
-              </button>
+            {comment._key ? (
+              <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2">
+                <CommentReactions
+                  programSlug={programSlug}
+                  commentKey={comment._key}
+                  initialReactions={comment.reactions}
+                  summaries={reactionSummaries?.[comment._key]}
+                  disabled={reactionsDisabled}
+                />
+                {onReply ? (
+                  <button
+                    type="button"
+                    onClick={() => onReply(comment)}
+                    className="text-xs font-semibold text-[#66c0f4] hover:text-white cursor-pointer">
+                    Reply
+                  </button>
+                ) : null}
+              </div>
             ) : null}
             {replies.length > 0 ? (
               <ul className="mt-4 space-y-3 border-l-2 border-[#2a475e] pl-4">
@@ -87,6 +109,18 @@ export default function ProgramCommentsList({ comments, onReply }: ProgramCommen
                         {replyDate ? <span className="text-xs text-[#8f98a0]">{replyDate}</span> : null}
                       </div>
                       <CommentBodyText body={reply.body} className="text-sm leading-relaxed text-[#8f98a0]" />
+                      {comment._key && reply._key ? (
+                        <div className="mt-2">
+                          <CommentReactions
+                            programSlug={programSlug}
+                            commentKey={comment._key}
+                            replyKey={reply._key}
+                            initialReactions={reply.reactions}
+                            summaries={reactionSummaries?.[reactionStorageKey(comment._key, reply._key)]}
+                            disabled={reactionsDisabled}
+                          />
+                        </div>
+                      ) : null}
                     </li>
                   );
                 })}

--- a/src/components/program/comments/ProgramCommentsList.tsx
+++ b/src/components/program/comments/ProgramCommentsList.tsx
@@ -1,134 +1,225 @@
-"use client";
-
-import CommentBodyText from "@/src/components/program/comments/CommentBodyText";
-import CommentReactions from "@/src/components/program/comments/CommentReactions";
-import { hasCommentBody } from "@/src/lib/program/commentBody";
-import { reactionStorageKey } from "@/src/lib/program/commentReactions";
-import type { ProgramComment, ProgramCommentReactionSummary } from "@/src/types/program";
-import { STAFF_COMMENT_AUTHOR_ROLE } from "@/src/lib/program/staffCommentIdentity";
-
-function roleBadgeClass(role: string): string {
-  if (role.trim() === STAFF_COMMENT_AUTHOR_ROLE) {
-    return "rounded-sm bg-[#1a3a5c] px-1.5 py-0.5 text-xs font-medium text-[#66c0f4]";
-  }
-  return "text-xs text-[#8f98a0]";
-}
-
-function formatCommentDate(iso?: string): string | null {
-  if (!iso?.trim()) return null;
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return null;
-  return d.toLocaleDateString(undefined, { dateStyle: "medium" });
-}
-
-function sortComments(comments: ProgramComment[]): ProgramComment[] {
-  return [...comments].sort((a, b) => {
-    if (a.isPinned && !b.isPinned) return -1;
-    if (!a.isPinned && b.isPinned) return 1;
-    const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-    const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-    return tb - ta;
-  });
-}
-
-type ProgramCommentsListProps = {
-  comments: ProgramComment[];
-  programSlug: string;
-  reactionSummaries?: Record<string, ProgramCommentReactionSummary[]>;
-  reactionsDisabled?: boolean;
-  onReply?: (comment: ProgramComment) => void;
-};
-
-export default function ProgramCommentsList({
-  comments,
-  programSlug,
-  reactionSummaries,
-  reactionsDisabled = false,
-  onReply
-}: ProgramCommentsListProps) {
-  const visible = sortComments(comments.filter(c => c.authorName?.trim() && hasCommentBody(c.body)));
-
-  if (visible.length === 0) {
-    return (
-      <p className="text-center text-sm text-[#8f98a0] py-6">
-        No comments yet. Be the first to share activation tips or feedback.
-      </p>
-    );
-  }
-
-  return (
-    <ul className="space-y-6">
-      {visible.map((comment, index) => {
-        const date = formatCommentDate(comment.createdAt);
-        const commentKey = comment._key ?? `idx-${index}`;
-        const replies = comment.replies?.filter(r => r.authorName?.trim() && hasCommentBody(r.body)) ?? [];
-
-        return (
-          <li key={commentKey} className="rounded-sm border border-[#2a475e] bg-[#16202d] p-4 sm:p-5">
-            <div className="mb-2 flex flex-wrap items-baseline gap-2">
-              <span className="font-semibold text-[#c6d4df]">{comment.authorName}</span>
-              {comment.authorRole?.trim() ? (
-                <span className={roleBadgeClass(comment.authorRole)}>{comment.authorRole.trim()}</span>
-              ) : null}
-              {comment.isPinned ? (
-                <span className="rounded-sm bg-[#1a3a5c] px-1.5 py-0.5 text-xs font-medium text-[#66c0f4]">Pinned</span>
-              ) : null}
-              {date ? <span className="text-xs text-[#8f98a0]">{date}</span> : null}
-            </div>
-            <CommentBodyText body={comment.body} className="text-sm leading-relaxed text-[#c6d4df]" />
-            {comment._key ? (
-              <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2">
-                <CommentReactions
-                  programSlug={programSlug}
-                  commentKey={comment._key}
-                  initialReactions={comment.reactions}
-                  summaries={reactionSummaries?.[comment._key]}
-                  disabled={reactionsDisabled}
-                />
-                {onReply ? (
-                  <button
-                    type="button"
-                    onClick={() => onReply(comment)}
-                    className="text-xs font-semibold text-[#66c0f4] hover:text-white cursor-pointer">
-                    Reply
-                  </button>
-                ) : null}
-              </div>
-            ) : null}
-            {replies.length > 0 ? (
-              <ul className="mt-4 space-y-3 border-l-2 border-[#2a475e] pl-4">
-                {replies.map((reply, ri) => {
-                  const replyDate = formatCommentDate(reply.createdAt);
-                  return (
-                    <li key={reply._key ?? `reply-${commentKey}-${ri}`}>
-                      <div className="mb-1 flex flex-wrap items-baseline gap-2">
-                        <span className="text-sm font-semibold text-[#c6d4df]">{reply.authorName}</span>
-                        {reply.authorRole?.trim() ? (
-                          <span className={roleBadgeClass(reply.authorRole)}>{reply.authorRole.trim()}</span>
-                        ) : null}
-                        {replyDate ? <span className="text-xs text-[#8f98a0]">{replyDate}</span> : null}
-                      </div>
-                      <CommentBodyText body={reply.body} className="text-sm leading-relaxed text-[#8f98a0]" />
-                      {comment._key && reply._key ? (
-                        <div className="mt-2">
-                          <CommentReactions
-                            programSlug={programSlug}
-                            commentKey={comment._key}
-                            replyKey={reply._key}
-                            initialReactions={reply.reactions}
-                            summaries={reactionSummaries?.[reactionStorageKey(comment._key, reply._key)]}
-                            disabled={reactionsDisabled}
-                          />
-                        </div>
-                      ) : null}
-                    </li>
-                  );
-                })}
-              </ul>
-            ) : null}
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
+"use client";
+
+import { useMemo, useState } from "react";
+import CommentBodyText from "@/src/components/program/comments/CommentBodyText";
+import CommentReactions from "@/src/components/program/comments/CommentReactions";
+import ProgramCommentEditInline from "@/src/components/program/comments/ProgramCommentEditInline";
+import { hasCommentBody } from "@/src/lib/program/commentBody";
+import { reactionStorageKey } from "@/src/lib/program/commentReactions";
+import { replyOwnershipKey } from "@/src/lib/program/programCommentOwnership";
+import type { ProgramComment, ProgramCommentReactionSummary } from "@/src/types/program";
+import { STAFF_COMMENT_AUTHOR_ROLE } from "@/src/lib/program/staffCommentIdentity";
+
+function roleBadgeClass(role: string): string {
+  if (role.trim() === STAFF_COMMENT_AUTHOR_ROLE) {
+    return "rounded-sm bg-[#1a3a5c] px-1.5 py-0.5 text-xs font-medium text-[#66c0f4]";
+  }
+  return "text-xs text-[#8f98a0]";
+}
+
+function formatCommentDate(iso?: string): string | null {
+  if (!iso?.trim()) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, { dateStyle: "medium" });
+}
+
+function CommentDateLine({ createdAt, editedAt }: { createdAt?: string; editedAt?: string }) {
+  const date = formatCommentDate(createdAt);
+  if (!date) return null;
+  const showEdited = Boolean(editedAt?.trim());
+  return (
+    <span className="text-xs text-[#8f98a0]">
+      {date}
+      {showEdited ? <span className="text-[#758691]"> (edited)</span> : null}
+    </span>
+  );
+}
+
+function sortComments(comments: ProgramComment[]): ProgramComment[] {
+  return [...comments].sort((a, b) => {
+    if (a.isPinned && !b.isPinned) return -1;
+    if (!a.isPinned && b.isPinned) return 1;
+    const ta = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+    const tb = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+    return tb - ta;
+  });
+}
+
+type ProgramCommentsListProps = {
+  comments: ProgramComment[];
+  programSlug: string;
+  reactionSummaries?: Record<string, ProgramCommentReactionSummary[]>;
+  reactionsDisabled?: boolean;
+  ownedCommentKeys?: ReadonlySet<string>;
+  ownedReplyKeys?: ReadonlySet<string>;
+  editDisabled?: boolean;
+  onReply?: (comment: ProgramComment) => void;
+  onEdited?: () => void;
+};
+
+export default function ProgramCommentsList({
+  comments,
+  programSlug,
+  reactionSummaries,
+  reactionsDisabled = false,
+  ownedCommentKeys,
+  ownedReplyKeys,
+  editDisabled = false,
+  onReply,
+  onEdited
+}: ProgramCommentsListProps) {
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+
+  const ownedComments = ownedCommentKeys ?? new Set<string>();
+  const ownedReplies = ownedReplyKeys ?? new Set<string>();
+
+  const visible = useMemo(
+    () => sortComments(comments.filter(c => c.authorName?.trim() && hasCommentBody(c.body))),
+    [comments]
+  );
+
+  if (visible.length === 0) {
+    return (
+      <p className="text-center text-sm text-[#8f98a0] py-6">
+        No comments yet. Be the first to share activation tips or feedback.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-6">
+      {visible.map((comment, index) => {
+        const commentKey = comment._key ?? `idx-${index}`;
+        const replies = comment.replies?.filter(r => r.authorName?.trim() && hasCommentBody(r.body)) ?? [];
+        const canEditComment = Boolean(comment._key && ownedComments.has(comment._key) && !editDisabled);
+        const isEditingComment = editingKey === commentKey;
+
+        return (
+          <li key={commentKey} className="rounded-sm border border-[#2a475e] bg-[#16202d] p-4 sm:p-5">
+            <div className="mb-2 flex flex-wrap items-baseline gap-2">
+              <span className="font-semibold text-[#c6d4df]">{comment.authorName}</span>
+              {comment.authorRole?.trim() ? (
+                <span className={roleBadgeClass(comment.authorRole)}>{comment.authorRole.trim()}</span>
+              ) : null}
+              {comment.isPinned ? (
+                <span className="rounded-sm bg-[#1a3a5c] px-1.5 py-0.5 text-xs font-medium text-[#66c0f4]">Pinned</span>
+              ) : null}
+              <CommentDateLine createdAt={comment.createdAt} editedAt={comment.editedAt} />
+            </div>
+
+            {isEditingComment && comment._key ? (
+              <ProgramCommentEditInline
+                programSlug={programSlug}
+                commentKey={comment._key}
+                body={comment.body}
+                onCancel={() => setEditingKey(null)}
+                onSaved={() => {
+                  setEditingKey(null);
+                  onEdited?.();
+                }}
+              />
+            ) : (
+              <CommentBodyText body={comment.body} className="text-sm leading-relaxed text-[#c6d4df]" />
+            )}
+
+            {comment._key && !isEditingComment ? (
+              <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2">
+                <CommentReactions
+                  programSlug={programSlug}
+                  commentKey={comment._key}
+                  initialReactions={comment.reactions}
+                  summaries={reactionSummaries?.[comment._key]}
+                  disabled={reactionsDisabled}
+                />
+                {canEditComment ? (
+                  <button
+                    type="button"
+                    onClick={() => setEditingKey(commentKey)}
+                    className="text-xs font-semibold text-[#66c0f4] hover:text-white cursor-pointer">
+                    Edit
+                  </button>
+                ) : null}
+                {onReply ? (
+                  <button
+                    type="button"
+                    onClick={() => onReply(comment)}
+                    className="text-xs font-semibold text-[#66c0f4] hover:text-white cursor-pointer">
+                    Reply
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+
+            {replies.length > 0 ? (
+              <ul className="mt-4 space-y-3 border-l-2 border-[#2a475e] pl-4">
+                {replies.map((reply, ri) => {
+                  const replyKey = reply._key ?? `reply-${commentKey}-${ri}`;
+                  const storageReplyKey = reply._key;
+                  const canEditReply = Boolean(
+                    comment._key &&
+                      storageReplyKey &&
+                      ownedReplies.has(replyOwnershipKey(comment._key, storageReplyKey)) &&
+                      !editDisabled
+                  );
+                  const editKey = storageReplyKey ? replyOwnershipKey(comment._key!, storageReplyKey) : null;
+                  const isEditingReply = editKey !== null && editingKey === editKey;
+
+                  return (
+                    <li key={replyKey}>
+                      <div className="mb-1 flex flex-wrap items-baseline gap-2">
+                        <span className="text-sm font-semibold text-[#c6d4df]">{reply.authorName}</span>
+                        {reply.authorRole?.trim() ? (
+                          <span className={roleBadgeClass(reply.authorRole)}>{reply.authorRole.trim()}</span>
+                        ) : null}
+                        <CommentDateLine createdAt={reply.createdAt} editedAt={reply.editedAt} />
+                      </div>
+
+                      {isEditingReply && comment._key && storageReplyKey ? (
+                        <ProgramCommentEditInline
+                          programSlug={programSlug}
+                          commentKey={comment._key}
+                          replyKey={storageReplyKey}
+                          body={reply.body}
+                          onCancel={() => setEditingKey(null)}
+                          onSaved={() => {
+                            setEditingKey(null);
+                            onEdited?.();
+                          }}
+                        />
+                      ) : (
+                        <CommentBodyText body={reply.body} className="text-sm leading-relaxed text-[#8f98a0]" />
+                      )}
+
+                      {comment._key && storageReplyKey && !isEditingReply ? (
+                        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2">
+                          <CommentReactions
+                            programSlug={programSlug}
+                            commentKey={comment._key}
+                            replyKey={storageReplyKey}
+                            initialReactions={reply.reactions}
+                            summaries={reactionSummaries?.[reactionStorageKey(comment._key, storageReplyKey)]}
+                            disabled={reactionsDisabled}
+                          />
+                          {canEditReply ? (
+                            <button
+                              type="button"
+                              onClick={() => setEditingKey(editKey)}
+                              className="text-xs font-semibold text-[#66c0f4] hover:text-white cursor-pointer">
+                              Edit
+                            </button>
+                          ) : null}
+                        </div>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+

--- a/src/components/programs/ProgramsFilter.tsx
+++ b/src/components/programs/ProgramsFilter.tsx
@@ -1,69 +1,136 @@
 import SearchInput from "@/src/components/ui/SearchInput";
-import { ProgramsFilterProps, FilterType, SortType } from "@/src/types/programs";
+import type { PlatformFilterType, ProgramsFilterProps } from "@/src/types/programs";
+
+const SELECT_CLASS =
+  "w-full min-w-[8.5rem] rounded-sm border border-[#3d6e8c] bg-[#32465a] px-2.5 py-2 text-xs text-[#c6d4df] focus:border-[#66c0f4] focus:outline-none focus:ring-2 focus:ring-[#1a9fff]/30 sm:min-w-[9.5rem] sm:px-3 sm:text-sm cursor-pointer";
+
+function FilterLabel({ htmlFor, children }: { htmlFor?: string; children: React.ReactNode }) {
+  return (
+    <label htmlFor={htmlFor} className="text-[11px] font-semibold uppercase tracking-wide text-[#8f98a0]">
+      {children}
+    </label>
+  );
+}
+
+function PlatformPills({
+  value,
+  onChange,
+  disabled
+}: {
+  value: PlatformFilterType;
+  onChange: (v: PlatformFilterType) => void;
+  disabled?: boolean;
+}) {
+  const options: Array<{ value: PlatformFilterType; label: string }> = [
+    { value: "all", label: "All" },
+    { value: "windows", label: "Windows" },
+    { value: "mac", label: "Mac" }
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-1" role="group" aria-label="Platform">
+      {options.map(opt => {
+        const active = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(opt.value)}
+            className={`rounded-sm border px-2.5 py-1.5 text-xs font-semibold transition-colors cursor-pointer disabled:opacity-50 sm:px-3 ${
+              active
+                ? "border-[#4a90c4] bg-[#1a3a5c] text-[#66c0f4]"
+                : "border-[#2a475e] bg-[#1b2838] text-[#c6d4df] hover:border-[#4a90c4]"
+            }`}>
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 export default function ProgramsFilter({
   searchTerm,
   filter,
   sortBy,
+  category,
+  platform,
+  categories,
   onSearchChange,
   onSearchCommit,
   onFilterChange,
-  onSortChange
+  onSortChange,
+  onCategoryChange,
+  onPlatformChange
 }: ProgramsFilterProps) {
   return (
     <div className="card-base mb-6 rounded-sm p-4 sm:mb-8 sm:p-5 lg:p-6">
-      <div className="flex flex-col lg:flex-row gap-4 sm:gap-5 lg:gap-6">
-        <div className="flex-1">
-          <SearchInput
-            value={searchTerm}
-            onChange={onSearchChange}
-            onKeyDown={e => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                onSearchCommit?.();
-              }
-            }}
-            placeholder="Search programs..."
-            className="[&_input]:rounded-sm [&_input]:border-[#3d6e8c] [&_input]:bg-[#32465a] [&_input]:text-[#c6d4df] [&_input]:placeholder:text-[#556772] [&_input]:focus:border-[#66c0f4] [&_input]:focus:ring-[#1a9fff]/30 [&_svg]:text-[#8f98a0]"
-          />
-        </div>
+      <div className="flex flex-col gap-5">
+        <SearchInput
+          value={searchTerm}
+          onChange={onSearchChange}
+          onKeyDown={e => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onSearchCommit?.();
+            }
+          }}
+          placeholder="Search programs..."
+          className="w-full [&_input]:rounded-sm [&_input]:border-[#3d6e8c] [&_input]:bg-[#32465a] [&_input]:text-[#c6d4df] [&_input]:placeholder:text-[#556772] [&_input]:focus:border-[#66c0f4] [&_input]:focus:ring-[#1a9fff]/30 [&_svg]:text-[#8f98a0]"
+        />
 
-        <div className="flex flex-col xs:flex-row gap-3 sm:gap-4">
-          <div className="flex items-center space-x-2">
-            <label
-              htmlFor="programs-filter-keys"
-              className="whitespace-nowrap text-xs font-medium text-[#8f98a0] sm:text-sm">
-              Keys:
-            </label>
-            <select
-              id="programs-filter-keys"
-              value={filter}
-              onChange={e => onFilterChange(e.target.value as FilterType)}
-              className="xs:flex-none flex-1 rounded-sm border border-[#3d6e8c] bg-[#32465a] px-2.5 py-2 text-xs text-[#c6d4df] focus:border-[#66c0f4] focus:outline-none focus:ring-2 focus:ring-[#1a9fff]/30 sm:px-3 sm:text-sm">
-              <option value="all">All Programs</option>
-              <option value="hasKeys">With Keys</option>
-              <option value="noKeys">Without Keys</option>
-            </select>
+        <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+          <div className="grid grid-cols-1 gap-4 min-[480px]:grid-cols-2 lg:grid-cols-3 xl:flex xl:flex-1 xl:flex-wrap xl:gap-x-5 xl:gap-y-4">
+            <div className="flex min-w-0 flex-col gap-1.5">
+              <FilterLabel htmlFor="programs-filter-keys">Keys</FilterLabel>
+              <select
+                id="programs-filter-keys"
+                value={filter}
+                onChange={e => onFilterChange(e.target.value as ProgramsFilterProps["filter"])}
+                className={SELECT_CLASS}>
+                <option value="all">All programs</option>
+                <option value="hasKeys">With keys</option>
+                <option value="noKeys">Without keys</option>
+              </select>
+            </div>
+
+            <div className="flex min-w-0 flex-col gap-1.5 lg:col-span-1 xl:min-w-[11rem] xl:flex-1 xl:max-w-xs">
+              <FilterLabel htmlFor="programs-filter-category">Category</FilterLabel>
+              <select
+                id="programs-filter-category"
+                value={category}
+                onChange={e => onCategoryChange(e.target.value)}
+                className={SELECT_CLASS}>
+                <option value="all">All categories</option>
+                {categories.map(cat => (
+                  <option key={cat._id} value={cat.slug}>
+                    {cat.title}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex min-w-0 flex-col gap-1.5 min-[480px]:col-span-2 lg:col-span-1 xl:col-span-1 xl:min-w-[12rem]">
+              <FilterLabel>Platform</FilterLabel>
+              <PlatformPills value={platform} onChange={onPlatformChange} />
+            </div>
           </div>
 
-          <div className="flex items-center space-x-2">
-            <label
-              htmlFor="programs-filter-sort"
-              className="whitespace-nowrap text-xs font-medium text-[#8f98a0] sm:text-sm">
-              Sort:
-            </label>
+          <div className="flex min-w-0 flex-col gap-1.5 xl:w-44 xl:shrink-0">
+            <FilterLabel htmlFor="programs-filter-sort">Sort</FilterLabel>
             <select
               id="programs-filter-sort"
               value={sortBy}
-              onChange={e => onSortChange(e.target.value as SortType)}
-              className="xs:flex-none flex-1 rounded-sm border border-[#3d6e8c] bg-[#32465a] px-2.5 py-2 text-xs text-[#c6d4df] focus:border-[#66c0f4] focus:outline-none focus:ring-2 focus:ring-[#1a9fff]/30 sm:px-3 sm:text-sm">
-              <option value="popular">Most Popular</option>
-              <option value="views">Most Viewed</option>
-              <option value="downloads">Most Downloaded</option>
-              <option value="latest">Recently Added</option>
-              <option value="oldest">Oldest Added</option>
-              <option value="name">Name A-Z</option>
-              <option value="nameDesc">Name Z-A</option>
+              onChange={e => onSortChange(e.target.value as ProgramsFilterProps["sortBy"])}
+              className={SELECT_CLASS}>
+              <option value="popular">Most popular</option>
+              <option value="views">Most viewed</option>
+              <option value="downloads">Most downloaded</option>
+              <option value="latest">Recently added</option>
+              <option value="oldest">Oldest added</option>
+              <option value="name">Name A–Z</option>
+              <option value="nameDesc">Name Z–A</option>
             </select>
           </div>
         </div>

--- a/src/components/social/SocialComponents.tsx
+++ b/src/components/social/SocialComponents.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { FaGithub, FaLinkedin, FaInstagram, FaYoutube, FaFacebook, FaGlobe } from "react-icons/fa";
+import {
+  FaGithub,
+  FaLinkedin,
+  FaInstagram,
+  FaYoutube,
+  FaFacebook,
+  FaTelegram,
+  FaGlobe
+} from "react-icons/fa";
 import { SiTrustpilot } from "react-icons/si";
 import { FaXTwitter } from "react-icons/fa6";
 import { trackEvent } from "@/src/lib/analytics/trackEvent";
@@ -15,6 +23,7 @@ export const SOCIAL_PLATFORMS = {
   x: { icon: FaXTwitter, name: "X" },
   youtube: { icon: FaYoutube, name: "YouTube" },
   facebook: { icon: FaFacebook, name: "Facebook" },
+  telegram: { icon: FaTelegram, name: "Telegram" },
   trustpilot: { icon: SiTrustpilot, name: "Trustpilot" },
   website: { icon: FaGlobe, name: "Website" },
   portfolio: { icon: FaGlobe, name: "Portfolio" }

--- a/src/lib/program/commentReactions.ts
+++ b/src/lib/program/commentReactions.ts
@@ -1,0 +1,102 @@
+import type { ProgramCommentReaction, ProgramCommentReactionSummary } from "@/src/types/program";
+
+export const MAX_REACTION_EMOJI_LENGTH = 16;
+/** Max reaction chips shown on a comment/reply (popularity + viewer's own). */
+export const MAX_VISIBLE_REACTION_EMOJI_TYPES = 6;
+/** Max distinct emojis one visitor may have active on one comment/reply. */
+export const MAX_REACTIONS_PER_VISITOR = 3;
+/** Safety cap on total reaction rows per comment/reply (spam/abuse). */
+export const MAX_REACTION_ROWS = 500;
+
+/** Map key for GET/POST: comment only, or `commentKey:replyKey`. */
+export function reactionStorageKey(commentKey: string, replyKey?: string | null): string {
+  return replyKey?.trim() ? `${commentKey}:${replyKey.trim()}` : commentKey;
+}
+
+/** Strip ZWJ / variation selectors noise and enforce length. */
+export function sanitizeReactionEmoji(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const emoji = raw.trim();
+  if (!emoji || emoji.length > MAX_REACTION_EMOJI_LENGTH) return null;
+  if (/^[\s\p{C}]+$/u.test(emoji)) return null;
+  return emoji;
+}
+
+function sortByPopularity(a: ProgramCommentReactionSummary, b: ProgramCommentReactionSummary): number {
+  return b.count - a.count || a.emoji.localeCompare(b.emoji);
+}
+
+export function aggregateCommentReactions(
+  reactions: ProgramCommentReaction[] | undefined | null,
+  viewerHash?: string | null
+): ProgramCommentReactionSummary[] {
+  const counts = new Map<string, { count: number; reacted: boolean }>();
+
+  for (const row of reactions ?? []) {
+    const emoji = typeof row.emoji === "string" ? row.emoji.trim() : "";
+    if (!emoji) continue;
+    const prev = counts.get(emoji) ?? { count: 0, reacted: false };
+    prev.count += 1;
+    if (viewerHash && row.ipHash === viewerHash) prev.reacted = true;
+    counts.set(emoji, prev);
+  }
+
+  return [...counts.entries()].map(([emoji, { count, reacted }]) => ({ emoji, count, reacted }));
+}
+
+/** Viewer emojis first (by count), then top others by count — max `MAX_VISIBLE_REACTION_EMOJI_TYPES`. */
+export function orderReactionsForDisplay(
+  summaries: ProgramCommentReactionSummary[]
+): ProgramCommentReactionSummary[] {
+  if (summaries.length === 0) return [];
+
+  const mine = summaries.filter(s => s.reacted).sort(sortByPopularity);
+  const others = summaries.filter(s => !s.reacted).sort(sortByPopularity);
+
+  const visible: ProgramCommentReactionSummary[] = [];
+  const seen = new Set<string>();
+
+  for (const s of mine) {
+    if (visible.length >= MAX_VISIBLE_REACTION_EMOJI_TYPES) break;
+    visible.push(s);
+    seen.add(s.emoji);
+  }
+  for (const s of others) {
+    if (visible.length >= MAX_VISIBLE_REACTION_EMOJI_TYPES) break;
+    if (seen.has(s.emoji)) continue;
+    visible.push(s);
+  }
+  return visible;
+}
+
+export function countVisitorReactionTypes(summaries: ProgramCommentReactionSummary[]): number {
+  return summaries.filter(s => s.reacted).length;
+}
+
+/** Whether this visitor may add (not remove) a reaction for `emoji`. */
+export function canVisitorAddReaction(
+  summaries: ProgramCommentReactionSummary[],
+  emoji: string
+): boolean {
+  const row = summaries.find(s => s.emoji === emoji);
+  if (row?.reacted) return true;
+  if (countVisitorReactionTypes(summaries) >= MAX_REACTIONS_PER_VISITOR) return false;
+  return true;
+}
+
+export function applyOptimisticReactionToggle(
+  summaries: ProgramCommentReactionSummary[],
+  emoji: string
+): ProgramCommentReactionSummary[] {
+  const row = summaries.find(s => s.emoji === emoji);
+  if (row?.reacted) {
+    const nextCount = row.count - 1;
+    if (nextCount <= 0) return summaries.filter(s => s.emoji !== emoji);
+    return summaries.map(s => (s.emoji === emoji ? { ...s, count: nextCount, reacted: false } : s));
+  }
+  if (row) {
+    return summaries.map(s => (s.emoji === emoji ? { ...s, count: s.count + 1, reacted: true } : s));
+  }
+  return [...summaries, { emoji, count: 1, reacted: true }];
+}
+

--- a/src/lib/program/getRelatedPrograms.ts
+++ b/src/lib/program/getRelatedPrograms.ts
@@ -1,0 +1,98 @@
+import { unstable_cache } from "next/cache";
+import { TAG_PROGRAM_LISTINGS } from "@/src/lib/cache/cacheTags";
+import { PUBLIC_ISR_REVALIDATE_SECONDS } from "@/src/lib/cache/constants";
+import { client } from "@/src/sanity/lib/client";
+import { relatedProgramsCandidatesQuery } from "@/src/lib/sanity/queries";
+import type { Program, ProgramCategoryRef, VendorRef } from "@/src/types/program";
+
+const RELATED_LIMIT = 5;
+const MAX_PER_VENDOR = 2;
+
+export type RelatedProgramsAnchor = {
+  slug: string;
+  categories?: ProgramCategoryRef[];
+  vendor?: VendorRef | null;
+};
+
+function categoryIdSet(categories: ProgramCategoryRef[] | undefined): Set<string> {
+  const ids = new Set<string>();
+  for (const cat of categories ?? []) {
+    if (cat?._id) ids.add(cat._id);
+  }
+  return ids;
+}
+
+/** Rank candidates: shared categories desc, then popularityScore desc; cap 2 per vendor in top 5. */
+export function rankRelatedPrograms(
+  anchor: RelatedProgramsAnchor,
+  candidates: Program[],
+  limit = RELATED_LIMIT
+): Program[] {
+  const anchorSlug = anchor.slug;
+  const anchorCats = categoryIdSet(anchor.categories);
+
+  const ranked = candidates
+    .filter(p => p.slug?.current && p.slug.current !== anchorSlug)
+    .map(p => {
+      const sharedCategoryCount = (p.categories ?? []).filter(c => anchorCats.has(c._id)).length;
+      const popularityScore = p.popularityScore ?? 0;
+      return { program: p, sharedCategoryCount, popularityScore };
+    })
+    .sort((a, b) => {
+      if (b.sharedCategoryCount !== a.sharedCategoryCount) {
+        return b.sharedCategoryCount - a.sharedCategoryCount;
+      }
+      return b.popularityScore - a.popularityScore;
+    });
+
+  const picked: Program[] = [];
+  const vendorCounts = new Map<string, number>();
+
+  for (const { program } of ranked) {
+    if (picked.length >= limit) break;
+
+    const vendorSlug = program.vendor?.slug;
+    if (vendorSlug) {
+      const count = vendorCounts.get(vendorSlug) ?? 0;
+      if (count >= MAX_PER_VENDOR) continue;
+      vendorCounts.set(vendorSlug, count + 1);
+    }
+
+    picked.push(program);
+  }
+
+  return picked;
+}
+
+async function fetchRelatedCandidates(slug: string): Promise<Program[]> {
+  const rows = await client.fetch<Program[]>(
+    relatedProgramsCandidatesQuery,
+    { slug },
+    { next: { tags: [TAG_PROGRAM_LISTINGS] } }
+  );
+  return rows ?? [];
+}
+
+function anchorCategoryCacheKey(categories: ProgramCategoryRef[] | undefined): string {
+  const ids = (categories ?? []).map(c => c._id).filter(Boolean).sort();
+  return ids.length > 0 ? ids.join(",") : "_none_";
+}
+
+function getCachedRankedRelatedPrograms(anchor: RelatedProgramsAnchor): Promise<Program[]> {
+  const { slug } = anchor;
+  const categoryKey = anchorCategoryCacheKey(anchor.categories);
+
+  return unstable_cache(
+    async () => {
+      const candidates = await fetchRelatedCandidates(slug);
+      return rankRelatedPrograms(anchor, candidates);
+    },
+    ["related-programs", slug, categoryKey],
+    { revalidate: PUBLIC_ISR_REVALIDATE_SECONDS, tags: [TAG_PROGRAM_LISTINGS] }
+  )();
+}
+
+/** Related programs for a program detail page (cached per slug). */
+export async function getCachedRelatedProgramsForSlug(anchor: RelatedProgramsAnchor): Promise<Program[]> {
+  return getCachedRankedRelatedPrograms(anchor);
+}

--- a/src/lib/program/programCommentOwnership.ts
+++ b/src/lib/program/programCommentOwnership.ts
@@ -1,0 +1,37 @@
+import { client } from "@/src/sanity/lib/client";
+
+export type ProgramCommentOwnership = {
+  commentKeys: string[];
+  replies: Array<{ commentKey: string; replyKey: string }>;
+};
+
+export async function fetchProgramCommentOwnership(
+  programId: string,
+  ipHash: string
+): Promise<ProgramCommentOwnership> {
+  const comments = await client.fetch<
+    Array<{
+      _key?: string;
+      ipHash?: string;
+      replies?: Array<{ _key?: string; ipHash?: string }>;
+    }> | null
+  >(`*[_id == $id][0].programComments[]{ _key, ipHash, replies[]{ _key, ipHash } }`, { id: programId });
+
+  const commentKeys: string[] = [];
+  const replies: Array<{ commentKey: string; replyKey: string }> = [];
+
+  for (const c of comments ?? []) {
+    if (c._key && c.ipHash === ipHash) commentKeys.push(c._key);
+    for (const r of c.replies ?? []) {
+      if (c._key && r._key && r.ipHash === ipHash) {
+        replies.push({ commentKey: c._key, replyKey: r._key });
+      }
+    }
+  }
+
+  return { commentKeys, replies };
+}
+
+export function replyOwnershipKey(commentKey: string, replyKey: string): string {
+  return `${commentKey}:${replyKey}`;
+}

--- a/src/lib/program/programUtils.ts
+++ b/src/lib/program/programUtils.ts
@@ -1,6 +1,6 @@
 import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
 import type { ProgramWithStats } from "@/src/types/home";
-import type { FilterType, SortType } from "@/src/types/programs";
+import type { FilterType, PlatformFilterType, SortType } from "@/src/types/programs";
 
 /**
  * Calculate popularity score for a program
@@ -107,6 +107,17 @@ export function normalizeFilterType(value?: string): FilterType {
     default:
       return "all";
   }
+}
+
+export function normalizePlatformFilter(value?: string | null): PlatformFilterType {
+  if (value === "windows" || value === "mac") return value;
+  return "all";
+}
+
+export function normalizeCategoryFilter(value?: string | null): string {
+  const slug = (value ?? "").trim().toLowerCase();
+  if (!slug || slug === "all") return "all";
+  return slug.replace(/[^a-z0-9-]/g, "");
 }
 
 /**

--- a/src/lib/program/toggleCommentReaction.ts
+++ b/src/lib/program/toggleCommentReaction.ts
@@ -1,0 +1,149 @@
+import { client } from "@/src/sanity/lib/client";
+import {
+  aggregateCommentReactions,
+  MAX_REACTION_ROWS,
+  MAX_REACTIONS_PER_VISITOR,
+  reactionStorageKey
+} from "@/src/lib/program/commentReactions";
+import type { ProgramCommentReaction, ProgramCommentReactionSummary } from "@/src/types/program";
+
+type SanityReactionRow = ProgramCommentReaction & { _key: string; _type: "programCommentReaction" };
+
+export type ReactionTarget =
+  | { kind: "comment"; commentKey: string }
+  | { kind: "reply"; commentKey: string; replyKey: string };
+
+function newKey(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 12);
+}
+
+function escapeKey(key: string): string {
+  return key.replace(/"/g, "");
+}
+
+function reactionsFieldPath(target: ReactionTarget): string {
+  const commentKey = escapeKey(target.commentKey);
+  if (target.kind === "comment") {
+    return `programComments[_key=="${commentKey}"].reactions`;
+  }
+  const replyKey = escapeKey(target.replyKey);
+  return `programComments[_key=="${commentKey}"].replies[_key=="${replyKey}"].reactions`;
+}
+
+export async function fetchReactions(
+  programId: string,
+  target: ReactionTarget
+): Promise<ProgramCommentReaction[]> {
+  const commentKey = escapeKey(target.commentKey);
+  if (target.kind === "reply") {
+    const replyKey = escapeKey(target.replyKey);
+    const rows = await client.fetch<ProgramCommentReaction[] | null>(
+      `*[_id == $id][0].programComments[_key == $commentKey][0].replies[_key == $replyKey][0].reactions[]{ _key, emoji, ipHash, createdAt }`,
+      { id: programId, commentKey, replyKey }
+    );
+    return rows ?? [];
+  }
+  const rows = await client.fetch<ProgramCommentReaction[] | null>(
+    `*[_id == $id][0].programComments[_key == $commentKey][0].reactions[]{ _key, emoji, ipHash, createdAt }`,
+    { id: programId, commentKey }
+  );
+  return rows ?? [];
+}
+
+export async function fetchProgramReactionSummaryMap(
+  programId: string,
+  viewerHash?: string | null
+): Promise<Record<string, ProgramCommentReactionSummary[]>> {
+  const comments = await client.fetch<
+    Array<{
+      _key?: string;
+      reactions?: ProgramCommentReaction[];
+      replies?: Array<{ _key?: string; reactions?: ProgramCommentReaction[] }>;
+    }> | null
+  >(
+    `*[_id == $id][0].programComments[]{
+      _key,
+      reactions[]{ emoji, ipHash },
+      replies[]{
+        _key,
+        reactions[]{ emoji, ipHash }
+      }
+    }`,
+    { id: programId }
+  );
+
+  const map: Record<string, ProgramCommentReactionSummary[]> = {};
+  for (const c of comments ?? []) {
+    if (!c._key) continue;
+    map[reactionStorageKey(c._key)] = aggregateCommentReactions(c.reactions, viewerHash);
+    for (const reply of c.replies ?? []) {
+      if (!reply._key) continue;
+      map[reactionStorageKey(c._key, reply._key)] = aggregateCommentReactions(reply.reactions, viewerHash);
+    }
+  }
+  return map;
+}
+
+function visitorDistinctEmojiCount(reactions: ProgramCommentReaction[], ipHash: string): number {
+  return new Set(reactions.filter(r => r.ipHash === ipHash).map(r => r.emoji).filter(Boolean)).size;
+}
+
+export async function toggleCommentReaction(opts: {
+  programId: string;
+  target: ReactionTarget;
+  emoji: string;
+  ipHash: string;
+}): Promise<{ reactions: ProgramCommentReactionSummary[]; action: "added" | "removed"; storageKey: string }> {
+  const { programId, target, emoji, ipHash } = opts;
+  const storageKey = reactionStorageKey(
+    target.commentKey,
+    target.kind === "reply" ? target.replyKey : undefined
+  );
+  const path = reactionsFieldPath(target);
+  const existing = await fetchReactions(programId, target);
+
+  const match = existing.find(r => r.emoji === emoji && r.ipHash === ipHash);
+  if (match?._key) {
+    const reactionKey = escapeKey(match._key);
+    await client
+      .patch(programId)
+      .unset([`${path}[_key=="${reactionKey}"]`])
+      .commit({ autoGenerateArrayKeys: true });
+
+    const next = existing.filter(r => r._key !== match._key);
+    return { reactions: aggregateCommentReactions(next, ipHash), action: "removed", storageKey };
+  }
+
+  if (existing.length >= MAX_REACTION_ROWS) {
+    throw new Error("REACTION_LIMIT");
+  }
+
+  const visitorEmojiCount = visitorDistinctEmojiCount(existing, ipHash);
+  const visitorAlreadyHasEmoji = existing.some(r => r.emoji === emoji && r.ipHash === ipHash);
+  if (!visitorAlreadyHasEmoji && visitorEmojiCount >= MAX_REACTIONS_PER_VISITOR) {
+    throw new Error("VISITOR_EMOJI_LIMIT");
+  }
+
+  const row: SanityReactionRow = {
+    _key: newKey(),
+    _type: "programCommentReaction",
+    emoji,
+    ipHash,
+    createdAt: new Date().toISOString()
+  };
+
+  await client
+    .patch(programId)
+    .setIfMissing({ [path]: [] })
+    .insert("after", `${path}[-1]`, [row])
+    .commit({ autoGenerateArrayKeys: true });
+
+  return {
+    reactions: aggregateCommentReactions([...existing, row], ipHash),
+    action: "added",
+    storageKey
+  };
+}
+
+/** @deprecated use fetchProgramReactionSummaryMap */
+export const fetchProgramCommentReactionMap = fetchProgramReactionSummaryMap;

--- a/src/lib/program/updateProgramComment.ts
+++ b/src/lib/program/updateProgramComment.ts
@@ -1,0 +1,63 @@
+import { client } from "@/src/sanity/lib/client";
+
+function escapeKey(key: string): string {
+  return key.replace(/"/g, "");
+}
+
+type CommentTarget =
+  | { kind: "comment"; commentKey: string }
+  | { kind: "reply"; commentKey: string; replyKey: string };
+
+function targetPath(target: CommentTarget): string {
+  const commentKey = escapeKey(target.commentKey);
+  if (target.kind === "comment") {
+    return `programComments[_key=="${commentKey}"]`;
+  }
+  const replyKey = escapeKey(target.replyKey);
+  return `programComments[_key=="${commentKey}"].replies[_key=="${replyKey}"]`;
+}
+
+async function fetchTargetIpHash(programId: string, target: CommentTarget): Promise<string | null> {
+  const commentKey = escapeKey(target.commentKey);
+  if (target.kind === "reply") {
+    const replyKey = escapeKey(target.replyKey);
+    const row = await client.fetch<{ ipHash?: string } | null>(
+      `*[_id == $id][0].programComments[_key == $commentKey][0].replies[_key == $replyKey][0]{ ipHash }`,
+      { id: programId, commentKey, replyKey }
+    );
+    return row?.ipHash ?? null;
+  }
+  const row = await client.fetch<{ ipHash?: string } | null>(
+    `*[_id == $id][0].programComments[_key == $commentKey][0]{ ipHash }`,
+    { id: programId, commentKey }
+  );
+  return row?.ipHash ?? null;
+}
+
+export async function updateProgramCommentBody(opts: {
+  programId: string;
+  target: CommentTarget;
+  body: string;
+  ipHash: string;
+}): Promise<{ editedAt: string }> {
+  const { programId, target, body, ipHash } = opts;
+  const ownerHash = await fetchTargetIpHash(programId, target);
+  if (!ownerHash || ownerHash !== ipHash) {
+    throw new Error("FORBIDDEN");
+  }
+
+  const editedAt = new Date().toISOString();
+  const base = targetPath(target);
+
+  await client
+    .patch(programId)
+    .set({
+      [`${base}.body`]: body,
+      [`${base}.editedAt`]: editedAt
+    })
+    .commit();
+
+  return { editedAt };
+}
+
+export type { CommentTarget };

--- a/src/lib/programs/getProgramsPageData.ts
+++ b/src/lib/programs/getProgramsPageData.ts
@@ -3,9 +3,16 @@ import { client } from "@/src/sanity/lib/client";
 import { programsListingProjection } from "@/src/lib/sanity/queries";
 import { mergeProgramStats } from "@/src/lib/analytics/eventsApi";
 import type { ProgramWithStats } from "@/src/types/home";
-import type { FilterType, SortType } from "@/src/types/programs";
+import type { FilterType, PlatformFilterType, SortType } from "@/src/types/programs";
+import type { ProgramCategoryOption } from "@/src/types/programs";
 import { portableTextToPlainText } from "@/src/lib/portableText/toPlainText";
-import { groqProgramsOrderClause, normalizeFilterType, normalizeSortType } from "@/src/lib/program/programUtils";
+import {
+  groqProgramsOrderClause,
+  normalizeCategoryFilter,
+  normalizeFilterType,
+  normalizePlatformFilter,
+  normalizeSortType
+} from "@/src/lib/program/programUtils";
 import { TAG_PROGRAM_LISTINGS } from "@/src/lib/cache/cacheTags";
 import { PUBLIC_ISR_REVALIDATE_SECONDS } from "@/src/lib/cache/constants";
 
@@ -18,6 +25,8 @@ export type ProgramsListData = {
   searchTerm: string;
   filter: FilterType;
   sortBy: SortType;
+  category: string;
+  platform: PlatformFilterType;
   page: number;
   programsPerPage: number;
 };
@@ -45,29 +54,68 @@ export const getCachedProgramsHeroTotals = unstable_cache(fetchProgramsHeroTotal
   tags: [TAG_PROGRAM_LISTINGS]
 });
 
-async function fetchProgramsListData(
-  searchTerm: string,
+async function fetchProgramCategoryOptions(): Promise<ProgramCategoryOption[]> {
+  const rows = await client.fetch<Array<{ _id: string; title?: string; slug?: string }>>(
+    `*[_type == "programCategory"] | order(title asc) { _id, title, "slug": slug.current }`,
+    {},
+    { next: { tags: [TAG_PROGRAM_LISTINGS] } }
+  );
+  return (rows ?? [])
+    .filter(r => r._id && r.title?.trim() && r.slug?.trim())
+    .map(r => ({ _id: r._id, title: r.title!.trim(), slug: r.slug!.trim() }));
+}
+
+export const getCachedProgramCategoryOptions = unstable_cache(fetchProgramCategoryOptions, ["program-category-options"], {
+  revalidate: PUBLIC_ISR_REVALIDATE_SECONDS,
+  tags: [TAG_PROGRAM_LISTINGS]
+});
+
+function buildProgramsFilterGroq(
   filter: FilterType,
-  sortBy: SortType,
-  page: number
-): Promise<ProgramsListData> {
-  const startIdx = (page - 1) * PROGRAMS_PER_PAGE;
-  const endIdx = startIdx + PROGRAMS_PER_PAGE - 1;
-  const filterQuery =
+  searchTerm: string,
+  category: string,
+  platform: PlatformFilterType
+): { filterExpr: string; params: Record<string, unknown> } {
+  const keyFilter =
     filter === "hasKeys" ? "count(cdKeys[]) > 0" : filter === "noKeys" ? "count(cdKeys[]) == 0" : "true";
   const searchFilter = searchTerm
     ? " && (title match $search || string::lower(pt::text(description)) match $search)"
     : "";
-  const programsFilter = `*[_type == "program" && ${filterQuery}${searchFilter}]`;
-  const countQuery = `count(${programsFilter})`;
-  const keyCountQuery = `${programsFilter}{"keyCount": count(cdKeys[])}`;
-  const listQuery = `${programsFilter} {${programsListingProjection}} ${groqProgramsOrderClause(sortBy)} [${startIdx}...${endIdx}]`;
-  const queryParams = searchTerm ? { search: `*${searchTerm.toLowerCase()}*` } : {};
+  const categoryFilter =
+    category !== "all" ? " && $categorySlug in categories[]->slug.current" : "";
+  const platformFilter =
+    platform !== "all" ? " && $platform in coalesce(platforms, [\"windows\"])" : "";
+
+  const params: Record<string, unknown> = {};
+  if (searchTerm) params.search = `*${searchTerm.toLowerCase()}*`;
+  if (category !== "all") params.categorySlug = category;
+  if (platform !== "all") params.platform = platform;
+
+  return {
+    filterExpr: `*[_type == "program" && ${keyFilter}${searchFilter}${categoryFilter}${platformFilter}]`,
+    params
+  };
+}
+
+async function fetchProgramsListData(
+  searchTerm: string,
+  filter: FilterType,
+  sortBy: SortType,
+  category: string,
+  platform: PlatformFilterType,
+  page: number
+): Promise<ProgramsListData> {
+  const startIdx = (page - 1) * PROGRAMS_PER_PAGE;
+  const endIdx = startIdx + PROGRAMS_PER_PAGE - 1;
+  const { filterExpr, params } = buildProgramsFilterGroq(filter, searchTerm, category, platform);
+  const countQuery = `count(${filterExpr})`;
+  const keyCountQuery = `${filterExpr}{"keyCount": count(cdKeys[])}`;
+  const listQuery = `${filterExpr} {${programsListingProjection}} ${groqProgramsOrderClause(sortBy)} [${startIdx}...${endIdx}]`;
 
   const [totalCount, keyCountRows, rawPrograms] = await Promise.all([
-    client.fetch<number>(countQuery, queryParams, { next: { tags: [TAG_PROGRAM_LISTINGS] } }),
-    client.fetch<Array<{ keyCount?: number }>>(keyCountQuery, queryParams, { next: { tags: [TAG_PROGRAM_LISTINGS] } }),
-    client.fetch<ProgramWithStats[]>(listQuery, queryParams, { next: { tags: [TAG_PROGRAM_LISTINGS] } })
+    client.fetch<number>(countQuery, params, { next: { tags: [TAG_PROGRAM_LISTINGS] } }),
+    client.fetch<Array<{ keyCount?: number }>>(keyCountQuery, params, { next: { tags: [TAG_PROGRAM_LISTINGS] } }),
+    client.fetch<ProgramWithStats[]>(listQuery, params, { next: { tags: [TAG_PROGRAM_LISTINGS] } })
   ]);
 
   const programs = mergeProgramStats((rawPrograms ?? []) as ProgramWithStats[]).map(program => ({
@@ -84,6 +132,8 @@ async function fetchProgramsListData(
     searchTerm,
     filter,
     sortBy,
+    category,
+    platform,
     page,
     programsPerPage: PROGRAMS_PER_PAGE
   };
@@ -93,16 +143,20 @@ export async function getProgramsListData(
   rawSearch: string | undefined,
   rawFilter: string | undefined,
   rawSort: string | undefined,
-  rawPage: string | undefined
+  rawPage: string | undefined,
+  rawCategory?: string | undefined,
+  rawPlatform?: string | undefined
 ): Promise<ProgramsListData> {
   const searchTerm = (rawSearch || "").trim();
   const filter = normalizeFilterType(rawFilter);
   const sortBy = normalizeSortType(rawSort);
+  const category = normalizeCategoryFilter(rawCategory);
+  const platform = normalizePlatformFilter(rawPlatform);
   const page = Math.max(1, Number.parseInt(rawPage || "1", 10) || 1);
 
   return unstable_cache(
-    () => fetchProgramsListData(searchTerm, filter, sortBy, page),
-    ["programs-list-v2", searchTerm, filter, sortBy, String(page)],
+    () => fetchProgramsListData(searchTerm, filter, sortBy, category, platform, page),
+    ["programs-list-v3", searchTerm, filter, sortBy, category, platform, String(page)],
     { revalidate: PUBLIC_ISR_REVALIDATE_SECONDS, tags: [TAG_PROGRAM_LISTINGS] }
   )();
 }

--- a/src/lib/sanity/getCachedRelatedPrograms.ts
+++ b/src/lib/sanity/getCachedRelatedPrograms.ts
@@ -1,16 +1,1 @@
-import { unstable_cache } from "next/cache";
-import { TAG_PROGRAM_LISTINGS } from "@/src/lib/cache/cacheTags";
-import { PUBLIC_ISR_REVALIDATE_SECONDS } from "@/src/lib/cache/constants";
-import { client } from "@/src/sanity/lib/client";
-import { popularProgramsQuery } from "@/src/lib/sanity/queries";
-import type { Program } from "@/src/types/program";
-
-/** Shared related-program pool (filtered per slug on the program page). */
-export const getCachedRelatedPrograms = unstable_cache(
-  async (): Promise<Program[]> => {
-    const rows = await client.fetch<Program[]>(popularProgramsQuery, {}, { next: { tags: [TAG_PROGRAM_LISTINGS] } });
-    return rows ?? [];
-  },
-  ["related-programs-pool"],
-  { revalidate: PUBLIC_ISR_REVALIDATE_SECONDS, tags: [TAG_PROGRAM_LISTINGS] }
-);
+export { getCachedRelatedProgramsForSlug as getCachedRelatedPrograms } from "@/src/lib/program/getRelatedPrograms";

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -117,6 +117,7 @@ export const adminProgramsQuery = `
     ipHash,
     body,
     createdAt,
+    editedAt,
     isPinned,
     reactions[]{ emoji },
     replies[]{
@@ -126,6 +127,7 @@ export const adminProgramsQuery = `
       ipHash,
       body,
       createdAt,
+      editedAt,
       reactions[]{ emoji }
     }
   },
@@ -144,6 +146,7 @@ export const adminProgramsWithCommentsQuery = `
     ipHash,
     body,
     createdAt,
+    editedAt,
     isPinned,
     reactions[]{ emoji, ipHash, createdAt },
     replies[]{
@@ -153,6 +156,7 @@ export const adminProgramsWithCommentsQuery = `
       ipHash,
       body,
       createdAt,
+      editedAt,
       reactions[]{ emoji }
     }
   }
@@ -189,6 +193,7 @@ export const programBySlugQuery = `
     ipHash,
     body,
     createdAt,
+    editedAt,
     isPinned,
     reactions[]{ emoji },
     replies[]{
@@ -198,6 +203,7 @@ export const programBySlugQuery = `
       ipHash,
       body,
       createdAt,
+      editedAt,
       reactions[]{ emoji }
     }
   },

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -118,13 +118,15 @@ export const adminProgramsQuery = `
     body,
     createdAt,
     isPinned,
+    reactions[]{ emoji },
     replies[]{
       _key,
       authorName,
       authorRole,
       ipHash,
       body,
-      createdAt
+      createdAt,
+      reactions[]{ emoji }
     }
   },
   cdKeys[]
@@ -143,13 +145,15 @@ export const adminProgramsWithCommentsQuery = `
     body,
     createdAt,
     isPinned,
+    reactions[]{ emoji, ipHash, createdAt },
     replies[]{
       _key,
       authorName,
       authorRole,
       ipHash,
       body,
-      createdAt
+      createdAt,
+      reactions[]{ emoji }
     }
   }
 }`;
@@ -186,13 +190,15 @@ export const programBySlugQuery = `
     body,
     createdAt,
     isPinned,
+    reactions[]{ emoji },
     replies[]{
       _key,
       authorName,
       authorRole,
       ipHash,
       body,
-      createdAt
+      createdAt,
+      reactions[]{ emoji }
     }
   },
   cdKeys[],

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -62,6 +62,8 @@ export const programsListingProjection = `
   "vendor": vendor->{ name, "slug": slug.current },
   "keyCount": count(cdKeys[]),
   "hasKeys": count(cdKeys[]) > 0,
+  "categories": categories[]->{ _id, title, "slug": slug.current },
+  "platforms": coalesce(platforms, ["windows"]),
   ${programStatsProjection}
 `;
 
@@ -73,8 +75,12 @@ export const relatedProgramsCardProjection = `
   description,
   image,
   _createdAt,
+  "vendor": vendor->{ name, "slug": slug.current },
+  "categories": categories[]->{ _id, title, "slug": slug.current },
+  "platforms": coalesce(platforms, ["windows"]),
   "keyCount": count(cdKeys[]),
-  "hasKeys": count(cdKeys[]) > 0
+  "hasKeys": count(cdKeys[]) > 0,
+  ${programStatsProjection}
 `;
 
 export const allProgramsQuery = `
@@ -97,6 +103,8 @@ export const adminProgramsQuery = `
   ${featuredBlockProjection},
   latestOfficialVersion,
   "vendor": vendor->{ name, "slug": slug.current },
+  "categories": categories[]->{ _id, title, "slug": slug.current },
+  "platforms": coalesce(platforms, ["windows"]),
   seo,
   aboutSections,
   faq,
@@ -173,6 +181,8 @@ export const programBySlugQuery = `
   ${featuredBlockProjection},
   latestOfficialVersion,
   "vendor": vendor->{ name, "slug": slug.current },
+  "categories": categories[]->{ _id, title, "slug": slug.current },
+  "platforms": coalesce(platforms, ["windows"]),
   seo,
   aboutSections,
   faq,
@@ -342,6 +352,9 @@ export const duplicateKeyReportQuery = `*[_type=="keyReport" && ipHash == $ipHas
 
 /* ------------ Popular Programs (related / light cards — no per-program stats) ------------ */
 export const popularProgramsQuery = `*[_type == "program"] | order(_createdAt desc) [0...6]{ ${relatedProgramsCardProjection} }`;
+
+/** Full candidate pool for related-program scoring (excludes current slug at fetch time). */
+export const relatedProgramsCandidatesQuery = `*[_type == "program" && slug.current != $slug]{ ${relatedProgramsCardProjection} }`;
 
 /* @deprecated Use programsWithStatsQuery + mergeProgramStats + sortPrograms("popular") — GROQ order uses stored scores only. */
 export const popularProgramsByViewsQuery = `*[_type == "program"]{ ${programsListingProjection}, ${featuredBlockProjection} } | order(popularityScore desc) [0...6]`;

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -20,7 +20,7 @@ import { storeSocialEntry } from "./store/storeSocialEntry";
 import { link } from "./store/link";
 
 import { aboutPoint, aboutSection } from "./program/aboutSection";
-import { programComment, programCommentReply } from "./program/programComment";
+import { programComment, programCommentReaction, programCommentReply } from "./program/programComment";
 import { faqItem, program } from "./program/program";
 import { cdKey } from "./program/cdKey";
 import { featuredProgramSettings } from "./program/featuredProgramSettings";
@@ -50,6 +50,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     aboutSection,
     programComment,
     programCommentReply,
+    programCommentReaction,
     faqItem,
     program,
     cdKey,

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -22,6 +22,7 @@ import { link } from "./store/link";
 import { aboutPoint, aboutSection } from "./program/aboutSection";
 import { programComment, programCommentReaction, programCommentReply } from "./program/programComment";
 import { faqItem, program } from "./program/program";
+import { programCategory } from "./program/programCategory";
 import { cdKey } from "./program/cdKey";
 import { featuredProgramSettings } from "./program/featuredProgramSettings";
 import { freeVsProRow } from "./program/freeVsProRow";
@@ -52,6 +53,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     programCommentReply,
     programCommentReaction,
     faqItem,
+    programCategory,
     program,
     cdKey,
     featuredProgramSettings,

--- a/src/sanity/schemaTypes/program/program.ts
+++ b/src/sanity/schemaTypes/program/program.ts
@@ -73,6 +73,29 @@ export const program = defineType({
       validation: Rule => Rule.required()
     }),
     defineField({
+      name: "categories",
+      title: "Categories",
+      type: "array",
+      of: [{ type: "reference", to: [{ type: "programCategory" }] }],
+      description:
+        "Pick existing program categories or create a new category document. Used for related program recommendations on the program page."
+    }),
+    defineField({
+      name: "platforms",
+      title: "Platforms",
+      type: "array",
+      of: [{ type: "string" }],
+      options: {
+        list: [
+          { title: "Windows", value: "windows" },
+          { title: "Mac", value: "mac" }
+        ],
+        layout: "grid"
+      },
+      initialValue: ["windows"],
+      validation: Rule => Rule.required().min(1)
+    }),
+    defineField({
       name: "programFlow",
       title: "Activation flow",
       type: "string",

--- a/src/sanity/schemaTypes/program/programCategory.ts
+++ b/src/sanity/schemaTypes/program/programCategory.ts
@@ -1,0 +1,34 @@
+import { defineField, defineType } from "sanity";
+
+export const programCategory = defineType({
+  name: "programCategory",
+  title: "Program category",
+  type: "document",
+  fields: [
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      description: "Display name (e.g. Driver tools, System cleanup).",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "slug",
+      title: "Slug",
+      type: "slug",
+      options: { source: "title" },
+      validation: Rule => Rule.required()
+    })
+  ],
+  preview: {
+    select: { title: "title", slug: "slug" },
+    prepare({ title, slug }) {
+      const t = typeof title === "string" ? title.trim() : "";
+      const s = slug?.current;
+      return {
+        title: t || "Category",
+        subtitle: s ? `/${s}` : undefined
+      };
+    }
+  }
+});

--- a/src/sanity/schemaTypes/program/programComment.ts
+++ b/src/sanity/schemaTypes/program/programComment.ts
@@ -71,6 +71,12 @@ export const programCommentReply = defineType({
       validation: Rule => Rule.required()
     }),
     defineField({
+      name: "editedAt",
+      title: "Last edited",
+      type: "datetime",
+      readOnly: true
+    }),
+    defineField({
       name: "reactions",
       title: "Reactions",
       type: "array",
@@ -134,6 +140,12 @@ export const programComment = defineType({
       type: "datetime",
       initialValue: () => new Date().toISOString(),
       validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "editedAt",
+      title: "Last edited",
+      type: "datetime",
+      readOnly: true
     }),
     defineField({
       name: "isPinned",

--- a/src/sanity/schemaTypes/program/programComment.ts
+++ b/src/sanity/schemaTypes/program/programComment.ts
@@ -1,5 +1,36 @@
 import { defineField, defineType } from "sanity";
 
+export const programCommentReaction = defineType({
+  name: "programCommentReaction",
+  title: "Comment reaction",
+  type: "object",
+  fields: [
+    defineField({
+      name: "emoji",
+      title: "Emoji",
+      type: "string",
+      validation: Rule => Rule.required().min(1).max(16)
+    }),
+    defineField({
+      name: "ipHash",
+      title: "Visitor hash",
+      type: "string",
+      description: "Hashed IP of reactor (toggle / spam review).",
+      readOnly: true
+    }),
+    defineField({
+      name: "createdAt",
+      title: "Date",
+      type: "datetime",
+      initialValue: () => new Date().toISOString(),
+      validation: Rule => Rule.required()
+    })
+  ],
+  preview: {
+    select: { title: "emoji", subtitle: "createdAt" }
+  }
+});
+
 export const programCommentReply = defineType({
   name: "programCommentReply",
   title: "Comment reply",
@@ -38,6 +69,13 @@ export const programCommentReply = defineType({
       type: "datetime",
       initialValue: () => new Date().toISOString(),
       validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "reactions",
+      title: "Reactions",
+      type: "array",
+      of: [{ type: "programCommentReaction" }],
+      description: "Emoji reactions from visitors (one entry per visitor + emoji)."
     })
   ],
   preview: {
@@ -102,6 +140,13 @@ export const programComment = defineType({
       title: "Pin to top",
       type: "boolean",
       initialValue: false
+    }),
+    defineField({
+      name: "reactions",
+      title: "Reactions",
+      type: "array",
+      of: [{ type: "programCommentReaction" }],
+      description: "Emoji reactions from visitors (one entry per visitor + emoji)."
     }),
     defineField({
       name: "replies",

--- a/src/sanity/schemaTypes/store/storeSocialEntry.ts
+++ b/src/sanity/schemaTypes/store/storeSocialEntry.ts
@@ -17,6 +17,7 @@ export const storeSocialEntry = defineType({
           { title: "X (Twitter)", value: "x" },
           { title: "YouTube", value: "youtube" },
           { title: "Facebook", value: "facebook" },
+          { title: "Telegram", value: "telegram" },
           { title: "Trustpilot", value: "trustpilot" },
           { title: "Website/Portfolio", value: "website" }
         ],

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -79,6 +79,7 @@ export interface ProgramCommentReply {
   ipHash?: string;
   body: string;
   createdAt?: string;
+  editedAt?: string;
   reactions?: ProgramCommentReaction[];
 }
 
@@ -89,6 +90,7 @@ export interface ProgramComment {
   ipHash?: string;
   body: string;
   createdAt?: string;
+  editedAt?: string;
   isPinned?: boolean;
   reactions?: ProgramCommentReaction[];
   replies?: ProgramCommentReply[];

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -57,6 +57,21 @@ export interface ProgramAboutSectionBlock {
   points?: ProgramAboutPoint[];
 }
 
+export interface ProgramCommentReaction {
+  _key?: string;
+  emoji: string;
+  /** Present in CMS / admin; omitted from public program queries. */
+  ipHash?: string;
+  createdAt?: string;
+}
+
+export interface ProgramCommentReactionSummary {
+  emoji: string;
+  count: number;
+  /** True when the current visitor already reacted with this emoji. */
+  reacted: boolean;
+}
+
 export interface ProgramCommentReply {
   _key?: string;
   authorName: string;
@@ -64,6 +79,7 @@ export interface ProgramCommentReply {
   ipHash?: string;
   body: string;
   createdAt?: string;
+  reactions?: ProgramCommentReaction[];
 }
 
 export interface ProgramComment {
@@ -74,6 +90,7 @@ export interface ProgramComment {
   body: string;
   createdAt?: string;
   isPinned?: boolean;
+  reactions?: ProgramCommentReaction[];
   replies?: ProgramCommentReply[];
 }
 

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -10,6 +10,16 @@ export type CDKeyStatus = "new" | "active" | "expired" | "limit";
 /** How activation is delivered for this program (Sanity `program.programFlow`). */
 export type ProgramFlow = "cd_key" | "link_based_cdkey" | "account" | "link_based_account";
 
+/** Supported OS targets for a program (`program.platforms` in Sanity). */
+export type ProgramPlatform = "windows" | "mac";
+
+/** Resolved category reference on a program. */
+export interface ProgramCategoryRef {
+  _id: string;
+  title: string;
+  slug: string;
+}
+
 export interface GiveawayLink {
   title?: string;
   url?: string;
@@ -138,6 +148,10 @@ export interface Program {
   featured?: ProgramFeatured;
   /** Resolved software publisher/brand. Null on legacy docs not yet backfilled. */
   vendor?: VendorRef | null;
+  /** Content categories for related-program matching. Empty on legacy docs. */
+  categories?: ProgramCategoryRef[];
+  /** Defaults to Windows-only when omitted in CMS or API. */
+  platforms?: ProgramPlatform[];
   /** Vendor-reported current version (e.g. from product page). */
   latestOfficialVersion?: string;
   seo?: {

--- a/src/types/programs/index.ts
+++ b/src/types/programs/index.ts
@@ -14,16 +14,28 @@ export interface ProgramsPageClientProps {
 
 export type FilterType = "all" | "hasKeys" | "noKeys";
 export type SortType = "popular" | "views" | "downloads" | "latest" | "oldest" | "name" | "nameDesc";
+export type PlatformFilterType = "all" | "windows" | "mac";
+
+export type ProgramCategoryOption = {
+  _id: string;
+  title: string;
+  slug: string;
+};
 
 export interface ProgramsFilterProps {
   searchTerm: string;
   filter: FilterType;
   sortBy: SortType;
+  category: string;
+  platform: PlatformFilterType;
+  categories: ProgramCategoryOption[];
   onSearchChange: (searchTerm: string) => void;
   /** Fire search immediately (e.g. Enter) instead of waiting for debounce. */
   onSearchCommit?: () => void;
   onFilterChange: (filter: FilterType) => void;
   onSortChange: (sortBy: SortType) => void;
+  onCategoryChange: (categorySlug: string) => void;
+  onPlatformChange: (platform: PlatformFilterType) => void;
 }
 
 export interface ProgramsGridProps {


### PR DESCRIPTION
## Summary

Ships richer program community interactions, Sanity-backed categories and platforms for discovery, smarter related programs, and a refactored /programs filter bar.

## Changelog

<!-- tags: feat, ui, api -->

### Highlights

- Emoji reactions and inline edit on program comments and replies
- Category chips and platform filters across program pages
- Related programs ranked by shared categories with vendor caps

### Community

- Emoji reactions on comments and replies with per-visitor limits and chip UI
- Noto Color Emoji so newer pictographs render reliably in reaction chips
- Visitors can edit their own comment or reply text with editedAt and ownership checks

### Discovery

- New programCategory documents; programs link to categories and declare windows/mac platforms
- Related programs ranked by shared categories and popularity
- Category chips on program hero and home cards; /programs filters by category and platform via URL params
- Platform glyphs on related program cards

### Other

- Telegram added as a store social link option

---

## Environment Variables

None

## Testing

- React/unreact on a comment and nested reply; confirm counts and chip order; verify newer pictograph emojis display
- Edit own comment as same visitor; confirm (edited) and that others cannot PATCH
- Assign categories/platforms in Studio; check chips on /program/[slug], related rail, and /programs?category=&platform=
- Confirm list API and page stay in sync when changing filters

## Technical Details

Deploy Sanity schema before production. Populate categories (and platforms) in Studio so filters and chips are not empty.

Sanity: programCategory type; categories + platforms on programs; programCommentReaction arrays and editedAt on comments/replies; telegram enum on store social entries.
