### PR TITLE
feat: public changelog, updates timeline, and animated sanity images

### DIFF
--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -1,0 +1,32 @@
+name: Sync changelog to Sanity
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  sync:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - run: npm ci
+
+      - name: Upsert changelog draft in Sanity
+        run: node scripts/syncChangelogPrToSanity.mjs ${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SANITY_API_TOKEN: ${{ secrets.SANITY_API_TOKEN }}
+          NEXT_PUBLIC_SANITY_STUDIO_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_SANITY_STUDIO_PROJECT_ID }}
+          NEXT_PUBLIC_SANITY_STUDIO_DATASET: ${{ secrets.NEXT_PUBLIC_SANITY_STUDIO_DATASET }}
+          NEXT_PUBLIC_SANITY_STUDIO_API_VERSION: ${{ secrets.NEXT_PUBLIC_SANITY_STUDIO_API_VERSION }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "backfill:vendors": "node --env-file=.env.local scripts/backfillVendors.mjs"
+    "backfill:vendors": "node --env-file=.env.local scripts/backfillVendors.mjs",
+    "backfill:changelog": "node --env-file=.env.local scripts/backfillChangelogToSanity.mjs",
+    "sync:changelog-pr": "node --env-file=.env.local scripts/syncChangelogPrToSanity.mjs"
   },
   "dependencies": {
     "@portabletext/react": "^6.2.0",

--- a/scripts/backfillChangelogToSanity.mjs
+++ b/scripts/backfillChangelogToSanity.mjs
@@ -1,0 +1,59 @@
+/**
+ * One-time backfill: upsert `changelogRelease` docs from merged GitHub PRs.
+ *
+ *   npm run backfill:changelog            # dry run
+ *   npm run backfill:changelog -- --write # upsert with published: true
+ *   npm run backfill:changelog -- --write --draft  # upsert as drafts
+ *
+ * Requires: NEXT_PUBLIC_SANITY_STUDIO_*, SANITY_API_TOKEN
+ * Optional: GITHUB_TOKEN (higher rate limits)
+ */
+import {
+  createSanityClientFromEnv,
+  fetchMergedPullRequests,
+  pullRequestToChangelogRelease,
+  upsertChangelogRelease
+} from "./changelogSyncUtils.mjs";
+
+const WRITE = process.argv.includes("--write");
+const DRAFT = process.argv.includes("--draft");
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const pulls = await fetchMergedPullRequests({ maxPages: 3, token });
+
+  const releases = pulls
+    .map(pull => pullRequestToChangelogRelease(pull))
+    .filter(release => release !== null);
+
+  console.log(`Merged PRs (excl. skip-changelog): ${releases.length}`);
+  for (const release of releases.slice(0, 10)) {
+    console.log(`  - #${release.prNumber} ${release.title.slice(0, 60)}… [${release.tags.join(", ")}]`);
+  }
+  if (releases.length > 10) console.log(`  … and ${releases.length - 10} more`);
+
+  if (!WRITE) {
+    console.log("\nDry run. Re-run with -- --write to upsert (published: true by default).");
+    return;
+  }
+
+  const client = createSanityClientFromEnv();
+  const published = !DRAFT;
+  let count = 0;
+
+  for (const release of releases) {
+    const pull = pulls.find(p => p.number === release.prNumber);
+    await upsertChangelogRelease(client, release, {
+      published,
+      rawPrBody: pull?.body ?? undefined
+    });
+    count++;
+  }
+
+  console.log(`\nUpserted ${count} changelogRelease docs (published: ${published}).`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/changelogSyncUtils.mjs
+++ b/scripts/changelogSyncUtils.mjs
@@ -1,0 +1,436 @@
+/**
+ * Shared changelog parser + Sanity upsert helpers for Node scripts / GitHub Actions.
+ * Mirrors src/lib/changelog/* (keep in sync when parser changes).
+ */
+import { createClient } from "@sanity/client";
+
+export const CHANGELOG_TAGS = [
+  "feat",
+  "fix",
+  "ui",
+  "perf",
+  "api",
+  "docs",
+  "refactor",
+  "enhance"
+];
+
+const CHANGELOG_TAG_SET = new Set(CHANGELOG_TAGS);
+
+const CHANGELOG_TAG_ALIASES = {
+  doc: "docs",
+  documentation: "docs",
+  refactoring: "refactor",
+  enhancement: "enhance",
+  improvements: "enhance",
+  improve: "enhance"
+};
+
+export const SKIP_LABEL = "skip-changelog";
+export const GITHUB_OWNER = "eyyMinda";
+export const GITHUB_REPO = "KeyAway";
+
+const SKIP_SECTION_TITLES = new Set([
+  "environment variables",
+  "env variables",
+  "environment",
+  "testing",
+  "technical details",
+  "test plan"
+]);
+
+const SENSITIVE_LINE_PATTERNS = [
+  /^\s*[A-Z][A-Z0-9_]{2,}\s*=\s*\S+/,
+  /process\.env\./i,
+  /\.env(\.[a-z]+)?\b/i,
+  /\b(api[_-]?key|client[_-]?secret|secret[_-]?key|access[_-]?token|auth[_-]?token|private[_-]?key)\b/i,
+  /\b(password|passwd|credential)s?\b/i,
+  /\bgh\s+secret\b/i,
+  /\bgithub[_-]?token\b/i,
+  /\bsanity[_-]?api[_-]?token\b/i,
+  /\bnextauth[_-]?secret\b/i,
+  /\bresend[_-]?api[_-]?key\b/i
+];
+
+const INLINE_SECRET_VALUE_RE = /\b([A-Z][A-Z0-9_]{2,})=([^\s`]+)/g;
+const CHANGELOG_TAGS_COMMENT_RE = /<!--\s*tags:\s*([^>]+?)\s*-->/i;
+const LEGACY_HIGHLIGHT_SECTION_TITLES = ["active changes", "changes", "highlights", "what's new", "whats new"];
+const CHANGELOG_BLOCK_TITLE = "changelog";
+
+function sectionKey(title) {
+  return title.trim().toLowerCase();
+}
+
+function shouldSkipChangelogSection(title) {
+  return SKIP_SECTION_TITLES.has(title.trim().toLowerCase());
+}
+
+function isSensitiveChangelogLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  return SENSITIVE_LINE_PATTERNS.some(pattern => pattern.test(trimmed));
+}
+
+function sanitizeChangelogText(text) {
+  const withoutCodeBlocks = text.replace(/```[\s\S]*?```/g, "");
+  const lines = withoutCodeBlocks.split(/\r?\n/);
+
+  return lines
+    .map(line => {
+      if (isSensitiveChangelogLine(line)) return "";
+      return line.replace(INLINE_SECRET_VALUE_RE, "$1=[redacted]");
+    })
+    .filter(line => line.trim().length > 0)
+    .join("\n")
+    .trim();
+}
+
+function sanitizeChangelogBullet(text) {
+  const cleaned = sanitizeChangelogText(text.replace(/^[-*]\s+/, "").trim());
+  return cleaned.replace(/`([^`]+)`/g, "$1");
+}
+
+function isChangelogTag(value) {
+  return CHANGELOG_TAG_SET.has(value.trim().toLowerCase());
+}
+
+function normalizeTagToken(raw) {
+  const token = raw.trim().toLowerCase();
+  if (isChangelogTag(token)) return token;
+  return CHANGELOG_TAG_ALIASES[token] ?? null;
+}
+
+function parseChangelogTagsFromComment(body) {
+  const match = CHANGELOG_TAGS_COMMENT_RE.exec(body);
+  if (!match?.[1]) return [];
+
+  return [
+    ...new Set(
+      match[1]
+        .split(/[,|\s]+/)
+        .map(token => normalizeTagToken(token))
+        .filter(Boolean)
+    )
+  ];
+}
+
+function parseChangelogTagsFromLabels(labels) {
+  return [
+    ...new Set(labels.map(label => normalizeTagToken(label)).filter(Boolean))
+  ];
+}
+
+function inferChangelogTagsFromTitle(title) {
+  const tags = new Set();
+  const lower = title.toLowerCase();
+
+  if (lower.startsWith("feat")) tags.add("feat");
+  if (lower.startsWith("fix")) tags.add("fix");
+  if (lower.startsWith("docs")) tags.add("docs");
+  if (lower.startsWith("refactor")) tags.add("refactor");
+  if (/\bui\b|style|design/.test(lower)) tags.add("ui");
+  if (/\bperf\b|performance/.test(lower)) tags.add("perf");
+  if (/\bapi\b|route|endpoint/.test(lower)) tags.add("api");
+  if (/\benhance|\bimprove/.test(lower)) tags.add("enhance");
+
+  return [...tags];
+}
+
+function resolveChangelogTags(body, title, labels = []) {
+  const merged = new Set([
+    ...parseChangelogTagsFromComment(body),
+    ...parseChangelogTagsFromLabels(labels),
+    ...inferChangelogTagsFromTitle(title)
+  ]);
+
+  if (merged.size === 0) merged.add("feat");
+  return [...merged];
+}
+
+function splitPublicBody(body) {
+  const parts = body.split(/^---\s*$/m);
+  return parts[0]?.trim() ?? body;
+}
+
+function parseMarkdownSections(body) {
+  const sections = [];
+  const chunks = body.split(/^##\s+/m);
+
+  for (let i = 1; i < chunks.length; i++) {
+    const chunk = chunks[i] ?? "";
+    const newline = chunk.indexOf("\n");
+    if (newline === -1) {
+      sections.push({ title: chunk.trim(), content: "" });
+      continue;
+    }
+    sections.push({
+      title: chunk.slice(0, newline).trim(),
+      content: chunk.slice(newline + 1).trim()
+    });
+  }
+
+  return sections;
+}
+
+function extractBullets(content) {
+  return content
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => /^[-*]\s+/.test(line))
+    .map(line => sanitizeChangelogBullet(line))
+    .filter(line => line.length > 0 && !isSensitiveChangelogLine(line));
+}
+
+function firstParagraph(content) {
+  const blocks = content
+    .split(/\r?\n\r?\n/)
+    .map(block => block.trim())
+    .filter(Boolean);
+
+  for (const block of blocks) {
+    if (/^[-*]\s+/m.test(block)) continue;
+    const sanitized = sanitizeChangelogText(block.replace(/\r?\n/g, " "));
+    if (sanitized) return sanitized;
+  }
+
+  return "";
+}
+
+function parseChangelogSubsections(changelogContent) {
+  const withoutTagComment = changelogContent.replace(/<!--\s*tags:[^>]+-->/i, "").trim();
+  const subParts = withoutTagComment.split(/^###\s+/m);
+
+  if (subParts.length <= 1) {
+    const bullets = extractBullets(withoutTagComment);
+    return { highlights: bullets, sections: [] };
+  }
+
+  const sections = [];
+  let highlights = [];
+
+  for (let i = 1; i < subParts.length; i++) {
+    const chunk = subParts[i] ?? "";
+    const newline = chunk.indexOf("\n");
+    const title = (newline === -1 ? chunk : chunk.slice(0, newline)).trim();
+    const content = newline === -1 ? "" : chunk.slice(newline + 1).trim();
+    const items = extractBullets(content);
+    if (items.length === 0) continue;
+
+    if (sectionKey(title) === "highlights") {
+      highlights = items;
+      continue;
+    }
+
+    sections.push({ title, items });
+  }
+
+  if (highlights.length === 0) {
+    highlights = sections.flatMap(section => section.items).slice(0, 6);
+  }
+
+  return { highlights, sections };
+}
+
+function parseLegacySections(visible) {
+  const summarySection = visible.find(section => sectionKey(section.title) === "summary");
+  const summary =
+    (summarySection ? firstParagraph(summarySection.content) : "") ||
+    firstParagraph(visible.map(section => section.content).join("\n\n"));
+
+  const highlightSection = visible.find(section =>
+    LEGACY_HIGHLIGHT_SECTION_TITLES.includes(sectionKey(section.title))
+  );
+  const highlights = highlightSection
+    ? extractBullets(highlightSection.content)
+    : extractBullets(visible.map(section => section.content).join("\n")).slice(0, 6);
+
+  const sections = visible
+    .filter(section => {
+      const key = sectionKey(section.title);
+      if (key === "summary" || key === CHANGELOG_BLOCK_TITLE) return false;
+      if (LEGACY_HIGHLIGHT_SECTION_TITLES.includes(key)) return false;
+      return extractBullets(section.content).length > 0;
+    })
+    .map(section => ({
+      title: section.title,
+      items: extractBullets(section.content)
+    }));
+
+  return { summary, highlights, sections };
+}
+
+export function pullRequestToChangelogRelease(pr) {
+  if (!pr.merged_at) return null;
+
+  const publicBody = splitPublicBody(pr.body?.trim() ?? "");
+  const parsed = parseMarkdownSections(publicBody);
+  const visible = parsed.filter(section => !shouldSkipChangelogSection(section.title));
+
+  const changelogSection = visible.find(section => sectionKey(section.title) === CHANGELOG_BLOCK_TITLE);
+  const legacy = parseLegacySections(visible);
+
+  let summary = legacy.summary;
+  let highlights = legacy.highlights;
+  let sections = legacy.sections;
+
+  if (changelogSection) {
+    const structured = parseChangelogSubsections(changelogSection.content);
+    highlights = structured.highlights.length > 0 ? structured.highlights : highlights;
+    sections = structured.sections.length > 0 ? structured.sections : sections;
+  }
+
+  if (!summary) {
+    summary = firstParagraph(publicBody) || sanitizeChangelogText(pr.title);
+  }
+
+  if (highlights.length === 0) {
+    highlights = sections.flatMap(section => section.items).slice(0, 6);
+  }
+  if (highlights.length === 0) {
+    highlights = [summary];
+  }
+
+  const mergedDate = new Date(pr.merged_at);
+  const id = Number.isFinite(mergedDate.getTime())
+    ? `${mergedDate.toISOString().slice(0, 10)}-pr-${pr.number}`
+    : `pr-${pr.number}`;
+
+  return {
+    id,
+    releasedAt: pr.merged_at,
+    title: sanitizeChangelogText(pr.title) || pr.title,
+    prNumber: pr.number,
+    tags: resolveChangelogTags(publicBody, pr.title, pr.labels ?? []),
+    summary,
+    highlights,
+    sections: sections.length > 0 ? sections : undefined
+  };
+}
+
+export function hasSkipChangelogLabel(labels = []) {
+  return labels.some(label => String(label).toLowerCase() === SKIP_LABEL);
+}
+
+export function changelogDocId(prNumber) {
+  return `changelogRelease.pr.${prNumber}`;
+}
+
+export function releaseToSanityDoc(release, { published = false, rawPrBody } = {}) {
+  return {
+    _id: changelogDocId(release.prNumber),
+    _type: "changelogRelease",
+    prNumber: release.prNumber,
+    releasedAt: release.releasedAt,
+    title: release.title,
+    summary: release.summary,
+    tags: release.tags,
+    highlights: release.highlights,
+    sections: (release.sections ?? []).map(section => ({
+      _type: "changelogSection",
+      title: section.title,
+      items: section.items
+    })),
+    published,
+    ...(rawPrBody ? { rawPrBody } : {})
+  };
+}
+
+export function createSanityClientFromEnv() {
+  const projectId = process.env.NEXT_PUBLIC_SANITY_STUDIO_PROJECT_ID;
+  const dataset = process.env.NEXT_PUBLIC_SANITY_STUDIO_DATASET;
+  const apiVersion = process.env.NEXT_PUBLIC_SANITY_STUDIO_API_VERSION || "2025-09-07";
+  const token = process.env.SANITY_API_TOKEN;
+
+  if (!projectId || !dataset) {
+    throw new Error("Missing NEXT_PUBLIC_SANITY_STUDIO_PROJECT_ID / NEXT_PUBLIC_SANITY_STUDIO_DATASET.");
+  }
+  if (!token) {
+    throw new Error("SANITY_API_TOKEN is required.");
+  }
+
+  return createClient({ projectId, dataset, apiVersion, token, useCdn: false });
+}
+
+export async function fetchGitHubPullRequest(number, token) {
+  const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/pulls/${number}`;
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "KeyAway-Changelog-Sync"
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const response = await fetch(url, { headers });
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`GitHub API ${response.status}: ${response.statusText}`);
+  }
+
+  const pull = await response.json();
+  return {
+    number: pull.number,
+    title: pull.title,
+    body: pull.body,
+    merged_at: pull.merged_at,
+    labels: (pull.labels ?? []).map(label => label.name)
+  };
+}
+
+/** Paginated merged PR list (newest merge first). */
+export async function fetchMergedPullRequests({ maxPages = 3, token } = {}) {
+  const pulls = [];
+
+  for (let page = 1; page <= maxPages; page++) {
+    const url = new URL(`https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/pulls`);
+    url.searchParams.set("state", "closed");
+    url.searchParams.set("sort", "updated");
+    url.searchParams.set("direction", "desc");
+    url.searchParams.set("per_page", "100");
+    url.searchParams.set("page", String(page));
+
+    const headers = {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "KeyAway-Changelog-Backfill"
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
+
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      throw new Error(`GitHub API ${response.status}: ${response.statusText}`);
+    }
+
+    const batch = await response.json();
+    if (!Array.isArray(batch) || batch.length === 0) break;
+
+    pulls.push(
+      ...batch.map(pull => ({
+        number: pull.number,
+        title: pull.title,
+        body: pull.body,
+        merged_at: pull.merged_at,
+        labels: (pull.labels ?? []).map(label => label.name)
+      }))
+    );
+
+    if (batch.length < 100) break;
+  }
+
+  return pulls
+    .filter(pull => pull.merged_at)
+    .filter(pull => !hasSkipChangelogLabel(pull.labels))
+    .sort((a, b) => new Date(b.merged_at).getTime() - new Date(a.merged_at).getTime());
+}
+
+export async function upsertChangelogRelease(client, release, options = {}) {
+  const { published = false, rawPrBody, preservePublished = false } = options;
+  const id = changelogDocId(release.prNumber);
+
+  let effectivePublished = published;
+  if (preservePublished) {
+    const existing = await client.getDocument(id).catch(() => null);
+    if (existing?.published === true) effectivePublished = true;
+  }
+
+  const doc = releaseToSanityDoc(release, { published: effectivePublished, rawPrBody });
+  await client.createOrReplace(doc, { autoGenerateArrayKeys: true });
+  return id;
+}

--- a/scripts/syncChangelogPrToSanity.mjs
+++ b/scripts/syncChangelogPrToSanity.mjs
@@ -1,0 +1,63 @@
+/**
+ * Sync a single merged PR to Sanity as a changelogRelease draft.
+ *
+ *   npm run sync:changelog-pr -- 112
+ *   node scripts/syncChangelogPrToSanity.mjs 112
+ *
+ * Skips PRs with the `skip-changelog` label. Used by GitHub Actions on merge.
+ */
+import {
+  createSanityClientFromEnv,
+  fetchGitHubPullRequest,
+  hasSkipChangelogLabel,
+  pullRequestToChangelogRelease,
+  upsertChangelogRelease
+} from "./changelogSyncUtils.mjs";
+
+const prArg = process.argv.find(arg => /^\d+$/.test(arg));
+const prNumber = prArg ? Number(prArg) : Number(process.env.PR_NUMBER);
+
+if (!Number.isFinite(prNumber) || prNumber < 1) {
+  console.error("Usage: syncChangelogPrToSanity.mjs <pr-number>");
+  process.exit(1);
+}
+
+async function main() {
+  const ghToken = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const pull = await fetchGitHubPullRequest(prNumber, ghToken);
+
+  if (!pull) {
+    console.log(`PR #${prNumber} not found.`);
+    return;
+  }
+
+  if (!pull.merged_at) {
+    console.log(`PR #${prNumber} is not merged — skipping.`);
+    return;
+  }
+
+  if (hasSkipChangelogLabel(pull.labels)) {
+    console.log(`PR #${prNumber} has skip-changelog — skipping.`);
+    return;
+  }
+
+  const release = pullRequestToChangelogRelease(pull);
+  if (!release) {
+    console.log(`PR #${prNumber} could not be parsed — skipping.`);
+    return;
+  }
+
+  const client = createSanityClientFromEnv();
+  const id = await upsertChangelogRelease(client, release, {
+    published: false,
+    preservePublished: true,
+    rawPrBody: pull.body ?? undefined
+  });
+
+  console.log(`Upserted draft ${id} for PR #${prNumber}.`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/v1/webhooks/revalidate/route.ts
+++ b/src/app/api/v1/webhooks/revalidate/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Errors } from "@/src/lib/api/errors";
 import { rateLimitMiddleware } from "@/src/lib/api/rateLimit";
 import {
+  TAG_CHANGELOG,
   TAG_FEATURED_PROGRAM,
   TAG_HOMEPAGE_PROGRAMS,
   TAG_HOMEPAGE_STATS,
@@ -79,6 +80,9 @@ export async function POST(req: NextRequest) {
       revalidateTag(TAG_HOMEPAGE_STATS, "max");
     } else if (t === "featuredProgramSettings") {
       revalidateTag(TAG_FEATURED_PROGRAM, "max");
+    } else if (t === "changelogRelease") {
+      revalidateTag(TAG_CHANGELOG, "max");
+      revalidatePath("/changelog");
     } else if (t === "vendor") {
       // Vendor edits change hub copy/metadata and program-card brand labels.
       revalidateTag(TAG_VENDORS, "max");

--- a/src/app/changelog/ChangelogContent.tsx
+++ b/src/app/changelog/ChangelogContent.tsx
@@ -1,0 +1,121 @@
+import Link from "next/link";
+import ChangelogReleaseList from "@/src/components/changelog/ChangelogReleaseList";
+import FeedShowMoreButton from "@/src/components/site/FeedShowMoreButton";
+import FeedWithMonthSidebar from "@/src/components/site/FeedWithMonthSidebar";
+import TrustPageHero from "@/src/components/site/TrustPageHero";
+import {
+  buildChangelogHref,
+  buildChangelogSidebarIndex,
+  filterChangelogByMonth,
+  groupChangelogByMonth,
+  resolveChangelogPageParams
+} from "@/src/lib/changelog/changelogPageUtils";import { getCachedChangelogReleases } from "@/src/lib/changelog/getChangelogReleases.server";
+import { formatChangelogDate } from "@/src/lib/changelog/changelogEntries";
+import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
+import {
+  applyFeedLimit,
+  CHANGELOG_FEED_DEFAULT_LIMIT,
+  CHANGELOG_FEED_LIMIT_INCREMENT,
+  nextFeedLimit,
+  resolveFeedLimit
+} from "@/src/lib/site/feedLimitUtils";
+import { formatMonthLabel } from "@/src/lib/updates/updatesPageUtils";
+
+/** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` (Next.js requires a literal). */
+export const revalidate = 43200;
+
+interface ChangelogContentProps {
+  searchParams: Promise<{ month?: string; limit?: string }>;
+}
+
+export default async function ChangelogContent({ searchParams }: ChangelogContentProps) {
+  const sp = await searchParams;
+  const { month } = resolveChangelogPageParams(sp);
+  const limit = resolveFeedLimit(sp.limit, CHANGELOG_FEED_DEFAULT_LIMIT);
+
+  const store = await getCachedStoreDetailsDocument();
+  const storeTitle = store?.title?.trim() || "KeyAway";
+  const releases = await getCachedChangelogReleases();
+  const latestDate = releases[0]?.releasedAt;
+
+  const sidebarYears = buildChangelogSidebarIndex(releases);
+  const filtered = filterChangelogByMonth(releases, month);
+  const unlimited = Boolean(month);
+  const { visible, hasMore, total } = applyFeedLimit(filtered, limit, unlimited);
+  const showMoreHref = buildChangelogHref(undefined, nextFeedLimit(limit, CHANGELOG_FEED_LIMIT_INCREMENT, total));
+
+  const heading = month ? formatMonthLabel(month) : "All releases";
+  const releaseGroups = groupChangelogByMonth(visible);
+  const latestReleaseId = !month ? visible[0]?.id : undefined;
+  return (
+    <div className="min-h-screen static-bg text-[#c6d4df]">
+      <TrustPageHero
+        label="Changelog"
+        title={
+          <>
+            What&apos;s new on <span className="text-gradient-pro">{storeTitle}</span>
+          </>
+        }
+        subtitle="Release notes for major features, improvements, and fixes shipped to KeyAway."
+        lastUpdated={latestDate ? formatChangelogDate(latestDate) : undefined}
+      />
+
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-sm border border-[#2a475e] bg-[#1b2838] px-4 py-3 sm:px-5">
+          <p className="text-sm text-[#8f98a0]">Platform release history</p>
+          <Link href="/updates" className="text-sm font-semibold text-[#66c0f4] transition-colors hover:text-white">
+            Catalog activity feed →
+          </Link>
+        </div>
+
+        <FeedWithMonthSidebar
+          scrollSpyEnabled={!month}
+          sidebar={{
+            years: sidebarYears,
+            activeMonth: month,
+            totalCount: releases.length,
+            allLabel: "All releases",
+            ariaLabel: "Filter changelog by month",
+            feed: "changelog"
+          }}>
+          <div className="mb-4">
+            <h2 className="text-xl font-bold text-white sm:text-2xl">{heading}</h2>
+          </div>
+
+          {visible.length === 0 ? (
+            <div className="rounded-sm border border-[#2a475e] bg-[#1b2838] px-5 py-10 text-center">
+              <p className="text-sm text-neutral-100 sm:text-base">
+                {month ? `No releases for ${formatMonthLabel(month).toLowerCase()}.` : "No releases yet."}
+              </p>
+              <Link
+                href="/changelog"
+                className="mt-4 inline-block text-sm font-semibold text-[#66c0f4] transition-colors hover:text-white">
+                View all releases →
+              </Link>
+            </div>
+          ) : (
+            <>
+              <ChangelogReleaseList
+                groups={releaseGroups}
+                monthFilter={month}
+                latestReleaseId={latestReleaseId}
+              />
+
+              {!unlimited && hasMore ? (
+                <FeedShowMoreButton href={showMoreHref} label="Load more releases" />
+              ) : null}
+            </>
+          )}
+
+          <p className="mt-10 text-center text-xs text-[#8f98a0] sm:text-sm lg:text-left">
+            For day-to-day listings and key drops, see{" "}
+            <Link href="/updates" className="font-semibold text-[#66c0f4] hover:text-white">
+              Updates
+            </Link>
+            .
+          </p>
+        </FeedWithMonthSidebar>
+      </div>
+    </div>
+  );
+}

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,0 +1,14 @@
+import { generateChangelogMetadata } from "@/src/lib/seo/metadata";
+import ChangelogContent from "./ChangelogContent";
+
+export async function generateMetadata() {
+  return generateChangelogMetadata();
+}
+
+interface ChangelogPageProps {
+  searchParams: Promise<{ month?: string; limit?: string }>;
+}
+
+export default function ChangelogPage({ searchParams }: ChangelogPageProps) {
+  return <ChangelogContent searchParams={searchParams} />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -78,12 +78,13 @@ export default async function RootLayout({
   const currentLogo = storeData?.logoLight;
   /** Match header/footer slot (~104×48 CSS px); keeps `/_next/image` width near 128–256 instead of 384+. */
   const LOGO_WIDTH_HINT = 120;
-  const logoDims = currentLogo ? getImageDimensions(currentLogo) : { width: 120, height: 48 };
+  const logoIntrinsic = currentLogo ? getImageDimensions(currentLogo) : { width: 120, height: 48 };
+  const logoHeight = Math.max(1, Math.round((logoIntrinsic.height / logoIntrinsic.width) * LOGO_WIDTH_HINT));
   const logoData: LogoData = {
     src: urlFor(currentLogo).width(LOGO_WIDTH_HINT).quality(70).auto("format").url(),
     alt: `${storeData?.title ?? "KeyAway"} logo`,
-    width: logoDims.width,
-    height: logoDims.height,
+    width: LOGO_WIDTH_HINT,
+    height: logoHeight,
     blurDataURL: urlFor(currentLogo).width(24).height(24).blur(10).url(),
     widthHint: LOGO_WIDTH_HINT,
     sizes: "120px",
@@ -112,10 +113,7 @@ export default async function RootLayout({
         {renderedHeadMetaTags}
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&display=swap"
-          rel="stylesheet"
-        />
+        <link href="https://fonts.googleapis.com/css2?family=Noto+Color+Emoji&display=swap" rel="stylesheet" />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#0f1923] text-[#c6d4df]`}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -18,7 +18,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = resolveSiteBaseUrl(store?.seo);
   const currentDate = new Date();
 
-  const trustPaths = ["/about", "/how-it-works", "/affiliate-disclosure", "/verification-policy", "/dmca", "/partners", "/updates"];
+  const trustPaths = ["/about", "/how-it-works", "/affiliate-disclosure", "/verification-policy", "/dmca", "/partners", "/updates", "/changelog"];
 
   // Static routes with proper SEO optimization
   const staticRoutes: MetadataRoute.Sitemap = [

--- a/src/app/updates/UpdatesContent.tsx
+++ b/src/app/updates/UpdatesContent.tsx
@@ -1,88 +1,125 @@
 import Link from "next/link";
 import JsonLd from "@/src/components/JsonLd";
-import UpdateFeedItem from "@/src/components/updates/UpdateFeedItem";
-import {
-  filterNotificationsByDays,
-  hasOlderNotifications,
-  readSiteNotificationHistory,
-  resolveUpdatesPageDays,
-  UPDATES_PAGE_DAYS_INCREMENT,
-  UPDATES_PAGE_MAX_DAYS
-} from "@/src/lib/notifications/notificationFeed.server";
+import FeedShowMoreButton from "@/src/components/site/FeedShowMoreButton";
+import FeedWithMonthSidebar from "@/src/components/site/FeedWithMonthSidebar";
+import TrustPageHero from "@/src/components/site/TrustPageHero";
+import UpdatesTimeline from "@/src/components/updates/UpdatesTimeline";
+import { readSiteNotificationHistory } from "@/src/lib/notifications/notificationFeed.server";
 import { getCachedStoreDetailsDocument } from "@/src/lib/sanity/getCachedStoreDetails";
 import { generateUpdatesPageJsonLd } from "@/src/lib/seo/jsonLd";
 import { resolveUpdatesPageSeo } from "@/src/lib/seo/trustPageSeo";
+import {
+  applyFeedLimit,
+  nextFeedLimit,
+  UPDATES_FEED_LIMIT_INCREMENT
+} from "@/src/lib/site/feedLimitUtils";
+import {
+  buildMonthSidebarIndex,
+  buildUpdatesHref,
+  filterNotificationsByMonth,
+  formatMonthLabel,
+  formatUpdateDate,
+  groupSortedNotifications,
+  resolveUpdatesPageParams
+} from "@/src/lib/updates/updatesPageUtils";
 
 /** Must match `PUBLIC_ISR_REVALIDATE_SECONDS` (Next.js requires a literal). */
 export const revalidate = 43200;
 
 interface UpdatesContentProps {
-  searchParams: Promise<{ days?: string }>;
+  searchParams: Promise<{ month?: string; limit?: string }>;
 }
 
 export default async function UpdatesContent({ searchParams }: UpdatesContentProps) {
   const sp = await searchParams;
-  const days = resolveUpdatesPageDays(sp.days);
+  const { month, limit } = resolveUpdatesPageParams(sp);
 
   const [store, allUpdates] = await Promise.all([getCachedStoreDetailsDocument(), readSiteNotificationHistory()]);
-  const updates = filterNotificationsByDays(allUpdates, days);
-  const showViewMore = hasOlderNotifications(allUpdates, days) && days < UPDATES_PAGE_MAX_DAYS;
-  const nextDays = Math.min(days + UPDATES_PAGE_DAYS_INCREMENT, UPDATES_PAGE_MAX_DAYS);
+  const sidebarYears = buildMonthSidebarIndex(allUpdates);
+  const filtered = filterNotificationsByMonth(allUpdates, month);
+  const unlimited = Boolean(month);
+  const { visible, hasMore, total } = applyFeedLimit(filtered, limit, unlimited);
+  const timeline = groupSortedNotifications(visible);
+  const showMoreHref = buildUpdatesHref(undefined, nextFeedLimit(limit, UPDATES_FEED_LIMIT_INCREMENT, total));
 
   const { pageUrl: siteUrl, storeTitle } = resolveUpdatesPageSeo(store);
-  const jsonLd = generateUpdatesPageJsonLd(updates, siteUrl);
+  const jsonLd = generateUpdatesPageJsonLd(filtered.slice(0, 50), siteUrl);
+
+  const heading = month ? formatMonthLabel(month) : "All updates";
+  const latestDate = allUpdates[0]?.createdAt;
 
   return (
     <>
       <JsonLd data={jsonLd} />
 
       <div className="min-h-screen static-bg text-[#c6d4df]">
-        <section className="border-b border-[#2a475e]">
-          <div className="mx-auto max-w-3xl px-4 py-10 text-center sm:px-6 sm:py-12 lg:px-8">
-            <h1 className="section-title">
-              Latest <span className="text-gradient-pro">updates</span>
-            </h1>
-            <p className="section-text mx-auto mt-3 max-w-xl">
-              New programs and fresh giveaway keys added to {storeTitle} in the last {days} days. This feed updates
-              automatically when our catalog changes.
-            </p>
-          </div>
-        </section>
+        <TrustPageHero
+          label="Updates"
+          title={
+            <>
+              Latest catalog updates on <span className="text-gradient-pro">{storeTitle}</span>
+            </>
+          }
+          subtitle={`New programs and fresh giveaway keys added to ${storeTitle}, refreshed from our live catalog.`}
+          lastUpdated={latestDate ? formatUpdateDate(latestDate) : undefined}
+        />
 
-        <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
-          {updates.length === 0 ? (
-            <div className="rounded-sm border border-[#2a475e] bg-[#1b2838] px-5 py-10 text-center">
-              <p className="text-sm text-neutral-100 sm:text-base">No catalog updates in the last {days} days.</p>
-              <Link
-                href="/programs"
-                className="mt-4 inline-block text-sm font-semibold text-[#66c0f4] transition-colors hover:text-white">
-                Browse all programs →
-              </Link>
-            </div>
-          ) : (
-            <ul className="space-y-3">
-              {updates.map(item => (
-                <UpdateFeedItem key={item.id} notification={item} />
-              ))}
-            </ul>
-          )}
-
-          {showViewMore ? (
-            <div className="mt-8 flex justify-center">
-              <Link
-                href={`/updates?days=${nextDays}`}
-                className="inline-flex min-h-11 items-center justify-center rounded-sm border border-[#4a90c4] bg-[#1a3a5c] px-6 py-2.5 text-sm font-semibold text-[#c6d4df] transition-colors hover:border-[#66c0f4] hover:bg-[#213246] hover:text-white">
-                View more updates
-              </Link>
-            </div>
-          ) : null}
-
-          <p className="mt-8 text-center text-xs text-[#8f98a0] sm:text-sm">
-            Want everything?{" "}
-            <Link href="/programs" className="font-semibold text-[#66c0f4] hover:text-white">
-              Browse the full program catalog
+        <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-10 lg:px-8">
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-sm border border-[#2a475e] bg-[#1b2838] px-4 py-3 sm:px-5">
+            <p className="text-sm text-[#8f98a0]">Catalog activity feed</p>
+            <Link href="/changelog" className="text-sm font-semibold text-[#66c0f4] transition-colors hover:text-white">
+              Platform release history →
             </Link>
-          </p>
+          </div>
+
+          <FeedWithMonthSidebar
+            scrollSpyEnabled={!month}
+            sidebar={{
+              years: sidebarYears,
+              activeMonth: month,
+              totalCount: allUpdates.length,
+              allLabel: "All updates",
+              ariaLabel: "Filter updates by month",
+              feed: "updates"
+            }}>
+            <div className="mb-4">
+              <h2 className="text-xl font-bold text-white sm:text-2xl">{heading}</h2>
+            </div>
+
+            {visible.length === 0 ? (
+              <div className="rounded-sm border border-[#2a475e] bg-[#1b2838] px-5 py-10 text-center">
+                <p className="text-sm text-neutral-100 sm:text-base">
+                  {month ? `No updates for ${formatMonthLabel(month).toLowerCase()}.` : "No catalog updates yet."}
+                </p>
+                {month ? (
+                  <Link
+                    href="/updates"
+                    className="mt-4 inline-block text-sm font-semibold text-[#66c0f4] transition-colors hover:text-white">
+                    View all updates →
+                  </Link>
+                ) : (
+                  <Link
+                    href="/programs"
+                    className="mt-4 inline-block text-sm font-semibold text-[#66c0f4] transition-colors hover:text-white">
+                    Browse all programs →
+                  </Link>
+                )}
+              </div>
+            ) : (
+              <>
+                <UpdatesTimeline groups={timeline} showYearHeadings={!month || timeline.length > 1} />
+                {!unlimited && hasMore ? (
+                  <FeedShowMoreButton href={showMoreHref} label="Load more updates" />
+                ) : null}
+              </>
+            )}
+
+            <p className="mt-8 text-center text-xs text-[#8f98a0] sm:text-sm lg:text-left">
+              <Link href="/programs" className="font-semibold text-[#66c0f4] hover:text-white">
+                Browse the full program catalog
+              </Link>
+            </p>
+          </FeedWithMonthSidebar>
         </div>
       </div>
     </>

--- a/src/app/updates/page.tsx
+++ b/src/app/updates/page.tsx
@@ -6,7 +6,7 @@ export async function generateMetadata() {
 }
 
 interface UpdatesPageProps {
-  searchParams: Promise<{ days?: string }>;
+  searchParams: Promise<{ month?: string; limit?: string }>;
 }
 
 export default function UpdatesPage({ searchParams }: UpdatesPageProps) {

--- a/src/components/changelog/ChangelogReleaseCard.tsx
+++ b/src/components/changelog/ChangelogReleaseCard.tsx
@@ -1,0 +1,96 @@
+import type { ChangelogRelease, ChangelogTag } from "@/src/lib/changelog/changelogEntries";
+import { formatChangelogDate } from "@/src/lib/changelog/changelogEntries";
+
+const TAG_STYLES: Record<ChangelogTag, string> = {
+  feat: "border-[#4a90c4]/50 bg-[#1a3a5c]/80 text-[#9fc6e3]",
+  fix: "border-[#3d6e1c]/50 bg-[#1a3a2a]/80 text-[#8bc34a]",
+  ui: "border-[#7b5ea7]/50 bg-[#2a1f3d]/80 text-[#c9b8e8]",
+  perf: "border-[#c9a227]/50 bg-[#3d3010]/80 text-[#f0d878]",
+  api: "border-[#2a8f8f]/50 bg-[#143030]/80 text-[#7fd4d4]",
+  docs: "border-[#5a6a7a]/50 bg-[#1a2530]/80 text-[#a8b8c8]",
+  refactor: "border-[#8f6a3c]/50 bg-[#2a2010]/80 text-[#d4a860]",
+  enhance: "border-[#3d8f6e]/50 bg-[#1a3028]/80 text-[#7fd4a8]"
+};
+
+type ChangelogReleaseCardProps = {
+  release: ChangelogRelease;
+  isLatest?: boolean;
+};
+
+export default function ChangelogReleaseCard({ release, isLatest = false }: ChangelogReleaseCardProps) {
+  return (
+    <article
+      className={`relative overflow-hidden rounded-sm border bg-[#1b2838] shadow-[0_12px_40px_rgba(0,0,0,0.28)] ${
+        isLatest ? "border-[#4a90c4]/70 ring-1 ring-[#4a90c4]/20" : "border-[#2a475e]"
+      }`}>
+      {isLatest ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 top-0 h-px bg-linear-to-r from-transparent via-[#66c0f4] to-transparent"
+        />
+      ) : null}
+
+      <div className="border-b border-[#2a475e]/80 bg-[#16202d]/80 px-5 py-4 sm:px-6">
+        <div className="flex flex-wrap items-center gap-2">
+          {isLatest ? (
+            <span className="inline-flex rounded-sm border border-[#4a90c4] bg-[#1a3a5c] px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-[#9fc6e3]">
+              Latest
+            </span>
+          ) : null}
+          <time dateTime={release.releasedAt} className="text-sm font-medium text-[#8f98a0]">
+            {formatChangelogDate(release.releasedAt)}
+          </time>
+          <span className="text-[#556772]">·</span>
+          <a
+            href={`https://github.com/eyyMinda/KeyAway/pull/${release.prNumber}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-semibold text-[#8fd4ff] transition-colors hover:text-white">
+            PR #{release.prNumber}
+          </a>
+        </div>
+
+        <h2 className="mt-3 text-lg font-bold leading-snug text-white sm:text-xl">{release.title}</h2>
+
+        <div className="mt-3 flex flex-wrap gap-2">
+          {release.tags.map(tag => (
+            <span
+              key={tag}
+              className={`inline-flex rounded-sm border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${TAG_STYLES[tag]}`}>
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-5 px-5 py-5 sm:px-6 sm:py-6">
+        <p className="text-sm leading-relaxed text-[#dce8f2] sm:text-base">{release.summary}</p>
+
+        <div className="rounded-sm border border-[#2a475e]/80 bg-[#0f1923]/50 p-4">
+          <p className="mb-2 text-xs font-bold uppercase tracking-wide text-[#7dd3ff]">Highlights</p>
+          <ul className="space-y-2">
+            {release.highlights.map(item => (
+              <li key={item} className="flex gap-2.5 text-sm leading-relaxed text-[#eef4f9]">
+                <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[#7dd3ff]" aria-hidden />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {release.sections?.map(section => (
+          <div key={section.title}>
+            <h3 className="mb-2 text-sm font-semibold uppercase tracking-wide text-[#9fadbd]">{section.title}</h3>
+            <ul className="space-y-1.5 border-l-2 border-[#2a475e] pl-4">
+              {section.items.map(item => (
+                <li key={item} className="text-sm leading-relaxed text-[#eef4f9]">
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/src/components/changelog/ChangelogReleaseList.tsx
+++ b/src/components/changelog/ChangelogReleaseList.tsx
@@ -1,0 +1,59 @@
+import ChangelogReleaseCard from "@/src/components/changelog/ChangelogReleaseCard";
+import type { ChangelogMonthGroup } from "@/src/lib/changelog/changelogPageUtils";
+
+type ChangelogReleaseListProps = {
+  groups: ChangelogMonthGroup[];
+  /** When set, content is already filtered to one month — hide month headings. */
+  monthFilter?: string;
+  /** Index of the newest release in the full visible list (for "Latest" badge). */
+  latestReleaseId?: string;
+};
+
+export default function ChangelogReleaseList({ groups, monthFilter, latestReleaseId }: ChangelogReleaseListProps) {
+  return (
+    <div className="relative">
+      <div
+        aria-hidden
+        className="absolute bottom-0 left-[11px] top-0 w-px bg-linear-to-b from-[#66c0f4]/80 via-[#2a475e] to-transparent sm:left-[15px]"
+      />
+
+      {groups.map(group => (
+        <section
+          key={group.monthKey}
+          data-feed-month={group.monthKey}
+          id={`month-${group.monthKey}`}
+          className="my-5 scroll-mt-24">
+          {!monthFilter ? (
+            <h3 className="mb-5 pl-10 text-base sm:text-lg font-semibold uppercase tracking-wide text-[#dce8f2] sm:pl-12">
+              {group.monthName}
+            </h3>
+          ) : null}
+
+          <ol className="space-y-10 sm:space-y-12">
+            {group.releases.map(release => {
+              const isLatest = !monthFilter && release.id === latestReleaseId;
+
+              return (
+                <li key={release.id} className="relative pl-10 sm:pl-12">
+                  <span
+                    aria-hidden
+                    className={`absolute left-0 top-6 flex h-6 w-6 items-center justify-center rounded-full border sm:top-7 sm:h-8 sm:w-8 ${
+                      isLatest
+                        ? "border-[#66c0f4] bg-[#1a3a5c] shadow-[0_0_16px_rgba(102,192,244,0.35)]"
+                        : "border-[#2a475e] bg-[#16202d]"
+                    }`}>
+                    <span
+                      className={`h-2 w-2 rounded-full sm:h-2.5 sm:w-2.5 ${isLatest ? "bg-[#66c0f4]" : "bg-[#556772]"}`}
+                    />
+                  </span>
+
+                  <ChangelogReleaseCard release={release} isLatest={isLatest} />
+                </li>
+              );
+            })}
+          </ol>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/general/AnimatedSanityImage.tsx
+++ b/src/components/general/AnimatedSanityImage.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ReactElement } from "react";
+
+type AnimatedSanityImageProps = {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+  aspectRatio: number;
+  className?: string;
+  priority: boolean;
+  fill: boolean;
+};
+
+export function AnimatedSanityImage({
+  src,
+  alt,
+  width,
+  height,
+  aspectRatio,
+  className,
+  priority,
+  fill
+}: AnimatedSanityImageProps): ReactElement {
+  const imgProps = {
+    src,
+    alt,
+    loading: priority ? ("eager" as const) : ("lazy" as const),
+    decoding: "async" as const,
+    ...(priority ? { fetchPriority: "high" as const } : {})
+  };
+
+  if (fill) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element -- motion assets bypass next/image
+      <img {...imgProps} className={className ?? "absolute inset-0 h-full w-full object-cover object-center"} />
+    );
+  }
+
+  return (
+    <span className="relative block w-full" style={{ aspectRatio }}>
+      {/* eslint-disable-next-line @next/next/no-img-element -- motion assets bypass next/image */}
+      <img
+        {...imgProps}
+        width={width}
+        height={height}
+        className={`block h-auto w-full ${className ?? ""}`.trim()}
+      />
+    </span>
+  );
+}

--- a/src/components/general/IdealImage.tsx
+++ b/src/components/general/IdealImage.tsx
@@ -1,23 +1,31 @@
 import { ReactElement } from "react";
 import Image from "next/image";
-import { getImageDimensions } from "@sanity/asset-utils";
+import { AnimatedSanityImage } from "@/src/components/general/AnimatedSanityImage";
+import {
+  resolveDisplayDimensions,
+  sanityImageLqip,
+  sanityImageNeedsMotionDelivery,
+  sanityMotionImageUrl,
+  sanityOptimizedImageUrl
+} from "@/src/lib/sanity/imageDelivery";
 import { urlFor } from "@/src/sanity/lib/image";
 import { SanityAsset } from "@sanity/image-url";
 
-interface IdealImageProps {
+export interface IdealImageProps {
   image?: SanityAsset;
   alt?: string;
   className?: string;
   sizes?: string;
+  /** Max rendered width in CSS px — CDN request is sized to this (use ~2× for retina if needed). */
   widthHint?: number;
   quality?: number;
-  /** When true: preload, eager load, and `fetchPriority="high"`. */
   priority?: boolean;
-  /**
-   * Cover a sized parent (`relative` + explicit size or aspect). Omit width/height on `Image`;
-   * use `className` for `object-cover` / positioning.
-   */
   fill?: boolean;
+  /**
+   * Set when the layout slot may contain animated WebP (about blocks, showcase).
+   * GIF is always auto-detected. Static JPG/PNG/WebP without Studio flag stay on next/image.
+   */
+  mayAnimate?: boolean;
 }
 
 export const IdealImage = ({
@@ -28,12 +36,33 @@ export const IdealImage = ({
   widthHint = 640,
   quality = 70,
   priority = false,
-  fill = false
+  fill = false,
+  mayAnimate = false
 }: IdealImageProps): ReactElement | null => {
   if (!image) return null;
+
   const hint = fill ? Math.max(widthHint, 1200) : widthHint;
-  const src = urlFor(image).width(hint).quality(quality).auto("format").url();
-  const blurDataURL = urlFor(image).width(24).height(24).blur(10).url();
+  const needsMotion = sanityImageNeedsMotionDelivery(image, { mayAnimate });
+  const display = resolveDisplayDimensions(image, hint);
+
+  if (needsMotion) {
+    return (
+      <AnimatedSanityImage
+        src={sanityMotionImageUrl(image, hint)}
+        alt={alt}
+        width={display.width}
+        height={display.height}
+        aspectRatio={display.aspectRatio}
+        className={className}
+        priority={priority}
+        fill={fill}
+      />
+    );
+  }
+
+  const lqip = sanityImageLqip(image);
+  const src = sanityOptimizedImageUrl(image, hint, quality);
+  const blurDataURL = lqip ?? urlFor(image).width(24).height(24).blur(10).url();
 
   const shared = {
     src,
@@ -50,12 +79,5 @@ export const IdealImage = ({
     return <Image {...shared} fill />;
   }
 
-  return (
-    <Image
-      {...shared}
-      width={getImageDimensions(image).width}
-      height={getImageDimensions(image).height}
-      {...(src.includes(".gif") ? { unoptimized: true } : {})}
-    />
-  );
+  return <Image {...shared} width={display.width} height={display.height} />;
 };

--- a/src/components/general/IdealImageClient.tsx
+++ b/src/components/general/IdealImageClient.tsx
@@ -32,6 +32,7 @@ export const IdealImageClient = ({
       sizes={sizes}
       quality={quality}
       priority={priority}
+      style={{ width: "auto", height: "auto" }}
       {...(priority ? { fetchPriority: "high" as const } : {})}
       {...(className ? { className } : {})}
     />

--- a/src/components/home/FeaturedProgramSection.tsx
+++ b/src/components/home/FeaturedProgramSection.tsx
@@ -31,7 +31,8 @@ export default function FeaturedProgramSection({ program }: FeaturedProgramSecti
   const fd = program.featured?.description;
   const useFeatured = portableTextHasContent(fd ?? null);
   const introBody = useFeatured ? fd : program.description;
-  const imageSource = program.featured?.showcaseGif || program.image;
+  const showcase = program.featured?.showcaseGif;
+  const imageSource = showcase || program.image;
 
   return (
     <section id="featured-program" className="border-y border-[#2a475e] py-8 sm:py-12 lg:py-16">
@@ -54,9 +55,10 @@ export default function FeaturedProgramSection({ program }: FeaturedProgramSecti
                 <IdealImage
                   image={imageSource}
                   alt={program.title}
-                  widthHint={960}
+                  widthHint={720}
                   sizes="(max-width: 1024px) 100vw, 50vw"
                   className="rounded-sm object-contain"
+                  mayAnimate={Boolean(showcase)}
                 />
               ) : (
                 <div className="flex h-80 w-full items-center justify-center rounded-sm border border-[#2a475e] bg-[#213246] sm:h-96 lg:h-[500px]">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -23,7 +23,8 @@ const TRUST_FOOTER_LINKS = [
   { href: "/affiliate-disclosure", label: "Affiliate disclosure" },
   { href: "/verification-policy", label: "Verification policy" },
   { href: "/partners", label: "Partners" },
-  { href: "/updates", label: "Updates" }
+  { href: "/updates", label: "Updates" },
+  { href: "/changelog", label: "Changelog" }
 ] as const;
 
 export default function Footer({ logoData, socialData, siteBaseUrl }: FooterProps) {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -95,8 +95,6 @@ export default function Header({ logoData, notifications: notificationsProp, soc
           {isLogo ? (
             <IdealImageClient
               {...logoData}
-              width={120}
-              height={48}
               priority
               className="max-w-3xs max-h-10 xs:max-h-12 w-auto h-auto"
             />

--- a/src/components/program/AboutSectionBlock.tsx
+++ b/src/components/program/AboutSectionBlock.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { IdealImage } from "@/src/components/general/IdealImage";
+import { ABOUT_SECTION_IMAGE_MAX_PX } from "@/src/lib/sanity/imageDelivery";
 import RichText from "@/src/components/portableText/RichText";
 import { urlFor } from "@/src/sanity/lib/image";
 import type { ProgramAboutSectionBlock } from "@/src/types";
@@ -20,12 +21,12 @@ export default function AboutSectionBlock({ section }: { section: ProgramAboutSe
       {sectionTitle ? (
         <h3 className="mb-3 text-lg font-bold text-white sm:text-xl lg:text-2xl">{sectionTitle}</h3>
       ) : null}
-      <div className="text-sm leading-snug text-neutral-100 [&_a]:text-[#66d9ff] [&_p]:my-2 [&_p]:leading-relaxed sm:text-base">
+      <div className="text-sm leading-snug text-neutral-100 [&_a]:text-[#66d9ff] [&_p]:my-3 sm:[&_p]:my-5 [&_p]:leading-relaxed sm:text-base">
         <RichText value={description} className="[&_ul]:list-disc [&_ul]:pl-5 [&_ol]:list-decimal" />
       </div>
       {points && points.length > 0 ? (
         <ul
-          className={`mt-4 space-y-2.5 text-sm text-neutral-100 sm:text-base ${
+          className={`mt-4 sm:mt-6 space-y-2.5 text-sm text-neutral-100 sm:text-base ${
             hasImage ? "text-left" : "inline-block text-left mx-auto max-w-lg"
           }`}>
           {points.map((p, i) => (
@@ -61,9 +62,16 @@ export default function AboutSectionBlock({ section }: { section: ProgramAboutSe
   }
 
   const imageEl = (
-    <div className="w-full max-w-md lg:w-2/5 shrink-0 mx-auto lg:mx-0">
+    <div className="w-full max-w-160 lg:w-4/9 shrink-0 mx-auto lg:mx-0">
       <div className="overflow-hidden rounded-sm border border-[#2a475e] bg-[#1b2838]">
-        <IdealImage image={image} alt={sectionTitle || "About"} className="w-full h-auto object-cover" />
+        <IdealImage
+          image={image}
+          alt={sectionTitle || "About"}
+          className="w-full h-auto object-cover"
+          widthHint={ABOUT_SECTION_IMAGE_MAX_PX}
+          sizes={`(max-width: 640px) 90vw, ${ABOUT_SECTION_IMAGE_MAX_PX}px`}
+          mayAnimate
+        />
       </div>
     </div>
   );
@@ -74,7 +82,7 @@ export default function AboutSectionBlock({ section }: { section: ProgramAboutSe
         invertMobile ? "flex-col-reverse" : ""
       } ${invertDesktop ? "lg:flex-row-reverse" : ""}`}>
       {imageEl}
-      <div className="w-full min-w-0 lg:w-3/5">{content}</div>
+      <div className="w-full min-w-0 lg:w-5/9">{content}</div>
     </div>
   );
 }

--- a/src/components/program/PlatformGlyphs.tsx
+++ b/src/components/program/PlatformGlyphs.tsx
@@ -1,0 +1,23 @@
+/** Four-pane mark (Windows-style tile). */
+export function WindowsGlyph({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" className={className} aria-hidden>
+      <path
+        fill="currentColor"
+        d="M0 2.3L6.8 1.3v6.4H0V2.3zm7.6-.9L16 0v8H7.6V1.4zM0 9.3h6.8V16L0 14.9V9.3zm7.6.1H16V16l-8.4-1.2V9.4z"
+      />
+    </svg>
+  );
+}
+
+/** Apple mark for macOS. */
+export function MacGlyph({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 16 16" className={className} aria-hidden>
+      <path
+        fill="currentColor"
+        d="M12.07 8.44c-.03-1.86 1.52-2.75 1.59-2.8-0.87-1.27-2.22-1.44-2.7-1.46-1.15-.12-2.25.68-2.83.68-.59 0-1.5-.66-2.47-.64-1.27.02-2.44.74-3.09 1.88-1.32 2.29-.34 5.68.95 7.54.63.91 1.38 1.93 2.37 1.89.95-.04 1.31-.61 2.46-.61 1.15 0 1.47.61 2.48.59 1.03-.02 1.68-.93 2.3-1.84.72-1.05 1.02-2.07 1.04-2.12-.02-.01-2-.77-2.02-3.05zm-1.9-5.5c.53-.64.89-1.53.79-2.42-.76.03-1.68.51-2.22 1.15-.49.57-.92 1.48-.8 2.35.85.07 1.71-.43 2.23-1.08z"
+      />
+    </svg>
+  );
+}

--- a/src/components/program/ProgramAboutSection.tsx
+++ b/src/components/program/ProgramAboutSection.tsx
@@ -13,7 +13,7 @@ export default function ProgramAboutSection({ program }: { program: Program }) {
         <h2 className="section-title mb-10 sm:mb-12">
           <span className="text-gradient-pro">About</span> {formatProgramDisplayTitle(program)}
         </h2>
-        <div className="max-w-2xl lg:max-w-5xl mx-auto space-y-14 sm:space-y-16 lg:space-y-20">
+        <div className="max-w-2xl lg:max-w-6xl mx-auto space-y-14 sm:space-y-16">
           {blocks.map((section, index) => (
             <AboutSectionBlock key={`about-${index}`} section={section} />
           ))}

--- a/src/components/program/RelatedPrograms.tsx
+++ b/src/components/program/RelatedPrograms.tsx
@@ -4,6 +4,7 @@ import { useState, useLayoutEffect, useMemo } from "react";
 import Link from "next/link";
 import { FaChevronLeft, FaChevronRight, FaDesktop } from "react-icons/fa";
 import { IdealImage } from "@/src/components/general/IdealImage";
+import { MacGlyph, WindowsGlyph } from "@/src/components/program/PlatformGlyphs";
 import { Program, ProgramPlatform } from "@/src/types";
 
 interface RelatedProgramsProps {
@@ -39,30 +40,6 @@ function computePageStarts(programCount: number, k: number): number[] {
     starts.push(lastStart);
   }
   return starts;
-}
-
-/** Four-pane mark (Windows-style tile) for store-row footer. */
-function WindowsGlyph({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 16 16" className={className} aria-hidden>
-      <path
-        fill="currentColor"
-        d="M0 2.3L6.8 1.3v6.4H0V2.3zm7.6-.9L16 0v8H7.6V1.4zM0 9.3h6.8V16L0 14.9V9.3zm7.6.1H16V16l-8.4-1.2V9.4z"
-      />
-    </svg>
-  );
-}
-
-/** Apple mark for macOS platform row. */
-function MacGlyph({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 16 16" className={className} aria-hidden>
-      <path
-        fill="currentColor"
-        d="M12.07 8.44c-.03-1.86 1.52-2.75 1.59-2.8-0.87-1.27-2.22-1.44-2.7-1.46-1.15-.12-2.25.68-2.83.68-.59 0-1.5-.66-2.47-.64-1.27.02-2.44.74-3.09 1.88-1.32 2.29-.34 5.68.95 7.54.63.91 1.38 1.93 2.37 1.89.95-.04 1.31-.61 2.46-.61 1.15 0 1.47.61 2.48.59 1.03-.02 1.68-.93 2.3-1.84.72-1.05 1.02-2.07 1.04-2.12-.02-.01-2-.77-2.02-3.05zm-1.9-5.5c.53-.64.89-1.53.79-2.42-.76.03-1.68.51-2.22 1.15-.49.57-.92 1.48-.8 2.35.85.07 1.71-.43 2.23-1.08z"
-      />
-    </svg>
-  );
 }
 
 const glyphClass = "h-3.5 w-3.5 shrink-0 text-[#7a8799] sm:h-4 sm:w-4";

--- a/src/components/programs/ProgramsFilter.tsx
+++ b/src/components/programs/ProgramsFilter.tsx
@@ -1,5 +1,14 @@
+import { MacGlyph, WindowsGlyph } from "@/src/components/program/PlatformGlyphs";
 import SearchInput from "@/src/components/ui/SearchInput";
 import type { PlatformFilterType, ProgramsFilterProps } from "@/src/types/programs";
+
+const platformGlyphClass = "h-3.5 w-3.5 shrink-0 sm:h-4 sm:w-4";
+
+function PlatformGlyph({ platform }: { platform: PlatformFilterType }) {
+  if (platform === "windows") return <WindowsGlyph className={platformGlyphClass} />;
+  if (platform === "mac") return <MacGlyph className={platformGlyphClass} />;
+  return null;
+}
 
 const SELECT_CLASS =
   "w-full min-w-[8.5rem] rounded-sm border border-[#3d6e8c] bg-[#32465a] px-2.5 py-2 text-xs text-[#c6d4df] focus:border-[#66c0f4] focus:outline-none focus:ring-2 focus:ring-[#1a9fff]/30 sm:min-w-[9.5rem] sm:px-3 sm:text-sm cursor-pointer";
@@ -37,11 +46,12 @@ function PlatformPills({
             type="button"
             disabled={disabled}
             onClick={() => onChange(opt.value)}
-            className={`rounded-sm border px-2.5 py-1.5 text-xs font-semibold transition-colors cursor-pointer disabled:opacity-50 sm:px-3 ${
+            className={`inline-flex items-center gap-1.5 rounded-sm border px-2.5 py-1.5 text-sm sm:py-2 font-semibold transition-colors cursor-pointer disabled:opacity-50 sm:px-3 ${
               active
                 ? "border-[#4a90c4] bg-[#1a3a5c] text-[#66c0f4]"
                 : "border-[#2a475e] bg-[#1b2838] text-[#c6d4df] hover:border-[#4a90c4]"
             }`}>
+            <PlatformGlyph platform={opt.value} />
             {opt.label}
           </button>
         );

--- a/src/components/site/FeedMonthSidebar.tsx
+++ b/src/components/site/FeedMonthSidebar.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { buildFeedMonthHref, type FeedKind } from "@/src/lib/site/feedHrefUtils";
+import type { SidebarYear } from "@/src/lib/site/monthSidebarUtils";
+
+const linkClass = (active: boolean) =>
+  `flex items-center justify-between rounded-sm px-3 py-2 text-sm transition-colors ${
+    active
+      ? "bg-[#213246] font-semibold text-white"
+      : "text-[#c6d4df] hover:bg-[#213246]/70 hover:text-white"
+  }`;
+
+export type FeedMonthSidebarProps = {
+  years: SidebarYear[];
+  /** Month selected via `?month=` URL filter. */
+  activeMonth?: string;
+  /** Month currently in view while scrolling (scroll-spy). */
+  visibleMonth?: string | null;
+  totalCount: number;
+  allLabel: string;
+  ariaLabel: string;
+  feed: FeedKind;
+};
+
+export default function FeedMonthSidebar({
+  years,
+  activeMonth,
+  visibleMonth,
+  totalCount,
+  allLabel,
+  ariaLabel,
+  feed
+}: FeedMonthSidebarProps) {
+  const highlightedMonth = activeMonth ?? visibleMonth ?? undefined;
+
+  useEffect(() => {
+    if (!visibleMonth || activeMonth) return;
+    document
+      .querySelector(`[data-sidebar-month="${visibleMonth}"]`)
+      ?.scrollIntoView({ block: "nearest" });
+  }, [visibleMonth, activeMonth]);
+
+  return (
+    <nav aria-label={ariaLabel} className="lg:sticky lg:top-24 lg:self-start">
+      <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-[#8f98a0]">Filter by month</p>
+
+      <ul className="space-y-1 rounded-sm border border-[#2a475e] bg-[#1b2838] p-2">
+        <li>
+          <Link
+            href={buildFeedMonthHref(feed)}
+            scroll={false}
+            className={linkClass(!activeMonth && !highlightedMonth)}
+            aria-current={!activeMonth && !highlightedMonth ? "true" : undefined}>
+            <span>{allLabel}</span>
+            <span className="text-xs tabular-nums text-[#8f98a0]">{totalCount}</span>
+          </Link>
+        </li>
+      </ul>
+
+      <div className="mt-4 max-h-[min(70vh,560px)] space-y-5 overflow-y-auto rounded-sm border border-[#2a475e] bg-[#1b2838] p-3">
+        {years.map(({ year, months }) => (
+          <div key={year}>
+            <p className="mb-2 px-1 text-xs font-bold uppercase tracking-wide text-[#66c0f4]">{year}</p>
+            <ul className="space-y-0.5">
+              {months.map(month => {
+                const isHighlighted = highlightedMonth === month.key;
+                return (
+                  <li key={month.key}>
+                    <Link
+                      href={buildFeedMonthHref(feed, month.key)}
+                      scroll={false}
+                      data-sidebar-month={month.key}
+                      className={linkClass(isHighlighted)}
+                      aria-current={isHighlighted ? "true" : undefined}>
+                      <span>{month.monthName}</span>
+                      <span className="text-xs tabular-nums text-[#8f98a0]">{month.count}</span>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/site/FeedShowMoreButton.tsx
+++ b/src/components/site/FeedShowMoreButton.tsx
@@ -1,0 +1,19 @@
+import Link from "next/link";
+
+type FeedShowMoreButtonProps = {
+  href: string;
+  label?: string;
+};
+
+export default function FeedShowMoreButton({ href, label = "Load more" }: FeedShowMoreButtonProps) {
+  return (
+    <div className="mt-8 flex justify-center">
+      <Link
+        href={href}
+        scroll={false}
+        className="inline-flex min-h-11 items-center justify-center rounded-sm border border-[#4a90c4] bg-[#1a3a5c] px-6 py-2.5 text-sm font-semibold text-[#c6d4df] transition-colors hover:border-[#66c0f4] hover:bg-[#213246] hover:text-white">
+        {label}
+      </Link>
+    </div>
+  );
+}

--- a/src/components/site/FeedWithMonthSidebar.tsx
+++ b/src/components/site/FeedWithMonthSidebar.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useRef, type ReactNode } from "react";
+import FeedMonthSidebar, { type FeedMonthSidebarProps } from "@/src/components/site/FeedMonthSidebar";
+import { useFeedMonthScrollSpy } from "@/src/hooks/useFeedMonthScrollSpy";
+import { useScrollToFeedOnMonthChange } from "@/src/hooks/useScrollToFeedOnMonthChange";
+import { FEED_SECTION_ID } from "@/src/lib/site/feedHrefUtils";
+
+type FeedWithMonthSidebarProps = {
+  sidebar: FeedMonthSidebarProps;
+  /** When false (month URL filter), sidebar uses the filter only. */
+  scrollSpyEnabled: boolean;
+  children: ReactNode;
+};
+
+export default function FeedWithMonthSidebar({
+  sidebar,
+  scrollSpyEnabled,
+  children
+}: FeedWithMonthSidebarProps) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const visibleMonth = useFeedMonthScrollSpy(scrollSpyEnabled, contentRef);
+  useScrollToFeedOnMonthChange();
+
+  return (
+    <section id={FEED_SECTION_ID} className="scroll-mt-24">
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,15rem)_minmax(0,1fr)] lg:gap-10 xl:grid-cols-[minmax(0,16rem)_minmax(0,1fr)]">
+        <FeedMonthSidebar {...sidebar} visibleMonth={scrollSpyEnabled ? visibleMonth : undefined} />
+        <div ref={contentRef} className="min-w-0">
+          {children}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/updates/UpdateFeedItem.tsx
+++ b/src/components/updates/UpdateFeedItem.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
+import { formatUpdateDay } from "@/src/lib/updates/updatesPageUtils";
 import type { Notification } from "@/src/types/notifications";
 
 type UpdateFeedItemProps = {
@@ -9,15 +10,14 @@ type UpdateFeedItemProps = {
 export default function UpdateFeedItem({ notification }: UpdateFeedItemProps) {
   const isNewProgram = notification.type === "new_program" || notification.type === "new_program_with_keys";
   const message = notification.message?.trim() ?? "";
-  const createdAt = new Date(notification.createdAt);
 
   return (
     <li>
       <Link
         href={`/program/${notification.programSlug}`}
-        className="group flex items-start gap-3 rounded-sm border border-[#2a475e] bg-[#1b2838] px-4 py-3 transition-colors hover:border-[#4a90c4] hover:bg-[#213246] sm:px-5 sm:py-4">
+        className="group flex items-center gap-4 py-3.5 sm:py-4 transition-colors hover:bg-[#1b2838]/60">
         {notification.imageUrl ? (
-          <div className="h-11 w-11 shrink-0 overflow-hidden rounded-sm border border-[#2a475e]">
+          <div className="h-10 w-10 shrink-0 overflow-hidden rounded-sm border border-[#2a475e] sm:h-11 sm:w-11">
             <Image
               src={notification.imageUrl}
               alt=""
@@ -30,20 +30,20 @@ export default function UpdateFeedItem({ notification }: UpdateFeedItemProps) {
           </div>
         ) : (
           <div
-            className={`flex h-11 w-11 shrink-0 items-center justify-center rounded-sm border ${
+            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-sm border sm:h-11 sm:w-11 ${
               isNewProgram ? "border-[#4a90c4] bg-[#1a3a5c]" : "border-[#3d6e1c] bg-[#1a3a2a]"
             }`}>
-            <span className="text-lg" aria-hidden>
+            <span className="text-base sm:text-lg" aria-hidden>
               {isNewProgram ? "✨" : "🔑"}
             </span>
           </div>
         )}
 
         <div className="min-w-0 flex-1">
-          <p className="font-semibold text-[#c6d4df] transition-colors group-hover:text-white">
-            {notification.programTitle}
-          </p>
-          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-[#8f98a0]">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <p className="font-semibold text-[#c6d4df] transition-colors group-hover:text-white">
+              {notification.programTitle}
+            </p>
             {isNewProgram ? (
               <span className="inline-flex rounded-sm border border-[#4a90c4] bg-[#1a3a5c] px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-[#9fc6e3]">
                 New listing
@@ -53,12 +53,15 @@ export default function UpdateFeedItem({ notification }: UpdateFeedItemProps) {
                 Keys added
               </span>
             )}
-            {message ? <span>{message}</span> : null}
-            <time dateTime={notification.createdAt}>
-              {createdAt.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
-            </time>
           </div>
+          {message ? <p className="mt-0.5 text-sm text-[#8f98a0]">{message}</p> : null}
         </div>
+
+        <time
+          dateTime={notification.createdAt}
+          className="hidden shrink-0 text-xs tabular-nums text-[#8f98a0] sm:block sm:text-sm">
+          {formatUpdateDay(notification.createdAt)}
+        </time>
       </Link>
     </li>
   );

--- a/src/components/updates/UpdatesTimeline.tsx
+++ b/src/components/updates/UpdatesTimeline.tsx
@@ -1,0 +1,36 @@
+import type { TimelineYear } from "@/src/lib/updates/updatesPageUtils";
+import UpdateFeedItem from "@/src/components/updates/UpdateFeedItem";
+
+type UpdatesTimelineProps = {
+  groups: TimelineYear[];
+  showYearHeadings?: boolean;
+};
+
+export default function UpdatesTimeline({ groups, showYearHeadings = true }: UpdatesTimelineProps) {
+  return (
+    <div className="divide-y divide-[#2a475e] rounded-sm border border-[#2a475e] bg-[#1b2838]">
+      {groups.map(yearGroup => (
+        <section key={yearGroup.year} className="px-4 sm:px-5">
+          {showYearHeadings ? (
+            <h2 className="sticky top-18 z-10 -mx-4 border-b border-[#2a475e] bg-[#1b2838]/95 px-4 py-3 text-lg font-bold text-white backdrop-blur-sm sm:-mx-5 sm:px-5">
+              {yearGroup.year}
+            </h2>
+          ) : null}
+
+          {yearGroup.months.map(month => (
+            <div key={month.monthKey} data-feed-month={month.monthKey} id={`month-${month.monthKey}`} className="scroll-mt-24">
+              <h3 className="pt-4 pb-2 text-sm font-semibold uppercase tracking-wide text-[#8f98a0]">
+                {showYearHeadings ? month.monthName : `${month.monthName} ${yearGroup.year}`}
+              </h3>
+              <ul className="divide-y divide-[#2a475e]/70">
+                {month.items.map(item => (
+                  <UpdateFeedItem key={item.id} notification={item} />
+                ))}
+              </ul>
+            </div>
+          ))}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useFeedMonthScrollSpy.ts
+++ b/src/hooks/useFeedMonthScrollSpy.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useState, type RefObject } from "react";
+import {
+  FEED_SCROLL_SPY_OFFSET_PX,
+  queryFeedMonthMarkers,
+  resolveActiveFeedMonth
+} from "@/src/lib/site/feedMonthScrollSpy";
+
+export function useFeedMonthScrollSpy(
+  enabled: boolean,
+  contentRef: RefObject<HTMLElement | null>
+): string | null {
+  const [visibleMonth, setVisibleMonth] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setVisibleMonth(null);
+      return;
+    }
+
+    let frame = 0;
+
+    const measure = () => {
+      frame = 0;
+      const root = contentRef.current ?? document;
+      const markers = queryFeedMonthMarkers(root);
+      const next = resolveActiveFeedMonth(markers, FEED_SCROLL_SPY_OFFSET_PX);
+      setVisibleMonth(prev => (prev === next ? prev : next));
+    };
+
+    const schedule = () => {
+      if (frame) return;
+      frame = window.requestAnimationFrame(measure);
+    };
+
+    measure();
+    window.addEventListener("scroll", schedule, { passive: true });
+    window.addEventListener("resize", schedule, { passive: true });
+
+    const root = contentRef.current;
+    const mutationObserver = root ? new MutationObserver(schedule) : null;
+    mutationObserver?.observe(root!, { childList: true, subtree: true });
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      window.removeEventListener("scroll", schedule);
+      window.removeEventListener("resize", schedule);
+      mutationObserver?.disconnect();
+    };
+  }, [enabled, contentRef]);
+
+  return enabled ? visibleMonth : null;
+}

--- a/src/hooks/useScrollToFeedOnMonthChange.ts
+++ b/src/hooks/useScrollToFeedOnMonthChange.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { scrollToFeedSection } from "@/src/lib/site/feedHrefUtils";
+
+/** Scroll to the feed grid when the month filter changes — not on limit-only pagination. */
+export function useScrollToFeedOnMonthChange() {
+  const searchParams = useSearchParams();
+  const month = searchParams.get("month");
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      if (month) scrollToFeedSection();
+      return;
+    }
+
+    scrollToFeedSection();
+  }, [month]);
+}

--- a/src/lib/cache/cacheTags.ts
+++ b/src/lib/cache/cacheTags.ts
@@ -27,6 +27,9 @@ export const TAG_FEATURED_PROGRAM = "featured-program";
 
 export const TAG_BUNDLE_COUNTS = "bundle-counts";
 
+/** Published changelogRelease documents for /changelog. */
+export const TAG_CHANGELOG = "changelog";
+
 export function programDetailTag(slug: string): string {
   return `program-${slug}`;
 }

--- a/src/lib/changelog/changelogContentFilter.ts
+++ b/src/lib/changelog/changelogContentFilter.ts
@@ -1,0 +1,54 @@
+/** Sections omitted from public changelog (internal / sensitive). */
+const SKIP_SECTION_TITLES = new Set([
+  "environment variables",
+  "env variables",
+  "environment",
+  "testing",
+  "technical details",
+  "test plan"
+]);
+
+const SENSITIVE_LINE_PATTERNS = [
+  /^\s*[A-Z][A-Z0-9_]{2,}\s*=\s*\S+/,
+  /process\.env\./i,
+  /\.env(\.[a-z]+)?\b/i,
+  /\b(api[_-]?key|client[_-]?secret|secret[_-]?key|access[_-]?token|auth[_-]?token|private[_-]?key)\b/i,
+  /\b(password|passwd|credential)s?\b/i,
+  /\bgh\s+secret\b/i,
+  /\bgithub[_-]?token\b/i,
+  /\bsanity[_-]?api[_-]?token\b/i,
+  /\bnextauth[_-]?secret\b/i,
+  /\bresend[_-]?api[_-]?key\b/i
+];
+
+const INLINE_SECRET_VALUE_RE = /\b([A-Z][A-Z0-9_]{2,})=([^\s`]+)/g;
+
+export function shouldSkipChangelogSection(title: string): boolean {
+  return SKIP_SECTION_TITLES.has(title.trim().toLowerCase());
+}
+
+export function isSensitiveChangelogLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  return SENSITIVE_LINE_PATTERNS.some(pattern => pattern.test(trimmed));
+}
+
+/** Strip or redact env-like assignments and drop sensitive lines. */
+export function sanitizeChangelogText(text: string): string {
+  const withoutCodeBlocks = text.replace(/```[\s\S]*?```/g, "");
+  const lines = withoutCodeBlocks.split(/\r?\n/);
+
+  return lines
+    .map(line => {
+      if (isSensitiveChangelogLine(line)) return "";
+      return line.replace(INLINE_SECRET_VALUE_RE, "$1=[redacted]");
+    })
+    .filter(line => line.trim().length > 0)
+    .join("\n")
+    .trim();
+}
+
+export function sanitizeChangelogBullet(text: string): string {
+  const cleaned = sanitizeChangelogText(text.replace(/^[-*]\s+/, "").trim());
+  return cleaned.replace(/`([^`]+)`/g, "$1");
+}

--- a/src/lib/changelog/changelogEntries.ts
+++ b/src/lib/changelog/changelogEntries.ts
@@ -1,0 +1,26 @@
+export type ChangelogTag = "feat" | "fix" | "ui" | "perf" | "api" | "docs" | "refactor" | "enhance";
+
+export type ChangelogSection = {
+  title: string;
+  items: string[];
+};
+
+/** Release notes content — add new entries when major versions ship. */
+export type ChangelogRelease = {
+  id: string;
+  releasedAt: string;
+  title: string;
+  prNumber: number;
+  tags: ChangelogTag[];
+  summary: string;
+  highlights: string[];
+  sections?: ChangelogSection[];
+};
+
+export function formatChangelogDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric"
+  });
+}

--- a/src/lib/changelog/changelogPageUtils.ts
+++ b/src/lib/changelog/changelogPageUtils.ts
@@ -1,0 +1,52 @@
+import type { ChangelogRelease } from "@/src/lib/changelog/changelogEntries";
+import { buildMonthSidebarIndex, formatMonthName, getMonthKey, parseMonthQueryParam } from "@/src/lib/site/monthSidebarUtils";
+
+export type ChangelogMonthGroup = {
+  monthKey: string;
+  monthName: string;
+  releases: ChangelogRelease[];
+};
+
+export function groupChangelogByMonth(releases: ChangelogRelease[]): ChangelogMonthGroup[] {
+  const groups: ChangelogMonthGroup[] = [];
+  let current: ChangelogMonthGroup | null = null;
+
+  for (const release of releases) {
+    const monthKey = getMonthKey(release.releasedAt);
+    if (!current || current.monthKey !== monthKey) {
+      current = { monthKey, monthName: formatMonthName(monthKey), releases: [] };
+      groups.push(current);
+    }
+    current.releases.push(release);
+  }
+
+  return groups;
+}
+
+export function buildChangelogSidebarIndex(releases: ChangelogRelease[]) {
+  return buildMonthSidebarIndex(releases, r => r.releasedAt);
+}
+
+export function filterChangelogByMonth(
+  releases: ChangelogRelease[],
+  monthKey: string | undefined
+): ChangelogRelease[] {
+  if (!monthKey) return releases;
+  return releases.filter(r => getMonthKey(r.releasedAt) === monthKey);
+}
+
+export function resolveChangelogPageParams(raw: { month?: string; limit?: string }) {
+  const month = parseMonthQueryParam(raw.month);
+  return { month };
+}
+
+export function buildChangelogHref(month: string | undefined, limit?: number): string {
+  const params = new URLSearchParams();
+  if (month) {
+    params.set("month", month);
+  } else if (limit !== undefined && limit > 0) {
+    params.set("limit", String(limit));
+  }
+  const q = params.toString();
+  return q ? `/changelog?${q}` : "/changelog";
+}

--- a/src/lib/changelog/changelogTags.ts
+++ b/src/lib/changelog/changelogTags.ts
@@ -1,0 +1,87 @@
+import type { ChangelogTag } from "@/src/lib/changelog/changelogEntries";
+
+export const CHANGELOG_TAGS: readonly ChangelogTag[] = [
+  "feat",
+  "fix",
+  "ui",
+  "perf",
+  "api",
+  "docs",
+  "refactor",
+  "enhance"
+] as const;
+
+const CHANGELOG_TAG_SET = new Set<string>(CHANGELOG_TAGS);
+
+/** Accept common synonyms in PR comments (normalized to canonical tag). */
+const CHANGELOG_TAG_ALIASES: Record<string, ChangelogTag> = {
+  doc: "docs",
+  documentation: "docs",
+  refactoring: "refactor",
+  enhancement: "enhance",
+  improvements: "enhance",
+  improve: "enhance"
+};
+
+/** HTML comment in PR body: `<!-- tags: feat, ui, api -->` */
+export const CHANGELOG_TAGS_COMMENT_RE = /<!--\s*tags:\s*([^>]+?)\s*-->/i;
+
+function normalizeTagToken(raw: string): ChangelogTag | null {
+  const token = raw.trim().toLowerCase();
+  if (isChangelogTag(token)) return token;
+  const alias = CHANGELOG_TAG_ALIASES[token];
+  return alias ?? null;
+}
+
+export function isChangelogTag(value: string): value is ChangelogTag {
+  return CHANGELOG_TAG_SET.has(value.trim().toLowerCase());
+}
+
+export function parseChangelogTagsFromComment(body: string): ChangelogTag[] {
+  const match = CHANGELOG_TAGS_COMMENT_RE.exec(body);
+  if (!match?.[1]) return [];
+
+  return [
+    ...new Set(
+      match[1]
+        .split(/[,|\s]+/)
+        .map(token => normalizeTagToken(token))
+        .filter((tag): tag is ChangelogTag => tag !== null)
+    )
+  ];
+}
+
+export function parseChangelogTagsFromLabels(labels: string[]): ChangelogTag[] {
+  return [
+    ...new Set(
+      labels.map(label => normalizeTagToken(label)).filter((tag): tag is ChangelogTag => tag !== null)
+    )
+  ];
+}
+
+export function inferChangelogTagsFromTitle(title: string): ChangelogTag[] {
+  const tags = new Set<ChangelogTag>();
+  const lower = title.toLowerCase();
+
+  if (lower.startsWith("feat")) tags.add("feat");
+  if (lower.startsWith("fix")) tags.add("fix");
+  if (lower.startsWith("docs")) tags.add("docs");
+  if (lower.startsWith("refactor")) tags.add("refactor");
+  if (/\bui\b|style|design/.test(lower)) tags.add("ui");
+  if (/\bperf\b|performance/.test(lower)) tags.add("perf");
+  if (/\bapi\b|route|endpoint/.test(lower)) tags.add("api");
+  if (/\benhance|\bimprove/.test(lower)) tags.add("enhance");
+
+  return [...tags];
+}
+
+export function resolveChangelogTags(body: string, title: string, labels: string[] = []): ChangelogTag[] {
+  const merged = new Set<ChangelogTag>([
+    ...parseChangelogTagsFromComment(body),
+    ...parseChangelogTagsFromLabels(labels),
+    ...inferChangelogTagsFromTitle(title)
+  ]);
+
+  if (merged.size === 0) merged.add("feat");
+  return [...merged];
+}

--- a/src/lib/changelog/fetchChangelogFromGitHub.ts
+++ b/src/lib/changelog/fetchChangelogFromGitHub.ts
@@ -1,0 +1,73 @@
+import type { ChangelogRelease } from "@/src/lib/changelog/changelogEntries";
+import { pullRequestToChangelogRelease } from "@/src/lib/changelog/parsePullRequestBody";
+
+const GITHUB_OWNER = "eyyMinda";
+const GITHUB_REPO = "KeyAway";
+const DEFAULT_LIMIT = 50;
+const SKIP_LABEL = "skip-changelog";
+
+type GitHubPullApiItem = {
+  number: number;
+  title: string;
+  body: string | null;
+  merged_at: string | null;
+  labels: Array<{ name: string }>;
+};
+
+async function fetchMergedPullRequests(limit: number): Promise<GitHubPullApiItem[]> {
+  const merged: GitHubPullApiItem[] = [];
+  const maxPages = Math.max(1, Math.ceil(limit / 100));
+
+  for (let page = 1; page <= maxPages && merged.length < limit; page++) {
+    const url = new URL(`https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/pulls`);
+    url.searchParams.set("state", "closed");
+    url.searchParams.set("sort", "updated");
+    url.searchParams.set("direction", "desc");
+    url.searchParams.set("per_page", "100");
+    url.searchParams.set("page", String(page));
+
+    const response = await fetch(url, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "KeyAway-Changelog"
+      },
+      next: { revalidate: 43200 }
+    });
+
+    if (!response.ok) {
+      console.error("[changelog] GitHub API error:", response.status, response.statusText);
+      break;
+    }
+
+    const pulls = (await response.json()) as GitHubPullApiItem[];
+    if (!pulls.length) break;
+
+    for (const pull of pulls) {
+      if (!pull.merged_at) continue;
+      if (pull.labels.some(label => label.name.toLowerCase() === SKIP_LABEL)) continue;
+      merged.push(pull);
+    }
+
+    if (pulls.length < 100) break;
+  }
+
+  return merged
+    .sort((a, b) => new Date(b.merged_at!).getTime() - new Date(a.merged_at!).getTime())
+    .slice(0, limit);
+}
+
+export async function fetchChangelogReleasesFromGitHub(limit = DEFAULT_LIMIT): Promise<ChangelogRelease[]> {
+  const pulls = await fetchMergedPullRequests(limit);
+
+  return pulls
+    .map(pull =>
+      pullRequestToChangelogRelease({
+        number: pull.number,
+        title: pull.title,
+        body: pull.body,
+        merged_at: pull.merged_at,
+        labels: pull.labels.map(label => label.name)
+      })
+    )
+    .filter((release): release is ChangelogRelease => release !== null);
+}

--- a/src/lib/changelog/getChangelogReleases.server.ts
+++ b/src/lib/changelog/getChangelogReleases.server.ts
@@ -1,0 +1,56 @@
+import { unstable_cache } from "next/cache";
+import type { ChangelogRelease } from "@/src/lib/changelog/changelogEntries";
+import { fetchChangelogReleasesFromGitHub } from "@/src/lib/changelog/fetchChangelogFromGitHub";
+import { TAG_CHANGELOG } from "@/src/lib/cache/cacheTags";
+import { publishedChangelogReleasesQuery } from "@/src/lib/sanity/queries/changelog";
+import { client } from "@/src/sanity/lib/client";
+
+type SanityChangelogRow = {
+  id: string;
+  releasedAt: string;
+  title: string;
+  prNumber: number;
+  tags: ChangelogRelease["tags"];
+  summary: string;
+  highlights: string[] | null;
+  sections: Array<{ title: string; items: string[] }> | null;
+};
+
+function mapSanityRow(row: SanityChangelogRow): ChangelogRelease {
+  const sections =
+    row.sections?.filter(section => section.title && section.items?.length) ?? undefined;
+
+  return {
+    id: row.id,
+    releasedAt: row.releasedAt,
+    title: row.title,
+    prNumber: row.prNumber,
+    tags: row.tags ?? [],
+    summary: row.summary,
+    highlights: row.highlights?.length ? row.highlights : [row.summary],
+    sections: sections?.length ? sections : undefined
+  };
+}
+
+async function fetchChangelogReleasesFromSanity(): Promise<ChangelogRelease[]> {
+  const rows = await client.fetch<SanityChangelogRow[]>(
+    publishedChangelogReleasesQuery,
+    {},
+    { next: { tags: [TAG_CHANGELOG] } }
+  );
+
+  return rows.map(mapSanityRow);
+}
+
+async function loadChangelogReleases(): Promise<ChangelogRelease[]> {
+  const fromSanity = await fetchChangelogReleasesFromSanity();
+  if (fromSanity.length > 0) return fromSanity;
+
+  return fetchChangelogReleasesFromGitHub(50);
+}
+
+export const getCachedChangelogReleases = unstable_cache(
+  loadChangelogReleases,
+  ["changelog-releases"],
+  { revalidate: 43200, tags: [TAG_CHANGELOG] }
+);

--- a/src/lib/changelog/parsePullRequestBody.ts
+++ b/src/lib/changelog/parsePullRequestBody.ts
@@ -1,0 +1,195 @@
+import type { ChangelogRelease, ChangelogSection } from "@/src/lib/changelog/changelogEntries";
+import {
+  isSensitiveChangelogLine,
+  sanitizeChangelogBullet,
+  sanitizeChangelogText,
+  shouldSkipChangelogSection
+} from "@/src/lib/changelog/changelogContentFilter";
+import { resolveChangelogTags } from "@/src/lib/changelog/changelogTags";
+
+type ParsedSection = {
+  title: string;
+  content: string;
+};
+
+const LEGACY_HIGHLIGHT_SECTION_TITLES = ["active changes", "changes", "highlights", "what's new", "whats new"];
+const CHANGELOG_BLOCK_TITLE = "changelog";
+
+function sectionKey(title: string): string {
+  return title.trim().toLowerCase();
+}
+
+function splitPublicBody(body: string): string {
+  const parts = body.split(/^---\s*$/m);
+  return parts[0]?.trim() ?? body;
+}
+
+function parseMarkdownSections(body: string): ParsedSection[] {
+  const sections: ParsedSection[] = [];
+  const chunks = body.split(/^##\s+/m);
+
+  for (let i = 1; i < chunks.length; i++) {
+    const chunk = chunks[i] ?? "";
+    const newline = chunk.indexOf("\n");
+    if (newline === -1) {
+      sections.push({ title: chunk.trim(), content: "" });
+      continue;
+    }
+    sections.push({
+      title: chunk.slice(0, newline).trim(),
+      content: chunk.slice(newline + 1).trim()
+    });
+  }
+
+  return sections;
+}
+
+function extractBullets(content: string): string[] {
+  return content
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => /^[-*]\s+/.test(line))
+    .map(line => sanitizeChangelogBullet(line))
+    .filter(line => line.length > 0 && !isSensitiveChangelogLine(line));
+}
+
+function firstParagraph(content: string): string {
+  const blocks = content
+    .split(/\r?\n\r?\n/)
+    .map(block => block.trim())
+    .filter(Boolean);
+
+  for (const block of blocks) {
+    if (/^[-*]\s+/m.test(block)) continue;
+    const sanitized = sanitizeChangelogText(block.replace(/\r?\n/g, " "));
+    if (sanitized) return sanitized;
+  }
+
+  return "";
+}
+
+function parseChangelogSubsections(changelogContent: string): {
+  highlights: string[];
+  sections: ChangelogSection[];
+} {
+  const withoutTagComment = changelogContent.replace(/<!--\s*tags:[^>]+-->/i, "").trim();
+  const subParts = withoutTagComment.split(/^###\s+/m);
+
+  if (subParts.length <= 1) {
+    const bullets = extractBullets(withoutTagComment);
+    return { highlights: bullets, sections: [] };
+  }
+
+  const sections: ChangelogSection[] = [];
+  let highlights: string[] = [];
+
+  for (let i = 1; i < subParts.length; i++) {
+    const chunk = subParts[i] ?? "";
+    const newline = chunk.indexOf("\n");
+    const title = (newline === -1 ? chunk : chunk.slice(0, newline)).trim();
+    const content = newline === -1 ? "" : chunk.slice(newline + 1).trim();
+    const items = extractBullets(content);
+    if (items.length === 0) continue;
+
+    if (sectionKey(title) === "highlights") {
+      highlights = items;
+      continue;
+    }
+
+    sections.push({ title, items });
+  }
+
+  if (highlights.length === 0) {
+    highlights = sections.flatMap(section => section.items).slice(0, 6);
+  }
+
+  return { highlights, sections };
+}
+
+function parseLegacySections(visible: ParsedSection[]): {
+  summary: string;
+  highlights: string[];
+  sections: ChangelogSection[];
+} {
+  const summarySection = visible.find(section => sectionKey(section.title) === "summary");
+  const summary =
+    (summarySection ? firstParagraph(summarySection.content) : "") ||
+    firstParagraph(visible.map(section => section.content).join("\n\n"));
+
+  const highlightSection = visible.find(section =>
+    LEGACY_HIGHLIGHT_SECTION_TITLES.includes(sectionKey(section.title))
+  );
+  const highlights = highlightSection
+    ? extractBullets(highlightSection.content)
+    : extractBullets(visible.map(section => section.content).join("\n")).slice(0, 6);
+
+  const sections: ChangelogSection[] = visible
+    .filter(section => {
+      const key = sectionKey(section.title);
+      if (key === "summary" || key === CHANGELOG_BLOCK_TITLE) return false;
+      if (LEGACY_HIGHLIGHT_SECTION_TITLES.includes(key)) return false;
+      return extractBullets(section.content).length > 0;
+    })
+    .map(section => ({
+      title: section.title,
+      items: extractBullets(section.content)
+    }));
+
+  return { summary, highlights, sections };
+}
+
+export type GitHubPullRequest = {
+  number: number;
+  title: string;
+  body: string | null;
+  merged_at: string | null;
+  labels?: string[];
+};
+
+export function pullRequestToChangelogRelease(pr: GitHubPullRequest): ChangelogRelease | null {
+  if (!pr.merged_at) return null;
+
+  const publicBody = splitPublicBody(pr.body?.trim() ?? "");
+  const parsed = parseMarkdownSections(publicBody);
+  const visible = parsed.filter(section => !shouldSkipChangelogSection(section.title));
+
+  const changelogSection = visible.find(section => sectionKey(section.title) === CHANGELOG_BLOCK_TITLE);
+  const legacy = parseLegacySections(visible);
+
+  let summary = legacy.summary;
+  let highlights = legacy.highlights;
+  let sections = legacy.sections;
+
+  if (changelogSection) {
+    const structured = parseChangelogSubsections(changelogSection.content);
+    highlights = structured.highlights.length > 0 ? structured.highlights : highlights;
+    sections = structured.sections.length > 0 ? structured.sections : sections;
+  }
+
+  if (!summary) {
+    summary = firstParagraph(publicBody) || sanitizeChangelogText(pr.title);
+  }
+
+  if (highlights.length === 0) {
+    highlights = sections.flatMap(section => section.items).slice(0, 6);
+  }
+  if (highlights.length === 0) {
+    highlights = [summary];
+  }
+
+  const mergedDate = new Date(pr.merged_at);
+  const id = Number.isFinite(mergedDate.getTime())
+    ? `${mergedDate.toISOString().slice(0, 10)}-pr-${pr.number}`
+    : `pr-${pr.number}`;
+
+  return {
+    id,
+    releasedAt: pr.merged_at,
+    title: sanitizeChangelogText(pr.title) || pr.title,
+    prNumber: pr.number,
+    tags: resolveChangelogTags(publicBody, pr.title, pr.labels ?? []),
+    summary,
+    highlights,
+    sections: sections.length > 0 ? sections : undefined
+  };
+}

--- a/src/lib/sanity/imageDelivery.ts
+++ b/src/lib/sanity/imageDelivery.ts
@@ -1,0 +1,139 @@
+import type { SanityImageSource } from "@sanity/image-url";
+import { getImageDimensions } from "@sanity/asset-utils";
+import { urlFor } from "@/src/sanity/lib/image";
+
+/** Max CSS px width for about-section side images (matches AboutSectionBlock layout). */
+export const ABOUT_SECTION_IMAGE_MAX_PX = 540;
+
+export type SanityImageField = {
+  preserveAnimation?: boolean;
+  asset?: {
+    _ref?: string;
+    mimeType?: string;
+    url?: string;
+    metadata?: {
+      dimensions?: { width: number; height: number; aspectRatio?: number };
+      lqip?: string;
+    };
+  };
+};
+
+export type MotionSlotOptions = {
+  /** Slot may contain animated WebP (about blocks, showcase). Static JPG/PNG still use next/image. */
+  mayAnimate?: boolean;
+};
+
+function getAsset(source: SanityImageSource): SanityImageField["asset"] | undefined {
+  if (!source || typeof source !== "object") return undefined;
+  return (source as SanityImageField).asset;
+}
+
+function isGifAsset(asset: NonNullable<SanityImageField["asset"]>): boolean {
+  const mime = asset.mimeType?.toLowerCase();
+  if (mime === "image/gif") return true;
+
+  const ref = asset._ref?.toLowerCase() ?? "";
+  if (ref.includes("-gif") || ref.endsWith("gif")) return true;
+
+  const url = asset.url?.toLowerCase() ?? "";
+  return url.includes(".gif");
+}
+
+export function isGifImageSource(source: SanityImageSource | undefined | null): boolean {
+  const asset = getAsset(source as SanityImageSource);
+  return asset ? isGifAsset(asset) : false;
+}
+
+export function isWebpImageSource(source: SanityImageSource | undefined | null): boolean {
+  const asset = getAsset(source as SanityImageSource);
+  if (!asset) return false;
+
+  const mime = asset.mimeType?.toLowerCase();
+  if (mime === "image/webp") return true;
+
+  const ref = asset._ref?.toLowerCase() ?? "";
+  if (ref.includes("-webp") || ref.endsWith("webp")) return true;
+
+  const url = asset.url?.toLowerCase() ?? "";
+  return url.includes(".webp");
+}
+
+/**
+ * True when the image must bypass next/image (GIF, flagged/slot WebP).
+ * JPG/PNG always false — even with preserveAnimation checked by mistake in Studio.
+ */
+export function sanityImageNeedsMotionDelivery(
+  source: SanityImageSource | undefined | null,
+  options: MotionSlotOptions = {}
+): boolean {
+  if (!source || typeof source !== "object") return false;
+
+  const image = source as SanityImageField;
+  const asset = image.asset;
+  if (!asset) return false;
+
+  if (isGifAsset(asset)) return true;
+
+  const webp = isWebpImageSource(source);
+  if (webp && (options.mayAnimate || image.preserveAnimation === true)) return true;
+
+  return false;
+}
+
+export function sanityImageLqip(source: SanityImageSource | undefined | null): string | undefined {
+  if (!source || typeof source !== "object") return undefined;
+  return (source as SanityImageField).asset?.metadata?.lqip;
+}
+
+export function resolveSanityImageDimensions(
+  source: SanityImageSource,
+  fallbackWidth = 640
+): { width: number; height: number } {
+  const fromMeta = (source as SanityImageField).asset?.metadata?.dimensions;
+  if (fromMeta?.width && fromMeta?.height) {
+    return { width: fromMeta.width, height: fromMeta.height };
+  }
+
+  try {
+    return getImageDimensions(source as Parameters<typeof getImageDimensions>[0]);
+  } catch {
+    return { width: fallbackWidth, height: Math.round(fallbackWidth * 0.5625) };
+  }
+}
+
+/** Intrinsic dimensions scaled to `maxWidth` for HTML width/height hints and aspect-ratio box. */
+export function resolveDisplayDimensions(
+  source: SanityImageSource,
+  maxWidth: number
+): { width: number; height: number; aspectRatio: number } {
+  const intrinsic = resolveSanityImageDimensions(source, maxWidth);
+  const aspectRatio = intrinsic.width / intrinsic.height;
+
+  if (intrinsic.width <= maxWidth) {
+    return { ...intrinsic, aspectRatio };
+  }
+
+  return {
+    width: maxWidth,
+    height: Math.round(maxWidth / aspectRatio),
+    aspectRatio
+  };
+}
+
+/** CDN URL for GIF / animated WebP — sized to `widthHint`, no auto-format conversion. */
+export function sanityMotionImageUrl(source: SanityImageSource, widthHint: number): string {
+  if (isWebpImageSource(source)) {
+    return urlFor(source).width(widthHint).format("webp").url();
+  }
+
+  if (isGifImageSource(source)) {
+    return urlFor(source).width(widthHint).fit("max").format("webp").quality(80).url();
+  }
+
+  return urlFor(source).width(widthHint).quality(80).auto("format").url();
+}
+
+/** Optimized static image URL for next/image. */
+export function sanityOptimizedImageUrl(source: SanityImageSource, widthHint: number, quality: number): string {
+  return urlFor(source).width(widthHint).quality(quality).auto("format").url();
+}

--- a/src/lib/sanity/queries.ts
+++ b/src/lib/sanity/queries.ts
@@ -34,10 +34,34 @@ export const storeDetailsQuery = `*[_type=="storeDetails"]{
 }`;
 
 /* ------------ Programs ------------ */
+/** GROQ fragment: image field with asset metadata for IdealImage (dimensions, lqip, animation flag). */
+export const sanityImageFieldProjection = `
+  ...,
+  preserveAnimation,
+  asset->{ url, mimeType, metadata { dimensions, lqip } }
+`;
+
 export const featuredBlockProjection = `
 featured{
   description,
-  showcaseGif
+  showcaseGif{
+    ${sanityImageFieldProjection}
+  }
+}`;
+
+/** About sections with dereferenced image assets for IdealImage. */
+export const programAboutSectionsProjection = `
+aboutSections[]{
+  ...,
+  image{
+    ${sanityImageFieldProjection}
+  },
+  points[]{
+    ...,
+    icon{
+      ${sanityImageFieldProjection}
+    }
+  }
 }`;
 
 /** Flattened analytics fields — reads nested `stats` with legacy top-level fallback. */
@@ -184,7 +208,7 @@ export const programBySlugQuery = `
   "categories": categories[]->{ _id, title, "slug": slug.current },
   "platforms": coalesce(platforms, ["windows"]),
   seo,
-  aboutSections,
+  ${programAboutSectionsProjection},
   faq,
   image,
   downloadLink,

--- a/src/lib/sanity/queries/changelog.ts
+++ b/src/lib/sanity/queries/changelog.ts
@@ -1,0 +1,13 @@
+export const publishedChangelogReleasesQuery = `*[_type == "changelogRelease" && published == true] | order(releasedAt desc) {
+  "id": _id,
+  releasedAt,
+  title,
+  prNumber,
+  tags,
+  summary,
+  highlights,
+  sections[]{
+    title,
+    items
+  }
+}`;

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -257,6 +257,11 @@ export async function generateUpdatesMetadata(): Promise<Metadata> {
   return generateTrustRouteMetadata(resolveUpdatesPageSeo);
 }
 
+export async function generateChangelogMetadata(): Promise<Metadata> {
+  const { resolveChangelogPageSeo } = await import("@/src/lib/seo/trustPageSeo");
+  return generateTrustRouteMetadata(resolveChangelogPageSeo);
+}
+
 export async function generateProgramsPageMetadata(): Promise<Metadata> {
   const storeData = await getCachedStoreDetailsDocument();
   const { title, description, pageUrl: url, ogImageUrl, storeTitle, keywords } = resolveProgramsPageSeo(storeData);

--- a/src/lib/seo/trustPageSeo.ts
+++ b/src/lib/seo/trustPageSeo.ts
@@ -75,6 +75,15 @@ export function resolveUpdatesPageSeo(store: StoreDetailsForSeo | null | undefin
     store,
     "/updates",
     "Latest Giveaway Keys & New Programs | [title]",
-    "New programs and fresh giveaway keys added to [title] in the last 90 days — auto-updated from our catalog."
+    "New programs and fresh giveaway keys added to [title] — updated automatically from our catalog."
+  );
+}
+
+export function resolveChangelogPageSeo(store: StoreDetailsForSeo | null | undefined) {
+  return resolveTrustPageSeo(
+    store,
+    "/changelog",
+    "Changelog & Release Notes | [title]",
+    "Structured release notes for major [title] improvements — features, fixes, and platform updates."
   );
 }

--- a/src/lib/site/feedHrefUtils.ts
+++ b/src/lib/site/feedHrefUtils.ts
@@ -1,0 +1,20 @@
+import { buildChangelogHref } from "@/src/lib/changelog/changelogPageUtils";
+import { buildUpdatesHref } from "@/src/lib/updates/updatesPageUtils";
+
+export type FeedKind = "changelog" | "updates";
+
+/** Scroll target for month-filter navigation (below hero + cross-link bar). */
+export const FEED_SECTION_ID = "feed";
+
+export function scrollToFeedSection() {
+  requestAnimationFrame(() => {
+    document.getElementById(FEED_SECTION_ID)?.scrollIntoView({ block: "start" });
+  });
+}
+
+export function buildFeedMonthHref(feed: FeedKind, month?: string, limit?: number): string {
+  if (feed === "changelog") {
+    return buildChangelogHref(month, limit);
+  }
+  return buildUpdatesHref(month, limit);
+}

--- a/src/lib/site/feedLimitUtils.ts
+++ b/src/lib/site/feedLimitUtils.ts
@@ -1,0 +1,30 @@
+/** Default visible rows when browsing the full feed (no sidebar month filter). */
+export const UPDATES_FEED_DEFAULT_LIMIT = 20;
+export const UPDATES_FEED_LIMIT_INCREMENT = 20;
+
+export const CHANGELOG_FEED_DEFAULT_LIMIT = 5;
+export const CHANGELOG_FEED_LIMIT_INCREMENT = 5;
+
+export function resolveFeedLimit(raw: string | undefined, defaultLimit: number): number {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed < defaultLimit) return defaultLimit;
+  return parsed;
+}
+
+export function applyFeedLimit<T>(
+  items: T[],
+  limit: number,
+  /** When true (e.g. sidebar month selected), show every item in the filtered set. */
+  unlimited: boolean
+): { visible: T[]; hasMore: boolean; total: number } {
+  const total = items.length;
+  if (unlimited) {
+    return { visible: items, hasMore: false, total };
+  }
+  const visible = items.slice(0, limit);
+  return { visible, hasMore: total > limit, total };
+}
+
+export function nextFeedLimit(currentLimit: number, increment: number, total: number): number {
+  return Math.min(currentLimit + increment, total);
+}

--- a/src/lib/site/feedMonthScrollSpy.ts
+++ b/src/lib/site/feedMonthScrollSpy.ts
@@ -1,0 +1,52 @@
+/** DOM attribute on the first block of each month section in the feed. */
+export const FEED_MONTH_MARKER_ATTR = "data-feed-month";
+
+/** Sidebar month link marker — used to scroll active item into view. */
+export const FEED_SIDEBAR_MONTH_ATTR = "data-sidebar-month";
+
+/** Match sticky sidebar (`top-24`) + a little breathing room. */
+export const FEED_SCROLL_SPY_OFFSET_PX = 120;
+
+/**
+ * Pick the month section the reader is currently in.
+ *
+ * Primary rule (dense feeds): the last month whose top edge crossed the activation line —
+ * standard TOC / scroll-spy behavior.
+ *
+ * Fallback (top of page, multiple months visible): topmost month section intersecting the viewport.
+ */
+export function resolveActiveFeedMonth(elements: HTMLElement[], activationLinePx: number): string | null {
+  if (elements.length === 0) return null;
+
+  let crossed: string | null = null;
+
+  for (const el of elements) {
+    const key = el.getAttribute(FEED_MONTH_MARKER_ATTR);
+    if (!key) continue;
+    if (el.getBoundingClientRect().top <= activationLinePx) {
+      crossed = key;
+    }
+  }
+
+  if (crossed) return crossed;
+
+  let topmost: { key: string; top: number } | null = null;
+
+  for (const el of elements) {
+    const key = el.getAttribute(FEED_MONTH_MARKER_ATTR);
+    if (!key) continue;
+
+    const rect = el.getBoundingClientRect();
+    if (rect.bottom <= activationLinePx || rect.top >= window.innerHeight) continue;
+
+    if (!topmost || rect.top < topmost.top) {
+      topmost = { key, top: rect.top };
+    }
+  }
+
+  return topmost?.key ?? null;
+}
+
+export function queryFeedMonthMarkers(root: ParentNode = document): HTMLElement[] {
+  return [...root.querySelectorAll<HTMLElement>(`[${FEED_MONTH_MARKER_ATTR}]`)];
+}

--- a/src/lib/site/monthSidebarUtils.ts
+++ b/src/lib/site/monthSidebarUtils.ts
@@ -1,0 +1,70 @@
+const MONTH_KEY_RE = /^(\d{4})-(0[1-9]|1[0-2])$/;
+
+export type SidebarMonth = {
+  key: string;
+  label: string;
+  year: number;
+  monthName: string;
+  count: number;
+};
+
+export type SidebarYear = {
+  year: number;
+  months: SidebarMonth[];
+};
+
+export function getMonthKey(iso: string): string {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return "0000-00";
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+export function formatMonthLabel(monthKey: string): string {
+  const match = MONTH_KEY_RE.exec(monthKey);
+  if (!match) return monthKey;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  return new Date(year, month - 1, 1).toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}
+
+export function formatMonthName(monthKey: string): string {
+  const match = MONTH_KEY_RE.exec(monthKey);
+  if (!match) return monthKey;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  return new Date(year, month - 1, 1).toLocaleDateString("en-US", { month: "long" });
+}
+
+export function buildMonthSidebarIndex<T>(items: T[], getDate: (item: T) => string): SidebarYear[] {
+  const counts = new Map<string, number>();
+
+  for (const item of items) {
+    const key = getMonthKey(getDate(item));
+    if (key === "0000-00") continue;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const byYear = new Map<number, SidebarMonth[]>();
+
+  for (const key of [...counts.keys()].sort((a, b) => b.localeCompare(a))) {
+    const year = Number(key.split("-")[0]);
+    const entry: SidebarMonth = {
+      key,
+      label: formatMonthLabel(key),
+      year,
+      monthName: formatMonthName(key),
+      count: counts.get(key) ?? 0
+    };
+    const list = byYear.get(year) ?? [];
+    list.push(entry);
+    byYear.set(year, list);
+  }
+
+  return [...byYear.entries()]
+    .sort(([a], [b]) => b - a)
+    .map(([year, months]) => ({ year, months }));
+}
+
+export function parseMonthQueryParam(raw: string | undefined): string | undefined {
+  return raw && MONTH_KEY_RE.test(raw) ? raw : undefined;
+}

--- a/src/lib/updates/updatesPageUtils.ts
+++ b/src/lib/updates/updatesPageUtils.ts
@@ -1,0 +1,101 @@
+import type { Notification } from "@/src/types/notifications";
+import { resolveFeedLimit, UPDATES_FEED_DEFAULT_LIMIT } from "@/src/lib/site/feedLimitUtils";
+import {
+  buildMonthSidebarIndex as buildMonthSidebarIndexFromDates,
+  formatMonthLabel,
+  formatMonthName,
+  getMonthKey,
+  parseMonthQueryParam,
+  type SidebarMonth,
+  type SidebarYear
+} from "@/src/lib/site/monthSidebarUtils";
+
+export type { SidebarMonth, SidebarYear };
+export { formatMonthLabel, formatMonthName, getMonthKey };
+
+export type UpdatesPageParams = {
+  month?: string;
+  limit: number;
+};
+
+export type TimelineMonth = {
+  monthKey: string;
+  monthName: string;
+  items: Notification[];
+};
+
+export type TimelineYear = {
+  year: number;
+  months: TimelineMonth[];
+};
+
+export function resolveUpdatesPageParams(raw: { month?: string; limit?: string }): UpdatesPageParams {
+  const month = parseMonthQueryParam(raw.month);
+  const limit = resolveFeedLimit(raw.limit, UPDATES_FEED_DEFAULT_LIMIT);
+  return { month, limit };
+}
+
+export function buildUpdatesHref(month: string | undefined, limit?: number): string {
+  const params = new URLSearchParams();
+  if (month) {
+    params.set("month", month);
+  } else if (limit !== undefined && limit > UPDATES_FEED_DEFAULT_LIMIT) {
+    params.set("limit", String(limit));
+  }
+  const q = params.toString();
+  return q ? `/updates?${q}` : "/updates";
+}
+
+export function filterNotificationsByMonth(
+  notifications: Notification[],
+  monthKey: string | undefined
+): Notification[] {
+  if (!monthKey) return notifications;
+  return notifications.filter(n => getMonthKey(n.createdAt) === monthKey);
+}
+
+export function groupSortedNotifications(items: Notification[]): TimelineYear[] {
+  const years: TimelineYear[] = [];
+  let currentYear: TimelineYear | null = null;
+  let currentMonth: TimelineMonth | null = null;
+
+  for (const item of items) {
+    const d = new Date(item.createdAt);
+    if (!Number.isFinite(d.getTime())) continue;
+
+    const year = d.getFullYear();
+    const monthKey = getMonthKey(item.createdAt);
+    const monthName = formatMonthName(monthKey);
+
+    if (!currentYear || currentYear.year !== year) {
+      currentYear = { year, months: [] };
+      years.push(currentYear);
+      currentMonth = null;
+    }
+
+    if (!currentMonth || currentMonth.monthKey !== monthKey) {
+      currentMonth = { monthKey, monthName, items: [] };
+      currentYear.months.push(currentMonth);
+    }
+
+    currentMonth.items.push(item);
+  }
+
+  return years;
+}
+
+export function buildMonthSidebarIndex(notifications: Notification[]): SidebarYear[] {
+  return buildMonthSidebarIndexFromDates(notifications, n => n.createdAt);
+}
+
+export function formatUpdateDay(iso: string): string {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return "";
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+export function formatUpdateDate(iso: string): string {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return "";
+  return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+}

--- a/src/sanity/schemaTypes/index.ts
+++ b/src/sanity/schemaTypes/index.ts
@@ -9,6 +9,7 @@ import { keyReport } from "./analytics/keyReport";
 import { visitor } from "./analytics/visitor";
 
 import { cronRun } from "./system/cronRun";
+import { changelogRelease } from "./system/changelogRelease";
 import { siteNotificationFeed } from "./system/siteNotificationFeed";
 import contactMessage from "./contact/contactMessage";
 import { contactMessageReply } from "./contact/contactMessageReply";
@@ -39,6 +40,7 @@ export const schema: { types: SchemaTypeDefinition[] } = {
     visitorBundle,
     keyReport,
     cronRun,
+    changelogRelease,
     siteNotificationFeed,
     contactMessage,
     contactMessageReply,

--- a/src/sanity/schemaTypes/program/aboutSection.ts
+++ b/src/sanity/schemaTypes/program/aboutSection.ts
@@ -60,7 +60,16 @@ export const aboutSection = defineType({
       title: "Image (optional)",
       type: "image",
       options: { hotspot: true },
-      description: "If set, shows side-by-side with text on large screens. If empty, text is centered."
+      description: "If set, shows side-by-side with text on large screens. If empty, text is centered.",
+      fields: [
+        defineField({
+          name: "preserveAnimation",
+          title: "Animated (GIF / animated WebP)",
+          type: "boolean",
+          initialValue: false,
+          description: "Enable when the file should play motion on the site (animated WebP or GIF)."
+        })
+      ]
     }),
     defineField({
       name: "invertDesktop",

--- a/src/sanity/schemaTypes/system/changelogRelease.ts
+++ b/src/sanity/schemaTypes/system/changelogRelease.ts
@@ -1,0 +1,123 @@
+import { CHANGELOG_TAGS } from "@/src/lib/changelog/changelogTags";
+import { defineField, defineType } from "sanity";
+
+const tagOptions = CHANGELOG_TAGS.map(tag => ({ title: tag, value: tag }));
+
+export const changelogRelease = defineType({
+  name: "changelogRelease",
+  title: "Changelog",
+  type: "document",
+  fields: [
+    defineField({
+      name: "prNumber",
+      title: "Pull request #",
+      type: "number",
+      validation: Rule => Rule.required().integer().min(1)
+    }),
+    defineField({
+      name: "releasedAt",
+      title: "Released at",
+      type: "datetime",
+      description: "PR merge time (UTC).",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: Rule => Rule.required()
+    }),
+    defineField({
+      name: "summary",
+      title: "Summary",
+      type: "text",
+      rows: 4,
+      validation: Rule =>
+        Rule.custom((value, context) => {
+          const published = (context.document as { published?: boolean } | undefined)?.published;
+          if (published && (!value || !String(value).trim())) {
+            return "Summary is required before publishing.";
+          }
+          return true;
+        })
+    }),
+    defineField({
+      name: "tags",
+      title: "Tags",
+      type: "array",
+      of: [{ type: "string" }],
+      options: { list: tagOptions },
+      validation: Rule => Rule.required().min(1)
+    }),
+    defineField({
+      name: "highlights",
+      title: "Highlights",
+      type: "array",
+      of: [{ type: "string" }]
+    }),
+    defineField({
+      name: "sections",
+      title: "Sections",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          name: "changelogSection",
+          fields: [
+            defineField({ name: "title", type: "string", validation: Rule => Rule.required() }),
+            defineField({
+              name: "items",
+              type: "array",
+              of: [{ type: "string" }],
+              validation: Rule => Rule.required().min(1)
+            })
+          ],
+          preview: {
+            select: { title: "title", items: "items" },
+            prepare({ title, items }) {
+              const n = Array.isArray(items) ? items.length : 0;
+              return { title: title || "Section", subtitle: `${n} item${n === 1 ? "" : "s"}` };
+            }
+          }
+        }
+      ]
+    }),
+    defineField({
+      name: "published",
+      title: "Published",
+      type: "boolean",
+      description: "Only published releases appear on /changelog.",
+      initialValue: false
+    }),
+    defineField({
+      name: "rawPrBody",
+      title: "Raw PR body (dev)",
+      type: "text",
+      rows: 8,
+      readOnly: true,
+      hidden: ({ document }) => !document?.rawPrBody
+    })
+  ],
+  orderings: [
+    {
+      title: "Release date (newest)",
+      name: "releasedAtDesc",
+      by: [{ field: "releasedAt", direction: "desc" }]
+    }
+  ],
+  preview: {
+    select: {
+      title: "title",
+      prNumber: "prNumber",
+      releasedAt: "releasedAt",
+      published: "published"
+    },
+    prepare({ title, prNumber, releasedAt, published }) {
+      const date = releasedAt ? new Date(releasedAt).toLocaleDateString("en-US") : "";
+      return {
+        title: title || `PR #${prNumber}`,
+        subtitle: `PR #${prNumber}${date ? ` · ${date}` : ""}${published ? "" : " · draft"}`
+      };
+    }
+  }
+});

--- a/src/sanity/structure.ts
+++ b/src/sanity/structure.ts
@@ -1,14 +1,55 @@
-import type { StructureResolver } from "sanity/structure";
+import type { StructureBuilder, StructureResolver } from "sanity/structure";
+
+/** Nested folder of document type lists (uses schema titles unless overridden). */
+function docGroup(S: StructureBuilder, title: string, types: string[]) {
+  return S.listItem()
+    .title(title)
+    .id(`group-${title.toLowerCase().replace(/\s+/g, "-")}`)
+    .child(
+      S.list()
+        .title(title)
+        .items(types.map(type => S.documentTypeListItem(type).id(type)))
+    );
+}
 
 // https://www.sanity.io/docs/structure-builder-cheat-sheet
 export const structure: StructureResolver = S =>
   S.list()
     .title("Content")
     .items([
+      // —— Top (pinned) ——
       S.listItem()
         .title("Visitors")
         .id("visitor-desk")
         .child(S.documentTypeList("visitor").title("Visitors")),
+
       S.divider(),
-      ...S.documentTypeListItems().filter(item => item.getId() !== "visitor")
+
+      // —— Content groups ——
+      docGroup(S, "Programs", [
+        "program",
+        "programCategory",
+        "vendor",
+        "featuredProgramSettings"
+      ]),
+
+      docGroup(S, "Store", ["storeDetails"]),
+
+      docGroup(S, "Community", ["contactMessage", "keySuggestion", "keyReport"]),
+
+      docGroup(S, "Analytics", ["trackingEvent", "trackingEventBundle", "visitorBundle"]),
+
+      docGroup(S, "System", ["siteNotificationFeed", "cronRun"]),
+
+      S.divider(),
+
+      // —— Bottom (pinned) ——
+      S.listItem()
+        .title("Changelog")
+        .id("changelog-desk")
+        .child(
+          S.documentTypeList("changelogRelease")
+            .title("Changelog")
+            .defaultOrdering([{ field: "releasedAt", direction: "desc" }])
+        )
     ]);

--- a/src/types/general/index.ts
+++ b/src/types/general/index.ts
@@ -1,18 +1,13 @@
 // General utility types
-import { SanityAsset } from "@sanity/image-url";
+import type { IdealImageProps } from "@/src/components/general/IdealImage";
+
+export type { IdealImageProps };
 
 export interface User {
   id: string;
   name: string;
   email: string;
   image?: string;
-}
-
-// Image component props
-export interface IdealImageProps {
-  image?: SanityAsset;
-  alt?: string;
-  className?: string;
 }
 
 export interface IdealImageClientProps {

--- a/src/types/program/index.ts
+++ b/src/types/program/index.ts
@@ -49,7 +49,18 @@ export interface ProgramFaqItem {
 }
 
 /** Sanity image field shape (asset ref for urlFor). */
-export type SanityImageField = { asset?: { _ref?: string; url?: string } };
+export type SanityImageField = {
+  preserveAnimation?: boolean;
+  asset?: {
+    _ref?: string;
+    url?: string;
+    mimeType?: string;
+    metadata?: {
+      dimensions?: { width: number; height: number; aspectRatio?: number };
+      lqip?: string;
+    };
+  };
+};
 
 export interface ProgramAboutPoint {
   text: PortableTextBlock[] | string;


### PR DESCRIPTION
## Summary

Ships a public `/changelog` fed from Sanity (with GitHub PR sync), rebuilds `/updates` as a month-filtered timeline with scroll-spy sidebar, delivers animated GIF/WebP from Sanity without breaking Next.js image optimization, and adds Windows/Mac platform glyphs on program discovery surfaces.

## Changelog

<!-- tags: feat, ui, perf, api, enhance -->

### Highlights

- New `/changelog` page with release cards, multi-tag labels, month sidebar, and load-more pagination
- Sanity-backed `changelogRelease` docs with backfill scripts and a merge-to-main GitHub Action for draft sync
- `/updates` rebuilt as a grouped timeline with shared month sidebar, scroll-spy highlight, and scroll-preserving load more
- Animated GIF and WebP delivery from Sanity via `imageDelivery` helpers and `AnimatedSanityImage`
- Platform glyphs on `/programs` filters and related program cards

### Changelog

- `changelogRelease` sanity schema with tags, highlights, sections, and a published flag
- PR body parser supports `## Changelog`, `###` subsections, tag comments, and redacts sensitive lines
- Backfill (`npm run backfill:changelog`) and per-PR sync (`sync:changelog-pr`) scripts plus `.github/workflows/changelog-sync.yml`
- Webhook revalidation for `TAG_CHANGELOG` when release docs publish
- Footer, sitemap, and metadata entries for the new route

### Updates feed

- `UpdatesTimeline` with sticky year headings and month markers for scroll-spy
- Shared `FeedMonthSidebar`, `FeedWithMonthSidebar`, and feed pagination utilities
- Sidebar scroll-spy highlights the active month while browsing; month filter scrolls to the feed grid instead of page top
- Cross-links between `/updates` and `/changelog`

### Image delivery

- `sanityMotionImageUrl()` and display-dimension helpers for motion-safe CDN URLs
- `IdealImage` `mayAnimate` slot for about blocks and featured showcase GIF
- `preserveAnimation` toggle on about-section images in Sanity Studio
- GROQ projection for image dimensions, LQIP, and animation metadata
- Site logo aspect-ratio warning fix on `IdealImageClient`

### Discovery

- `PlatformGlyphs` component wired into `ProgramsFilter` and `RelatedPrograms`

### Studio

- Sanity desk grouped into Programs, Store, Community, Analytics, and System folders
- Visitors pinned top, Changelog pinned bottom

---

## Environment Variables

None new for the public site.

GitHub Action / backfill scripts require existing Sanity env plus:

- `SANITY_API_TOKEN` (repo secret for changelog-sync workflow)
- `NEXT_PUBLIC_SANITY_STUDIO_PROJECT_ID`, `NEXT_PUBLIC_SANITY_STUDIO_DATASET` (repo secrets)

Optional: `GITHUB_TOKEN` is provided by Actions automatically.

## Testing

- [ ] `/changelog` loads published sanity releases; month filter and load more preserve scroll position
- [ ] `/updates` timeline, month sidebar scroll-spy, and load more
- [ ] Merge a test PR to main → changelog-sync workflow upserts a draft `changelogRelease`
- [ ] `npm run backfill:changelog` dry run and `--write` on staging dataset
- [ ] Program about images with `preserveAnimation` render as GIF/WebP where expected
- [ ] Platform filter glyphs on `/programs` and related cards

## Technical Details

- 29 commits on branch; sanity backfill already run locally for 36 merged PRs
- Changelog GitHub fallback remains if sanity has zero published docs
- Parser logic duplicated in `scripts/changelogSyncUtils.mjs` — keep in sync with `parsePullRequestBody.ts`
- Studio `changelogRelease` sections require `_key` on array items (`autoGenerateArrayKeys: true` in sync scripts)
